### PR TITLE
Display proper order_id for woocommerce orders

### DIFF
--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -112,16 +112,10 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 
 		//back compat
 		if ( empty( $item['order_id_link'] ) ) {
-			$display_id = $item['order_id'];
-			if ( function_exists('wc_get_order') && wc_get_order( $item['order_id'] ) ) {
-				$display_id = wc_get_order( $item['order_id'] )->get_order_number();
-			}
-			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $display_id ) );
-		} else {
-			$id = $item['order_id_link'];
+			$item['order_id_link'] = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $item['order_id'] ) );
 		}
 
-		return $id;
+		return $item['order_id_link'];
 	}
 
 	/**

--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -112,7 +112,11 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 
 		//back compat
 		if ( empty( $item['order_id_link'] ) ) {
-			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $item['order_id'] ) );
+			$display_id = $item['order_id'];
+			if ( function_exists('wc_get_order') && wc_get_order( $item['order_id'] ) ) {
+				$display_id = wc_get_order( $item['order_id'] )->get_order_number();
+			}
+			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $display_id ) );
 		} else {
 			$id = $item['order_id_link'];
 		}


### PR DESCRIPTION
This PR addresses an issue where the displayed order ID for an attendee does not match the ID elsewhere in the system.  This is because at current, it is just showing the bare ID, rather than calling the `get_order_number` method on the woocommerce order.  _This will only change the current behavior if the item's order_id is a woocommerce order._

Why would the order number be different than the order ID?  See http://www.woothemes.com/products/sequential-order-numbers-pro/