### PR TITLE
Tickets: datepicker opts for one ticket shouldn't be inherited by other tickets (#30688)

### DIFF
--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -348,6 +348,10 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			$( '#ticket_form input:not(:button):not(:radio):not(:checkbox)' ).val( '' );
 			$( '#ticket_form input:checkbox' ).attr( 'checked', false );
 
+			// Reset the min/max datepicker settings so that they aren't inherited by the next ticket that is edited
+			$( '#ticket_start_date' ).datepicker( 'option', 'maxDate', null );
+			$( '#ticket_end_date' ).datepicker( 'option', 'minDate', null );
+
 			$( '.ticket_start_time' ).hide();
 			$( '.ticket_end_time' ).hide();
 			$( '.ticket.sale_price' ).hide();


### PR DESCRIPTION
See (internal ref) #30688 for context: the same form is reused for each ticket that is edited in the event editor. This change prevents the min/max date options set for the first ticket being inherited by the next.
