### PR TITLE
PHP 5.2 doesn't do `static`. Use `self`

### DIFF
--- a/src/Tribe/Asset/Factory.php
+++ b/src/Tribe/Asset/Factory.php
@@ -7,7 +7,7 @@
 		 * @return Tribe__Events__Asset__Factory
 		 */
 		public static function instance() {
-			return new static;
+			return new self;
 		}
 
 		/**

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -152,6 +152,21 @@ if ( ! class_exists( 'Tribe__Events__Template_Factory' ) ) {
 		protected static function handle_asset_package_request( $name, $deps, $vendor_url, $prefix, $tec ) {
 
 			$asset = self::get_asset_factory_instance( $name );
+
+			self::prepare_asset_package_request( $asset, $name, $deps, $vendor_url, $prefix, $tec );
+		}
+
+		/**
+		 * initializes asset package request
+		 *
+		 * @param object              $asset         The Tribe__Events__*Asset object
+		 * @param string              $name          The asset name in the `hyphen-separated-format`
+		 * @param array               $deps          An array of dependency handles
+		 * @param string              $vendor_url    URL to vendor scripts and styles dir
+		 * @param string              $prefix        MT script and style prefix
+		 * @param Tribe__Events__Main $tec           An instance of the main plugin class
+		 */
+		protected static function prepare_asset_package_request( $asset, $name, $deps, $vendor_url, $prefix, $tec ) {
 			if ( ! $asset ) {
 				do_action( $prefix . '-' . $name );
 

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'Tribe__Events__Template_Factory' ) ) {
 		 */
 		protected static function handle_asset_package_request( $name, $deps, $vendor_url, $prefix, $tec ) {
 
-			$asset = static::get_asset_factory_instance( $name );
+			$asset = self::get_asset_factory_instance( $name );
 			if ( ! $asset ) {
 				do_action( $prefix . '-' . $name );
 


### PR DESCRIPTION
Since PHP 5.2 doesn't like `static`, I needed to restructure my recent restructure a bit so other plugins can have their own Assets.

Related: https://github.com/moderntribe/events-pro/pull/12

See: https://central.tri.be/issues/36164 and https://central.tri.be/issues/33500