### PR TITLE
BugFix #29769 - Convert RSS Event Date to UTC000

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -679,26 +679,20 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			global $post;
 
 			if ( is_object( $post ) && $post->post_type == Tribe__Events__Main::POSTTYPE && is_feed() && $gmt ) {
-
-				// Don't interfere if the timezone hasn't been set
-				$zone = get_option( 'timezone_string', false );
-				if ( false === $zone ) {
-					return $time;
-				}
-
-				// Get time and timezone
-				$time = new DateTime( tribe_get_start_date( $post->ID, false, $d ) );
-				$zone = new DateTimeZone( $zone );
-
-				// Apply timezone and calculate offset
-				$time->setTimezone( $zone );
-				$offset = $zone->getOffset( $time );
-				$offset *= - 2;
 				
-				// Apply correction as WordPress always outputs a pubDate set to 00:00 (UTC)
-				$time->modify( "$offset seconds" );
-				$time = $time->format( TribeDateUtils::DBDATETIMEFORMAT );
-				$time = mysql2date( $d, $time );
+				//WordPress always outputs a pubDate set to 00:00 (UTC) so account for that when returning the Event Start Date and Time
+				$zone = get_option( 'timezone_string', false );
+				
+				if ( $zone ) {
+				  $zone = new DateTimeZone( $zone );
+				} else {
+				  $zone = new DateTimeZone( 'UTC' );
+				}
+				
+				$time = new DateTime( tribe_get_start_date( $post->ID, false, $d ), $zone );
+				$time->setTimezone( new DateTimeZone( 'UTC' ) );
+				$time = $time->format( $d );
+								
 			}
 
 			return $time;


### PR DESCRIPTION
WordPress always outputs a pubDate set to 00:00 (UTC) so this takes that
into account with the event date.

Resolves this ticket:
https://central.tri.be/issues/29769