### PR TITLE
After retrieving date format from db, strip slashes (#35633)

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -961,8 +961,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$format = tribe_get_option( 'dateWithoutYearFormat', 'F j' );
 		}
 
-		return apply_filters( 'tribe_date_format', $format );
-
+		// Strip slashes - otherwise the slashes for escaped characters will themselves be escaped
+		return apply_filters( 'tribe_date_format', stripslashes( $format ) );
 	}
 
 	/**


### PR DESCRIPTION
This change lets users successfully escape chars in the date format settings (internal ref #35633 for context).