### PR TITLE
Add Ticket events in tickets.js

### DIFF
--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -355,13 +355,13 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		}
 
 		function tickets_start_spin() {
-			jQuery( '#event_tickets' ).css( 'opacity', '0.5' );
-			jQuery( "#tribe-loading" ).show();
+			$( '#event_tickets' ).css( 'opacity', '0.5' );
+			$( "#tribe-loading" ).show();
 		}
 
 		function tickets_stop_spin() {
-			jQuery( '#event_tickets' ).css( 'opacity', '1' );
-			jQuery( "#tribe-loading" ).hide();
+			$( '#event_tickets' ).css( 'opacity', '1' );
+			$( "#tribe-loading" ).hide();
 		}
 
 		function tribe_fix_image_width() {

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -126,7 +126,9 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		var $tribetickets = $('#tribetickets');
 
 		/* "Save Ticket" button action */
-		$( '#ticket_form_save' ).click( function() {
+		$( '#ticket_form_save' ).click( function( e ) {
+
+			$tribetickets.trigger('eventSaveTicket.tribe', e);
 
 			tickets_start_spin();
 
@@ -141,6 +143,8 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 				ajaxurl,
 				params,
 				function( response ) {
+					$tribetickets.trigger('eventSavedTicket.tribe', response);
+
 					if ( response.success ) {
 						ticket_clear_form();
 						$( 'td.ticket_list_container' ).empty().html( response.data );
@@ -163,6 +167,8 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		$tribetickets.on( 'click', '.ticket_delete', function( e ) {
 
 			e.preventDefault();
+			
+			$tribetickets.trigger('eventDeleteTicket.tribe', e);
 
 			tickets_start_spin();
 
@@ -177,6 +183,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 				ajaxurl,
 				params,
 				function( response ) {
+					$tribetickets.trigger('eventDeletedTicket.tribe', response);
 
 					if ( response.success ) {
 						ticket_clear_form();
@@ -216,6 +223,8 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 					params,
 					function( response ) {
 						ticket_clear_form();
+
+						$tribetickets.trigger('eventEditTicket.tribe', response);
 
 						var regularPrice = response.data.price;
 						var salePrice    = regularPrice;

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -123,6 +123,8 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 
 		} );
 
+		var $tribetickets = $('#tribetickets');
+
 		/* "Save Ticket" button action */
 		$( '#ticket_form_save' ).click( function() {
 
@@ -158,7 +160,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 
 		/* "Delete Ticket" link action */
 
-		$( '#tribetickets' ).on( 'click', '.ticket_delete', function( e ) {
+		$tribetickets.on( 'click', '.ticket_delete', function( e ) {
 
 			e.preventDefault();
 
@@ -191,7 +193,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 
 		/* "Edit Ticket" link action */
 
-		$( '#tribetickets' )
+		$tribetickets
 			.on( 'click', '.ticket_edit', function( e ) {
 
 				e.preventDefault();
@@ -365,7 +367,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 		}
 
 		function tribe_fix_image_width() {
-			if ( $( '#tribetickets' ).width() < $tiximg.width() ) {
+			if ( $tribetickets.width() < $tiximg.width() ) {
 				$tiximg.css( "width", '95%' );
 			}
 		}


### PR DESCRIPTION
This PR adds new javascript events to the tickets.js script which handles ticket creation, modification, and deletion from an Event edit screen.

No behavioral changes are introduced here, this is all for making the code more extendable.

The events that are triggered are all done on the `#tribetickets` container, and follow a particular convention where `tribe` is the jQuery event namespace:

- `eventSaveTicket.tribe`
- `eventSavedTicket.tribe`
- `eventEditTicket.tribe`
- `eventDeleteTicket.tribe`
- `eventDeletedTicket.tribe`

Note the missing `eventEditedTicket.tribe` - as the event for updating an event is just another Save.  Edit is triggered just after the new edit form is loaded and reset.

The pre-event hooks are passed the jQuery event object that triggered the action, and the completed events are passed the ajax response object.

These hooks make managing additional product fields possible on the ticket, or working with your own custom fields, without resorting to just using the same click bindings. 

In addition to this, there are a few other supporting small changes, like caching the jQuery object for the `#tribetickets` container which is used for emitting the events (as well as a few other places), and updating `$` instead of `jQuery` in a few places for consistency.

These events can be viewed in the console by adding this jQuery for testing
```js
jQuery(function($){

	function log(){
		console.log(arguments[0].type);
	}

	$('#tribetickets')
		.on('eventSaveTicket.tribe', log)
		.on('eventSavedTicket.tribe', log)
		.on('eventEditTicket.tribe', log)
		.on('eventDeleteTicket.tribe', log)
		.on('eventDeletedTicket.tribe', log)
});
```