### PR TITLE
added method to turn off sslverify

### DIFF
--- a/lib/pue/lib/pue_plugin_update_engine.class.php
+++ b/lib/pue/lib/pue_plugin_update_engine.class.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'TribePluginUpdateEngineChecker' ) ) {
 		 * @return bool
 		 */
 		public function get_sslverify() {
-			return apply_filters( 'pue_get_sslverify', ( defined( 'PUE_UPDATE_URL' ) ) ? FALSE : TRUE );
+			return apply_filters( 'pue_get_sslverify', ( defined( 'PUE_SSLVERIFY' ) ) ? FALSE : TRUE );
 		}
 
 		/**

--- a/lib/pue/lib/pue_plugin_update_engine.class.php
+++ b/lib/pue/lib/pue_plugin_update_engine.class.php
@@ -114,6 +114,20 @@ if ( ! class_exists( 'TribePluginUpdateEngineChecker' ) ) {
 		}
 
 		/**
+		 * Determine whether or not to verify the SSL cert for the PUE update API endpoint url
+		 *
+		 * Default is to verify the certificate. This is a good thing.
+		 *
+		 * Reason: development environments where the PUE_UPDATE_URL constant is set often have self-signed certificates. 
+		 * This allows overriding this easily, while defaulting to more secure behavior.
+		 *
+		 * @return bool
+		 */
+		public function get_sslverify() {
+			return apply_filters( 'pue_get_sslverify', ( defined( 'PUE_UPDATE_URL' ) ) ? FALSE : TRUE );
+		}
+
+		/**
 		 * Get the PUE update API endpoint url
 		 *
 		 * @return string
@@ -520,8 +534,9 @@ if ( ! class_exists( 'TribePluginUpdateEngineChecker' ) ) {
 
 			//Various options for the wp_remote_get() call. Plugins can filter these, too.
 			$options = array(
-				'timeout' => 15, //seconds
-				'headers' => array(
+				'timeout'    => 15, //seconds
+				'sslverify'  => (bool) $this->get_sslverify(),
+				'headers'    => array(
 					'Accept' => 'application/json'
 				),
 			);
@@ -845,4 +860,3 @@ if ( ! class_exists( 'TribePluginUpdateEngineChecker' ) ) {
 		}
 	}
 }
-?>


### PR DESCRIPTION
Issue: when the `PUE_UPDATE_URL` constant is set to a site with a self-signed certificate for development purposes, the PUE client can't access the PUE server. 

This works around that by relaxing the SSL verification done when the `PUE_UPDATE_URL` constant is set.