### PR TITLE
Restore startTime and endTime month tooltip template vars for back co…

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1242,6 +1242,16 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			'categoryClasses' => $category_classes,
 		);
 
+		/**
+		 * Template overrides (of month/tooltip.php) set up in 3.9.3 or earlier may still expect
+		 * these vars and will break without them, so they are being kept temporarily for
+		 * backwards compatibility purposes.
+		 *
+		 * @todo consider removing in 4.0
+		 */
+		$json['startTime'] = tribe_get_start_date( $event );
+		$json['endTime']   = tribe_get_end_date( $event );
+
 		if ( $additional ) {
 			$json = array_merge( (array) $json, (array) $additional );
 		}


### PR DESCRIPTION
Custom `month/tooltip.php` templates set up with TEC 3.9.3 or earlier may expect the `startTime` and `endTime` vars to be available.

If they are not (they were removed in commit 959251c5f8d - internal Central ref #30805) the JS templating system gets upset and tooltips stop working altogether.

This change restores those vars so that, as a minimum, month view tooltips continue to display for those users who have customized them.