### PR TITLE
Suppress splash screen sometimes. Don't be as nitpicky about showing it

### DIFF
--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -71,10 +71,12 @@ class Tribe__Events__Activation_Page {
 			return; // a way to skip these checks and
 		}
 
-		// bail if activating from network or bulk
-		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) {
+		// bail if we aren't activating a plugin
+		if ( ! get_transient( '_tribe_events_activation_redirect' ) ) {
 			return;
 		}
+
+		delete_transient( '_tribe_events_activation_redirect' );
 
 		if ( ! current_user_can( Tribe__Events__Settings::instance()->requiredCap ) ){
 			return;

--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -71,11 +71,8 @@ class Tribe__Events__Activation_Page {
 			return; // a way to skip these checks and
 		}
 
-		// bail if activating from network, or bulk
-		if (
-			is_network_admin()
-			|| isset( $_GET['activate-multi'] )
-		) {
+		// bail if activating from network or bulk
+		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) {
 			return;
 		}
 

--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -71,8 +71,12 @@ class Tribe__Events__Activation_Page {
 			return; // a way to skip these checks and
 		}
 
-		if ( isset( $_GET['_wpnonce'] ) || isset( $_GET['activate'] ) || isset( $_GET['s'] ) ) {
-			return; // if WP is doing something we skip
+		// bail if activating from network, or bulk
+		if (
+			is_network_admin()
+			|| isset( $_GET['activate-multi'] )
+		) {
+			return;
 		}
 
 		if ( ! current_user_can( Tribe__Events__Settings::instance()->requiredCap ) ){

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2597,6 +2597,20 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
+		 * plugin activation callback
+		 * @see register_deactivation_hook()
+		 *
+		 * @param bool $network_deactivating
+		 */
+		public static function activate() {
+			self::flushRewriteRules();
+
+			if ( ! is_network_admin() && ! isset( $_GET['activate-multi'] ) ) {
+				set_transient( '_tribe_events_activation_redirect', 1, 30 );
+			}
+		}
+
+		/**
 		 * plugin deactivation callback
 		 * @see register_deactivation_hook()
 		 *

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -33,6 +33,6 @@ require_once dirname( __FILE__ ) . '/src/Tribe/Main.php';
 
 Tribe__Events__Main::instance();
 
-register_activation_hook( __FILE__, array( 'Tribe__Events__Main', 'flushRewriteRules' ) );
+register_activation_hook( __FILE__, array( 'Tribe__Events__Main', 'activate' ) );
 register_deactivation_hook( __FILE__, array( 'Tribe__Events__Main', 'deactivate' ) );
 


### PR DESCRIPTION
When activating a plugin, there is a `nonce`, `action`, and `s` parameter on the URL which prevents the splash screen from displaying. Don't worry about those vars.

See: https://central.tri.be/issues/34265