### PR TITLE
Only inject date fields into queries when appropriate

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -710,7 +710,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				}
 
 				// trim trailing characters
-				$order_sql = trim( $order_sql, ', \t\n\r\0\x0B' );
+				$order_sql = trim( $order_sql, ", \t\n\r\0\x0B" );
 			} else {
 				if ( $query->tribe_is_multi_posttype && self::can_inject_date_field( $query ) ) {
 					if ( $query->get( 'orderby' ) == 'date' || $query->get( 'orderby' ) == '' ) {


### PR DESCRIPTION
This resolves a long-standing conflict with the Posts 2 Posts plugin which has historically required [a workaround](https://github.com/scribu/wp-posts-to-posts/issues/249).

**Note:** ~~This probably needs a QA pass before merging and smoketesting.~~ This has been QA'd and can be merged.

See: https://central.tri.be/issues/33288