### PR TITLE
Allow Attendees_Table constructor to accept arguments

### DIFF
--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -14,9 +14,18 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 
 	/**
 	 * Class constructor
+	 *
+	 * @param array $args  additional arguments/overrides
+	 *
+	 * @see WP_List_Table::__construct()
 	 */
-	function __construct() {
-		parent::__construct( array( 'singular' => 'attendee', 'plural' => 'attendees', 'ajax' => true ) );
+	function __construct( $args = array() ) {
+		$args = wp_parse_args( $args, array(
+			'singular' => 'attendee',
+			'plural'   => 'attendees',
+			'ajax'     => true
+		) );
+		parent::__construct( $args );
 	}
 
 

--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -25,7 +25,7 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 			'plural'   => 'attendees',
 			'ajax'     => true
 		) );
-		parent::__construct( $args );
+		parent::__construct( apply_filters( 'tribe_events_tickets_attendees_table_args', $args ) );
 	}
 
 


### PR DESCRIPTION
This is a simple change which does just what it says, it allows the constructor to accept extra arguments or override any of the defaults.

This has no affect on the normal functionality of the plugin/attendees table.  It is necessary though however for the list table to be used on any other admin page (e.g. WooCommerce order - which has been my use-case).  To do this, we need to be able to pass in the `screen` key in the arguments array.