### PR TITLE
Update grunt paths to match the restructured plugin directory

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -48,7 +48,7 @@ Outside of that object you will note something like this:
       "version": "3.7",
       "repository": "git@github.com:moderntribe/the-events-calendar.git",
       "_bowerpath": "dev/bower_components",
-      "_resourcepath": "resources",
+      "_resourcepath": "src/resources",
       "_componentpath": "dev/dev_components",
       "engines": {
         "node": "0.10.30",
@@ -61,12 +61,12 @@ For example, we can use them in Grunt tasks like so:
 
 	libs: {
     		src: [
-    			'<%= pkg._resourcepath %>/debug/ba-debug.js',
-    			'<%= pkg._resourcepath %>/jquery-ui/ui/jquery.ui.core.js',
-    			'<%= pkg._resourcepath %>/jquery-ui/ui/jquery.ui.effect.js',
-    			'<%= pkg._resourcepath %>/jquery.fitvids/jquery.fitvids.js'
+    			'<%= pkg._resourcepath %>/js/debug/ba-debug.js',
+    			'<%= pkg._resourcepath %>/js/jquery-ui/ui/jquery.ui.core.js',
+    			'<%= pkg._resourcepath %>/js/jquery-ui/ui/jquery.ui.effect.js',
+    			'<%= pkg._resourcepath %>/js/jquery.fitvids/jquery.fitvids.js'
     		],
-    		dest: '<%= pkg._resourcepath %>/libs.js'
+    		dest: '<%= pkg._resourcepath %>/js/libs.js'
     	},
 
 When installing new packages make sure you add the flag `--save-dev` to add them to the package.json file.

--- a/dev/grunt_options/clean.js
+++ b/dev/grunt_options/clean.js
@@ -17,19 +17,19 @@ module.exports = {
 
 	resourcescripts: [
 
-		'<%= pkg._resourcepath %>/events-admin.processed.js',
-		'<%= pkg._resourcepath %>/tickets.processed.js',
-		'<%= pkg._resourcepath %>/tickets-attendees.processed.js',
-		'<%= pkg._resourcepath %>/tribe-events.processed.js',
-		'<%= pkg._resourcepath %>/tribe-events-ajax-calendar.processed.js',
-		'<%= pkg._resourcepath %>/tribe-events-ajax-day.processed.js',
-		'<%= pkg._resourcepath %>/tribe-events-ajax-list.processed.js',
-		'<%= pkg._resourcepath %>/tribe-events-bar.processed.js',
-		'<%= pkg._resourcepath %>/tribe-settings.processed.js'
+		'<%= pkg._resourcepath %>/js/events-admin.processed.js',
+		'<%= pkg._resourcepath %>/js/tickets.processed.js',
+		'<%= pkg._resourcepath %>/js/tickets-attendees.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-events.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-events-ajax-day.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-events-ajax-list.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-events-bar.processed.js',
+		'<%= pkg._resourcepath %>/js/tribe-settings.processed.js'
 	],
 
 	resourcecss: [
-		'<%= pkg._resourcepath %>/*.min.css'
+		'<%= pkg._resourcepath %>/css/*.min.css'
 	]
 
 

--- a/dev/grunt_options/csslint.js
+++ b/dev/grunt_options/csslint.js
@@ -29,7 +29,7 @@ module.exports = {
 			import: false,
 			force:true
 		},
-		src: ['<%= pkg._resourcepath %>/*.css', '<%= pkg._resourcepath %>/!*.min.css']
+		src: ['<%= pkg._resourcepath %>/css/*.css', '<%= pkg._resourcepath %>/css/!*.min.css']
 	}
 
 };

