### PR TITLE
Make the single event Google map object available externally via tribeEventsSingleMap

### DIFF
--- a/resources/embedded-map.js
+++ b/resources/embedded-map.js
@@ -60,6 +60,9 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 			title   : venueTitle,
 			position: position
 		} );
+
+		// Assign the Google Map to a global variable so themes or plugins can interact with it
+		tribeEventsSingleMap.map = map;
 	}
 
 	// Iterate through available addresses and set up the map for each


### PR DESCRIPTION
This allows plugin or theme code to modify the Google map. The tribeEventsSingleMap var will have all the data needed: initial zoom level, addresses, and the google map object itself.

For example, we may want to disable the scrollwheel. With this commit, the following can be called from outside The Event Calendar:
`tribeEventsSingleMap.map.setOptions({scrollwheel:false});`