### PR TITLE
Make attendee table nav filterable

### DIFF
--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -187,32 +187,37 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 	 *
 	 * Used for the Print, Email and Export buttons, and for the jQuery based search.
 	 *
+	 * @param string $which (top|bottom)
+	 * @see WP_List_Table::display()
 	 */
 	function extra_tablenav( $which ) {
 
-		echo '<div class="alignleft actions">';
-
-		echo sprintf( '<input type="button" name="print" class="print button action" value="%s">', __( 'Print', 'tribe-events-calendar' ) );
-		echo sprintf( '<input type="button" name="email" class="email button action" value="%s">', __( 'Email', 'tribe-events-calendar' ) );
-		echo sprintf(
-			'<a href="%s" class="export button action">%s</a>', esc_url(
-				add_query_arg(
-					array(
-						"attendees_csv"       => true,
-						"attendees_csv_nonce" => wp_create_nonce( 'attendees_csv_nonce' )
-					)
-				)
-			), __( 'Export', 'tribe-events-calendar' )
+		$export_url = add_query_arg(
+			array(
+				"attendees_csv"       => true,
+				"attendees_csv_nonce" => wp_create_nonce( 'attendees_csv_nonce' )
+			)
 		);
 
-		echo '</div>';
+		$nav = array(
+			'left' => array(
+				'print'  => sprintf( '<input type="button" name="print" class="print button action" value="%s">', esc_attr__( 'Print', 'tribe-events-calendar' ) ),
+				'email'  => sprintf( '<input type="button" name="email" class="email button action" value="%s">', esc_attr__( 'Email', 'tribe-events-calendar' ) ),
+				'export' => sprintf( '<a href="%s" class="export button action">%s</a>', esc_url( $export_url ),          __( 'Export', 'tribe-events-calendar' ) ),
+			),
+			'right' => array()
+		);
 
 		if ( 'top' == $which ) {
-			echo '<div class="alignright">';
-			echo sprintf( '%s: <input type="text" name="filter_attendee" id="filter_attendee" value="">', __( "Filter by purchaser name, ticket #, order # or security code", "tribe-events-calendar" ) );
-			echo '</div>';
-
+			$nav['right']['filter_box'] = sprintf( '%s: <input type="text" name="filter_attendee" id="filter_attendee" value="">', __( "Filter by purchaser name, ticket #, order # or security code", "tribe-events-calendar" ) );
 		}
+
+		$nav = apply_filters( 'tribe_events_tickets_attendees_table_nav', $nav, $which );
+
+		?>
+		<div class="alignleft actions"><?php echo join( $nav['left'] ); ?></div>
+		<div class="alignright"><?php echo join( $nav['right'] ) ?></div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
This PR makes the attendee's list table top/bottom nav extendable by first restructuring the output into an array, and then making that filterable via a new filter `tribe_events_tickets_attendees_table_nav ` before output.

The structure of the array, in combination with the `$which` position passed by the filter, makes extending any combination of the `top`, `bottom`, `left`, `right` nav very easy.

No real change in the current behavior here, but there is one minor change which may not be obvious that _could_, which is the use of `esc_attr__()` for the _Print_ and _Email_ action buttons (instead of `__()`, since those translations are passed into the `value` attribute of their respective buttons.