--- a/dev/grunt_options/cssmin.js
+++ b/dev/grunt_options/cssmin.js
@@ -21,7 +21,7 @@ module.exports = {
 	resourcecss: {
 
 		expand: true,
-		src   : ['<%= pkg._resourcepath %>/*.css', '<%= pkg._resourcepath %>/!*.min.css'],
+		src   : ['<%= pkg._resourcepath %>/css/*.css', '<%= pkg._resourcepath %>/css/!*.min.css'],
 		ext   : '.min.css'
 	}
 

--- a/dev/grunt_options/jshint.js
+++ b/dev/grunt_options/jshint.js
@@ -45,15 +45,15 @@ module.exports = {
 		},
 		files  : {
 			src: [
-				'<%= pkg._resourcepath %>/events-admin.js',
-				'<%= pkg._resourcepath %>/tickets.js',
-				'<%= pkg._resourcepath %>/tickets-attendees.js',
-				'<%= pkg._resourcepath %>/tribe-events.js',
-				'<%= pkg._resourcepath %>/tribe-events-ajax-calendar.js',
-				'<%= pkg._resourcepath %>/tribe-events-ajax-day.js',
-				'<%= pkg._resourcepath %>/tribe-events-ajax-list.js',
-				'<%= pkg._resourcepath %>/tribe-events-bar.js',
-				'<%= pkg._resourcepath %>/tribe-settings.js'
+				'<%= pkg._resourcepath %>/js/events-admin.js',
+				'<%= pkg._resourcepath %>/js/tickets.js',
+				'<%= pkg._resourcepath %>/js/tickets-attendees.js',
+				'<%= pkg._resourcepath %>/js/tribe-events.js',
+				'<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.js',
+				'<%= pkg._resourcepath %>/js/tribe-events-ajax-day.js',
+				'<%= pkg._resourcepath %>/js/tribe-events-ajax-list.js',
+				'<%= pkg._resourcepath %>/js/tribe-events-bar.js',
+				'<%= pkg._resourcepath %>/js/tribe-settings.js'
 			]
 		}
 	}

--- a/dev/grunt_options/preprocess.js
+++ b/dev/grunt_options/preprocess.js
@@ -42,15 +42,15 @@ module.exports = {
 	},
 	resourcescripts : {
 		files : {
-			'<%= pkg._resourcepath %>/events-admin.processed.js' : '<%= pkg._resourcepath %>/events-admin.js',
-			'<%= pkg._resourcepath %>/tickets.processed.js' : '<%= pkg._resourcepath %>/tickets.js',
-			'<%= pkg._resourcepath %>/tickets-attendees.processed.js' : '<%= pkg._resourcepath %>/tickets-attendees.js',
-			'<%= pkg._resourcepath %>/tribe-events.processed.js' : '<%= pkg._resourcepath %>/tribe-events.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-calendar.processed.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-calendar.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-day.processed.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-day.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-list.processed.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-list.js',
-			'<%= pkg._resourcepath %>/tribe-events-bar.processed.js' : '<%= pkg._resourcepath %>/tribe-events-bar.js',
-			'<%= pkg._resourcepath %>/tribe-settings.processed.js' : '<%= pkg._resourcepath %>/tribe-settings.js'
+			'<%= pkg._resourcepath %>/js/events-admin.processed.js' : '<%= pkg._resourcepath %>/js/events-admin.js',
+			'<%= pkg._resourcepath %>/js/tickets.processed.js' : '<%= pkg._resourcepath %>/js/tickets.js',
+			'<%= pkg._resourcepath %>/js/tickets-attendees.processed.js' : '<%= pkg._resourcepath %>/js/tickets-attendees.js',
+			'<%= pkg._resourcepath %>/js/tribe-events.processed.js' : '<%= pkg._resourcepath %>/js/tribe-events.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.processed.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-day.processed.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-day.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-list.processed.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-list.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-bar.processed.js' : '<%= pkg._resourcepath %>/js/tribe-events-bar.js',
+			'<%= pkg._resourcepath %>/js/tribe-settings.processed.js' : '<%= pkg._resourcepath %>/js/tribe-settings.js'
 		}
 	}
 

