### PR TITLE
Expose embedded map objects for easier customization potential (#33910)

### DIFF
--- a/src/resources/js/embedded-map.js
+++ b/src/resources/js/embedded-map.js
@@ -3,13 +3,14 @@
  */
 if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 	var mapHolder,
-		position,
-		streetAddress,
-		venueCoords,
-		venueTitle;
+	    position,
+	    venueObject,
+	    venueAddress,
+	    venueCoords,
+	    venueTitle;
 
 	// The tribeEventsSingleMap object must be accessible (as it contains the venue address data etc)
-	if ("undefined" === typeof tribeEventsSingleMap ) return;
+	if ( "undefined" === typeof tribeEventsSingleMap ) return;
 
 	/**
 	 * Determine whether to use long/lat coordinates (these are preferred) or the venue's street
@@ -24,7 +25,7 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 	 * Use long/lat coordinates to position the pin marker.
 	 */
 	function useCoords() {
-		position = new google.maps.LatLng(venueCoords[0], venueCoords[1]);
+		position = new google.maps.LatLng( venueCoords[0], venueCoords[1] );
 		initialize();
 	}
 
@@ -35,7 +36,7 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 		var geocoder = new google.maps.Geocoder();
 
 		geocoder.geocode(
-			{ "address": streetAddress },
+			{ "address": venueAddress },
 			function ( results, status ) {
 				if ( status == google.maps.GeocoderStatus.OK ) {
 					position = results[0].geometry.location;
@@ -47,16 +48,26 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 
 	/**
 	 * Setup the map and apply a marker.
+	 *
+	 * Note that for each individual map, the actual map object can be accessed via the
+	 * tribeEventsSingleMap object. In simple cases (ie, where there is only one map on
+	 * the page) that means you can access it and change its properties via:
+	 *
+	 *     tribeEventsSingleMap.addresses[0].map
+	 *
+	 * Where there are multiple maps - such as in a custom list view with a map per
+	 * event - tribeEventsSingleMap.addresses can be iterated through and changes made
+	 * on an map-by-map basis.
 	 */
 	function initialize() {
-		var map = new google.maps.Map( mapHolder, {
+		venueObject.map = new google.maps.Map( mapHolder, {
 			zoom     : parseInt( tribeEventsSingleMap.zoom ),
 			center   : position,
 			mapTypeId: google.maps.MapTypeId.ROADMAP
 		} );
 
 		new google.maps.Marker( {
-			map     : map,
+			map     : venueObject.map,
 			title   : venueTitle,
 			position: position
 		} );
@@ -66,9 +77,10 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 	$.each( tribeEventsSingleMap.addresses, function( index, venue ) {
 		mapHolder = document.getElementById( "tribe-events-gmap-" + index );
 		if ( null !== mapHolder ) {
-			streetAddress = "undefined" !== typeof venue.address ? venue.address : false;
-			venueCoords   = "undefined" !== typeof venue.coords  ? venue.coords  : false;
-			venueTitle    = venue.title;
+			venueObject  = "undefined" !== typeof venue ? venue: {};
+			venueAddress = "undefined" !== typeof venue.address ? venue.address : false;
+			venueCoords  = "undefined" !== typeof venue.coords  ? venue.coords  : false;
+			venueTitle   = venue.title;
 			prepare();
 		}
 	});


### PR DESCRIPTION
[PR/38](https://github.com/moderntribe/the-events-calendar/pull/38) by @tddewey was a great idea and is encapsulated by this new PR, which targets the `release/119` branch and incorporates some further tweaks to ensure we don't overwrite the map object where multiple maps are delivered in the same page.

Props: [@tddewey](https://github.com/tddewey)