### PR TITLE
Apply `the_title` filter to event title

### DIFF
--- a/lib/the-events-calendar.class.php
+++ b/lib/the-events-calendar.class.php
@@ -3968,9 +3968,9 @@ if ( ! class_exists( 'TribeEvents' ) ) {
 			$results = $wpdb->get_row( $eventsQuery, OBJECT );
 			if ( is_object( $results ) ) {
 				if ( ! $anchor ) {
-					$anchor = $results->post_title;
+					$anchor = apply_filters( 'the_title', $results->post_title );
 				} elseif ( strpos( $anchor, '%title%' ) !== false ) {
-					$anchor = preg_replace( '|%title%|', $results->post_title, $anchor );
+					$anchor = preg_replace( '|%title%|', apply_filters( 'the_title', $results->post_title ), $anchor );
 				}
 
 				return apply_filters( 'tribe_events_get_event_link', '<a href="' . tribe_get_event_link( $results ) . '">' . $anchor . '</a>' );


### PR DESCRIPTION
mqTranslate saves all translations of a post title inside its `post_title` attribute. As such, when `get_event_link` retrieves it, it will display all translations concatenated instead of only the correct one.

Applying the `the_title` filter will only display the correct one.