### PR TITLE
fix Tickets_Pro path property

### DIFF
--- a/src/Tribe/Tickets/Tickets_Pro.php
+++ b/src/Tribe/Tickets/Tickets_Pro.php
@@ -54,7 +54,7 @@ class Tribe__Events__Tickets__Tickets_Pro {
 		add_action( 'admin_menu',                               array( $this, 'attendees_page_register'         )        );
 		add_filter( 'post_row_actions',                         array( $this, 'attendees_row_action'            )        );
 
-		$this->path = trailingslashit( dirname( dirname( dirname( __FILE__ ) ) ) );
+		$this->path = trailingslashit( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) );
 		$this->google_event_data = new Tribe__Events__Tickets__Google_Event_Data;
 	}
 


### PR DESCRIPTION
Just a simple change here. The path property was 1 directory too shallow in its definition, so all of the templates it was attempting to load were failing as they all had a `src/src/` in the path instead of `src/`.