### PR TITLE
Default view is month (#29374)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2096,7 +2096,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function default_view() {
 			// Compare the stored default view option to the list of available views
-			$default         = $this->getOption( 'viewOption', '' );
+			$default         = $this->getOption( 'viewOption', 'month' );
 			$available_views = (array) apply_filters( 'tribe-events-bar-views', array(), false );
 
 			foreach ( $available_views as $view ) {


### PR DESCRIPTION
Month view is our default calendar view (and shows as such in *Events > Settings > Display* in a clean install).

This fixes a problem where:

* Within a brand new install, month view shows as default in Events → Settings → Display
* On following the view events link we are presented with list view instead
* Behind the scenes, the default view option was also then changed to month view creating a janky experience