### PR TITLE
Centralize and make consistent the logic for checking for AllDay

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -93,13 +93,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 
 			if ( isset( $data['EventAllDay'] ) )
 			{
-				$data['EventAllDay'] = trim( $data['EventAllDay'] );
-
-				if (
-					'true' === $data['EventAllDay']
-					|| 'yes' === $data['EventAllDay']
-					|| true === $data['EventAllDay']
-				) {
+				if ( Tribe__Events__Date_Helpers::is_all_day( $data['EventAllDay'] ) ) {
 					$data['EventAllDay'] = 'yes';
 				} else {
 					$data['EventAllDay'] = 'no';

--- a/src/Tribe/Admin/Event_Meta_Box.php
+++ b/src/Tribe/Admin/Event_Meta_Box.php
@@ -132,7 +132,7 @@ class Tribe__Events__Admin__Event_Meta_Box {
 	 * Assess if this is an all day event.
 	 */
 	protected function set_all_day() {
-		$this->vars['isEventAllDay'] = ( $this->vars['_EventAllDay'] == 'yes' || ! Tribe__Events__Date_Utils::dateOnly( $this->vars['_EventStartDate'] ) ) ? 'checked="checked"' : '';
+		$this->vars['isEventAllDay'] = ( Tribe__Events__Date_Helpers::is_all_day( $this->vars['_EventAllDay'] ) || ! Tribe__Events__Date_Utils::dateOnly( $this->vars['_EventStartDate'] ) ) ? 'checked="checked"' : '';
 	}
 
 	protected function set_start_date_time() {

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -351,5 +351,22 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 			if ( --$week_starts_on < 0 ) $week_starts_on = 6;
 			return $week_starts_on;
 		}
+
+		/**
+		 * Helper method to convert EventAllDay values to a boolean
+		 *
+		 * @param mixed $all_day_value Value to check for "all day" status. All day values: (true, 'true', 'TRUE', 'yes')
+		 *
+		 * @return boolean Is value considered "All Day"?
+		 */
+		public static function is_all_day( $all_day_value ) {
+			$all_day_value = trim( $all_day_value );
+
+			return (
+				'true' === strtolower( $all_day_value )
+				|| 'yes' === strtolower( $all_day_value )
+				|| true === $all_day_value
+			);
+		}
 	}
 }

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -278,7 +278,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return bool
 	 */
 	function tribe_event_is_all_day( $postId = null ) {
-		$output = ! ! tribe_get_event_meta( $postId, '_EventAllDay', true );
+		$output = Tribe__Events__Date_Helpers::is_all_day( tribe_get_event_meta( $postId, '_EventAllDay', true ) );
 
 		return apply_filters( 'tribe_event_is_all_day', $output, $postId );
 	}


### PR DESCRIPTION
The checkbox for determining if something was AllDay was different than the logic in tribe_event_is_all_day where any truthy value (including `'no'` and `'false'`) would be considered true. The new `Tribe__Events__Date_Utils::is_all_day()` method now looks for explicitly true values (`true`, `'true'`, `'TRUE'`, and `'yes'`) and considers all other values to be false.

See: https://central.tri.be/issues/36928