--- a/dev/grunt_options/uglify.js
+++ b/dev/grunt_options/uglify.js
@@ -16,15 +16,15 @@ module.exports = {
 
 	resourcescripts: {
 		files: {
-			'<%= pkg._resourcepath %>/events-admin.min.js' : '<%= pkg._resourcepath %>/events-admin.processed.js',
-			'<%= pkg._resourcepath %>/tickets.min.js' : '<%= pkg._resourcepath %>/tickets.processed.js',
-			'<%= pkg._resourcepath %>/tickets-attendees.min.js' : '<%= pkg._resourcepath %>/tickets-attendees.processed.js',
-			'<%= pkg._resourcepath %>/tribe-events.min.js' : '<%= pkg._resourcepath %>/tribe-events.processed.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-calendar.min.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-calendar.processed.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-day.min.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-day.processed.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-list.min.js' : '<%= pkg._resourcepath %>/tribe-events-ajax-list.processed.js',
-			'<%= pkg._resourcepath %>/tribe-events-bar.min.js' : '<%= pkg._resourcepath %>/tribe-events-bar.processed.js',
-			'<%= pkg._resourcepath %>/tribe-settings.min.js' : '<%= pkg._resourcepath %>/tribe-settings.processed.js'
+			'<%= pkg._resourcepath %>/js/events-admin.min.js' : '<%= pkg._resourcepath %>/js/events-admin.processed.js',
+			'<%= pkg._resourcepath %>/js/tickets.min.js' : '<%= pkg._resourcepath %>/js/tickets.processed.js',
+			'<%= pkg._resourcepath %>/js/tickets-attendees.min.js' : '<%= pkg._resourcepath %>/js/tickets-attendees.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-events.min.js' : '<%= pkg._resourcepath %>/js/tribe-events.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.min.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-day.min.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-day.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-list.min.js' : '<%= pkg._resourcepath %>/js/tribe-events-ajax-list.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-bar.min.js' : '<%= pkg._resourcepath %>/js/tribe-events-bar.processed.js',
+			'<%= pkg._resourcepath %>/js/tribe-settings.min.js' : '<%= pkg._resourcepath %>/js/tribe-settings.processed.js'
 		}
 	}
 

--- a/dev/grunt_options/watch.js
+++ b/dev/grunt_options/watch.js
@@ -25,8 +25,8 @@ module.exports = {
 
 	resourcecss: {
 		files: [
-			'<%= pkg._resourcepath %>/*.css',
-			'<%= pkg._resourcepath %>/!*.min.css'
+			'<%= pkg._resourcepath %>/css/*.css',
+			'<%= pkg._resourcepath %>/css/!*.min.css'
 		],
 		tasks: [
 			'clean:resourcecss',
@@ -39,15 +39,15 @@ module.exports = {
 	},
 	resourcescripts: {
 		files: [
-			'<%= pkg._resourcepath %>/events-admin.js',
-			'<%= pkg._resourcepath %>/tickets.js',
-			'<%= pkg._resourcepath %>/tickets-attendees.js',
-			'<%= pkg._resourcepath %>/tribe-events.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-calendar.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-day.js',
-			'<%= pkg._resourcepath %>/tribe-events-ajax-list.js',
-			'<%= pkg._resourcepath %>/tribe-events-bar.js',
-			'<%= pkg._resourcepath %>/tribe-settings.js'
+			'<%= pkg._resourcepath %>/js/events-admin.js',
+			'<%= pkg._resourcepath %>/js/tickets.js',
+			'<%= pkg._resourcepath %>/js/tickets-attendees.js',
+			'<%= pkg._resourcepath %>/js/tribe-events.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-calendar.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-day.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-ajax-list.js',
+			'<%= pkg._resourcepath %>/js/tribe-events-bar.js',
+			'<%= pkg._resourcepath %>/js/tribe-settings.js'
 		],
 		tasks: [
 			'jshint:resourcescripts',

--- a/dev/package.json
+++ b/dev/package.json
@@ -4,7 +4,7 @@
   "repository": "git@github.com:moderntribe/the-events-calendar.git",
   "_zipname": "the-events-calendar",
   "_zipfoldername": "the-events-calendar",
-  "_resourcepath": "resources",
+  "_resourcepath": "src/resources",
   "engines": {
     "node": "0.10.30",
     "npm": "1.4.23"


### PR DESCRIPTION
Related:
* https://github.com/moderntribe/events-community/pull/8
* https://github.com/moderntribe/events-eventbrite/pull/14
* https://github.com/moderntribe/events-facebook/pull/7
* https://github.com/moderntribe/events-filterbar/pull/5
* https://github.com/moderntribe/events-pro/pull/16
* https://github.com/moderntribe/events-tickets-edd/pull/5
* https://github.com/moderntribe/events-tickets-shopp/pull/4
* https://github.com/moderntribe/events-tickets-woo/pull/10
* https://github.com/moderntribe/events-tickets-wpec/pull/7

See: https://central.tri.be/issues/36506