### PR TITLE
Add sortable events table by tax + Refactoring

### DIFF
--- a/lib/Admin_List.php
+++ b/lib/Admin_List.php
@@ -71,6 +71,10 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 				case 'end-date':
 					$meta_key = '_EventEndDate';
 				break;
+				
+				default:
+					return $clauses;
+				break;
 			}
 			
 			global $wpdb;

--- a/lib/Admin_List.php
+++ b/lib/Admin_List.php
@@ -227,15 +227,19 @@ SQL;
 		 * @return void
 		 */
 		public static function custom_columns( $column_id, $post_id ) {
-			if ( $column_id == 'events-cats' ) {
-				$event_cats = get_the_term_list( $post_id, Tribe__Events__Main::TAXONOMY, '', ', ', '' );
-				echo ( $event_cats ) ? strip_tags( $event_cats ) : '—';
-			}
-			if ( $column_id == 'start-date' ) {
-				echo tribe_get_start_date( $post_id, false );
-			}
-			if ( $column_id == 'end-date' ) {
-				echo tribe_get_end_date( $post_id, false );
+			switch ( $column_id ) {
+				case 'events-cats':
+					$event_cats = get_the_term_list( $post_id, Tribe__Events__Main::TAXONOMY, '', ', ', '' );
+					echo ( $event_cats ) ? strip_tags( $event_cats ) : '—';
+				break;
+				
+				case 'start-date':
+					echo tribe_get_start_date( $post_id, false );
+				break;
+				
+				case 'end-date':
+					echo tribe_get_end_date( $post_id, false );
+				break;
 			}
 		}
 

--- a/lib/Admin_List.php
+++ b/lib/Admin_List.php
@@ -141,7 +141,7 @@ SQL;
 		 * @return string modified limits clause
 		 */
 		public static function events_search_limits( $limits, $query ) {
-			if ( ! $query->is_main_query() || $query->get( 'post_type' ) != Tribe__Events__Main::POSTTYPE || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			if ( ! $query->is_main_query() || $query->get( 'post_type' ) != Tribe__Events__Main::POSTTYPE ) {
 				return $limits;
 			}
 			global $current_screen;

--- a/lib/Admin_List.php
+++ b/lib/Admin_List.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 		 * @return  string                  ASC/DESC prefixed with a single space
 		 */
 		public static function get_sort_direction( WP_Query $wp_query ) {
-			return ' ' . (('ASC' == strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC');
+			return ' ' . ( ( 'ASC' == strtoupper( $wp_query->get( 'order' ) ) ) ? 'ASC' : 'DESC' );
 		}
 		
 		/**


### PR DESCRIPTION
**New:**  
- Added sorting by event category and tags. Code was based off similar work from [my own plugin](https://github.com/kittsville/WP-Librarian/blob/e2bb0e176633dbb38a83912aeccbb2d4cdae03c8/lib/admin-tables.class.php#L453-L493), which was based on code by Mike Schinkel.

**Refactored:**  

- Removed duplicate is_admin check
- Replaced obfuscated event date sorting logic with single function. Also got rid of unnecessary use of two SQL joins rather than just one.
- Aligned and commented hook registration for an easier to read/understand init(). Now looks more like hook registration in main plugin class
- Replaced 3 if statements with a switch for very slightly faster but mainly easier to read function logic

[Here's a quick look at the sorting in action](http://imgur.com/a/GRpWC). Note that sorting by a taxonomy hides events that have no terms for that tax.

While I was working on this I noticed a query is leaking from `Query.php` and potentially causing a minor performance loss for all events queries. If you check out the generated SQL with any debugging plugin you'll see the offending join being added to the admin tables queries.

If you don't want to add the sortable feature then please still consider accepting the refactoring done in the other commits. 