### PR TITLE
Allow tickets with a cost of 0 to affect the event price

### DIFF
--- a/src/Tribe/Tickets/Tickets.php
+++ b/src/Tribe/Tickets/Tickets.php
@@ -701,8 +701,9 @@ if ( ! class_exists( 'Tribe__Events__Tickets__Tickets' ) ) {
 					continue;
 				}
 
+
 				// An empty price property can be ignored (but do add if the price is explicitly set to zero)
-				elseif ( ! empty( $ticket->price ) && is_numeric( $ticket->price ) ) {
+				elseif ( isset( $ticket->price ) && is_numeric( $ticket->price ) ) {
 					$prices[] = $ticket->price;
 				}
 			}


### PR DESCRIPTION
`! empty( $ticket->price )` evaluates to false if price is `0`. Using `isset` instead allows 0 to be interpreted as a number.

See: https://central.tri.be/issues/36107

---

This fix allows events with `$0` tickets to display `Free` next to it!

![screen shot 2015-06-01 at 3 57 38 pm](https://cloud.githubusercontent.com/assets/430385/7921944/051828fe-0877-11e5-8949-9042a028a2a6.png)
