### PR TITLE
Use customized date/time separator in admin pages

### DIFF
--- a/admin-views/events-meta-box.php
+++ b/admin-views/events-meta-box.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<input autocomplete="off" tabindex="<?php tribe_events_tab_index(); ?>" type="text" class="tribe-datepicker" name="EventStartDate" id="EventStartDate" value="<?php echo esc_attr( $EventStartDate ) ?>" />
 							<span class="helper-text hide-if-js"><?php _e( 'YYYY-MM-DD', 'tribe-events-calendar' ) ?></span>
 				<span class="timeofdayoptions">
-					<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
+					<?php echo tribe_get_datetime_separator(); ?>
 					<select tabindex="<?php tribe_events_tab_index(); ?>" name="EventStartHour">
 						<?php echo $startHourOptions; ?>
 					</select>
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<input autocomplete="off" type="text" class="tribe-datepicker" name="EventEndDate" id="EventEndDate" value="<?php echo esc_attr( $EventEndDate ); ?>" />
 							<span class="helper-text hide-if-js"><?php _e( 'YYYY-MM-DD', 'tribe-events-calendar' ) ?></span>
 				<span class="timeofdayoptions">
-					<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
+					<?php echo tribe_get_datetime_separator(); ?>
 					<select class="tribeEventsInput" tabindex="<?php tribe_events_tab_index(); ?>" name="EventEndHour">
 						<?php echo $endHourOptions; ?>
 					</select>

--- a/admin-views/events-meta-box.php
+++ b/admin-views/events-meta-box.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<input autocomplete="off" tabindex="<?php tribe_events_tab_index(); ?>" type="text" class="tribe-datepicker" name="EventStartDate" id="EventStartDate" value="<?php echo esc_attr( $EventStartDate ) ?>" />
 							<span class="helper-text hide-if-js"><?php _e( 'YYYY-MM-DD', 'tribe-events-calendar' ) ?></span>
 				<span class="timeofdayoptions">
-					@
+					<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
 					<select tabindex="<?php tribe_events_tab_index(); ?>" name="EventStartHour">
 						<?php echo $startHourOptions; ?>
 					</select>
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<input autocomplete="off" type="text" class="tribe-datepicker" name="EventEndDate" id="EventEndDate" value="<?php echo esc_attr( $EventEndDate ); ?>" />
 							<span class="helper-text hide-if-js"><?php _e( 'YYYY-MM-DD', 'tribe-events-calendar' ) ?></span>
 				<span class="timeofdayoptions">
-					@
+					<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
 					<select class="tribeEventsInput" tabindex="<?php tribe_events_tab_index(); ?>" name="EventEndHour">
 						<?php echo $endHourOptions; ?>
 					</select>

--- a/admin-views/tickets/meta-box.php
+++ b/admin-views/tickets/meta-box.php
@@ -129,7 +129,7 @@ $modules = TribeEventsTickets::modules();
 						<input autocomplete="off" type="text" class="ticket_field" size='7' name="ticket_start_date"
 							   id="ticket_start_date" value="">
 						<span class="ticket_start_time ticket_time">
-							@
+							<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
 							<select name="ticket_start_hour" id="ticket_start_hour" class="ticket_field">
 								<?php echo $startHourOptions; ?>
 							</select>
@@ -154,7 +154,7 @@ $modules = TribeEventsTickets::modules();
 							   id="ticket_end_date" value="">
 
 						<span class="ticket_end_time ticket_time">
-							@
+							<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
 							<select name="ticket_end_hour" id="ticket_end_hour" class="ticket_field">
 								<?php echo $endHourOptions; ?>
 							</select>

--- a/admin-views/tickets/meta-box.php
+++ b/admin-views/tickets/meta-box.php
@@ -129,7 +129,7 @@ $modules = TribeEventsTickets::modules();
 						<input autocomplete="off" type="text" class="ticket_field" size='7' name="ticket_start_date"
 							   id="ticket_start_date" value="">
 						<span class="ticket_start_time ticket_time">
-							<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
+							<?php echo tribe_get_datetime_separator(); ?>
 							<select name="ticket_start_hour" id="ticket_start_hour" class="ticket_field">
 								<?php echo $startHourOptions; ?>
 							</select>
@@ -154,7 +154,7 @@ $modules = TribeEventsTickets::modules();
 							   id="ticket_end_date" value="">
 
 						<span class="ticket_end_time ticket_time">
-							<?php echo tribe_get_option('dateTimeSeparator', '@'); ?>
+							<?php echo tribe_get_datetime_separator(); ?>
 							<select name="ticket_end_hour" id="ticket_end_hour" class="ticket_field">
 								<?php echo $endHourOptions; ?>
 							</select>

--- a/public/template-tags/general.php
+++ b/public/template-tags/general.php
@@ -921,6 +921,15 @@ if ( class_exists( 'TribeEvents' ) ) {
 	}
 
 	/**
+	 * Returns the customized date/time separator, or the default '@' symbol.
+	 *
+	 * @return string
+	 */
+	function tribe_get_datetime_separator() {
+		return tribe_get_option('dateTimeSeparator', '@');
+	}
+
+	/**
 	 *
 	 * @return mixed|void
 	 */


### PR DESCRIPTION
Remove hardcoded @-symbol and replace with user-specified separator in admin pages