### PR TITLE
Let updateEvent set the 'post_type' arg like createEvent does

### DIFF
--- a/lib/API.php
+++ b/lib/API.php
@@ -58,10 +58,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		 */
 		public static function updateEvent( $eventId, $args ) {
 			$args['ID'] = $eventId;
-
-			if ( ! in_array( Tribe__Events__Events::POSTTYPE, (array) $args['post_type'] ) ) {
-				return false;
-			}
+			$args['post_type'] = Tribe__Events__Events::POSTTYPE;
 
 			if ( wp_update_post( $args ) ) {
 				Tribe__Events__API::saveEventMeta( $eventId, $args, get_post( $eventId ) );


### PR DESCRIPTION
When writing an import script that would check if the event already exists before creating a new one I would have a look at **Tribe__Events__API:: createEvent** to see what arguments were required. I saw that it sets the `post_type` argument to **Tribe__Events__Events::POSTTYPE** which is nice, so I don't have to.

Later I stumbled upon that when I found that my import script was not properly updating the existing events and I discovered that **Tribe__Events__API:: updateEvent** requires the `post_type` to be set properly in the passed arguments.

The behavior of updateEvent should be consistent with createEvent so this PR removes the if-clause and instead sets the post_type to the arg. 