### PR TITLE
Rename tribe_get_prev_event_link filter

### DIFF
--- a/public/template-tags/link.php
+++ b/public/template-tags/link.php
@@ -36,7 +36,7 @@ if ( class_exists( 'Tribe__Events__Events' ) ) {
 	function tribe_get_prev_event_link( $anchor = false ) {
 		global $post;
 
-		return apply_filters( 'tribe_get_next_event_link', Tribe__Events__Events::instance()->get_event_link( $post, 'previous', $anchor ) );
+		return apply_filters( 'tribe_get_prev_event_link', Tribe__Events__Events::instance()->get_event_link( $post, 'previous', $anchor ) );
 	}
 
 	/**


### PR DESCRIPTION
Currently the filter is called **tribe_get_next_event_link** however, the function is called **tribe_get_prev_event_link** so I think the filter should be named according to the function. 