### PR TITLE
Update tribe-templates.class.php - Check that $post is object before calling

### DIFF
--- a/lib/tribe-templates.class.php
+++ b/lib/tribe-templates.class.php
@@ -685,7 +685,7 @@ if ( ! class_exists( 'TribeEventsTemplates' ) ) {
 		 */
 		public static function event_date_to_pubDate( $time, $d, $gmt ) {
 			global $post;
-			if ( $post->post_type == TribeEvents::POSTTYPE && is_feed() && $gmt ) {
+			if ( is_object( $post ) && $post->post_type == TribeEvents::POSTTYPE && is_feed() && $gmt ) {
 				$time = tribe_get_start_date( $post->ID, false, $d );
 				$time = mysql2date( $d, $time );
 			}


### PR DESCRIPTION
Checks that $post exists before calling it.  Fixes an issue with conflicts with other plugins and/or custom post types.

Notice: Trying to get property of non-object in /Users/Support/dev/WordPress/wp-content/plugins/the-events-calendar/lib/tribe-templates.class.php on line 688