### PR TITLE
Register meta if Register Meta class exists (#37024)

### DIFF
--- a/src/functions/advanced-functions/meta_registration.php
+++ b/src/functions/advanced-functions/meta_registration.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-if ( ! class_exists( 'Tribe__Events__Advanced_Functions__Register_Meta' ) ) {
+if ( class_exists( 'Tribe__Events__Advanced_Functions__Register_Meta' ) ) {
 	/**
 	 * Register Meta Group: Event Details
 	 *


### PR DESCRIPTION
Changed the check so we *do* register meta groups etc when the relevant class exists.