### PR TITLE
The `tribe_get_datetime_separator` should not be escaped by default

### DIFF
--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -334,7 +334,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * @return string
 	 */
-	function tribe_get_datetime_separator( $default = ' @ ', $esc = true ) {
+	function tribe_get_datetime_separator( $default = ' @ ', $esc = false ) {
 		$separator = (string) tribe_get_option( 'dateTimeSeparator', $default );
 		if ( $esc ) {
 			$separator = (array) str_split( $separator );


### PR DESCRIPTION
Relates: #93 