### PR TITLE
Resolving DatePicker saving bug

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -91,14 +91,22 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		public static function saveEventMeta( $event_id, $data, $event = null ) {
 			$tec = Tribe__Events__Main::instance();
 
-			if ( isset( $data['EventAllDay'] ) )
-			{
+			if ( isset( $data['EventAllDay'] ) ) {
 				if ( Tribe__Events__Date_Utils::is_all_day( $data['EventAllDay'] ) ) {
 					$data['EventAllDay'] = 'yes';
 				} else {
 					$data['EventAllDay'] = 'no';
 				}
-			}//end if
+			}
+
+			$datepicker_format = Tribe__Events__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
+			if ( isset( $data['EventStartDate'] ) ){
+				$data['EventStartDate'] = Tribe__Events__Date_Utils::time_from_format( $datepicker_format, $data['EventStartDate'] );
+			}
+
+			if ( isset( $data['EventEndDate'] ) ){
+				$data['EventEndDate'] = Tribe__Events__Date_Utils::time_from_format( $datepicker_format, $data['EventEndDate'] );
+			}
 
 			if ( isset( $data['EventAllDay'] ) && ( 'yes' === $data['EventAllDay'] || ! isset( $data['EventStartDate'] ) ) ) {
 				$data['EventStartDate'] = tribe_event_beginning_of_day( $data['EventStartDate'] );
@@ -106,12 +114,12 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 			} else {
 				delete_post_meta( $event_id, '_EventAllDay' );
 				if ( isset( $data['EventStartMeridian'] ) ) {
-					$data['EventStartDate'] = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventStartDate'] . " " . $data['EventStartHour'] . ":" . $data['EventStartMinute'] . ":00 " . $data['EventStartMeridian'] ) );
-					$data['EventEndDate']   = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventEndDate'] . " " . $data['EventEndHour'] . ":" . $data['EventEndMinute'] . ":00 " . $data['EventEndMeridian'] ) );
+					$data['EventStartDate'] = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventStartDate'] . ' ' . $data['EventStartHour'] . ':' . $data['EventStartMinute'] . ':00 ' . $data['EventStartMeridian'] ) );
+					$data['EventEndDate']   = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventEndDate'] . ' ' . $data['EventEndHour'] . ':' . $data['EventEndMinute'] . ':00 ' . $data['EventEndMeridian'] ) );
 
 				} else {
-					$data['EventStartDate'] = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventStartDate'] . " " . $data['EventStartHour'] . ":" . $data['EventStartMinute'] . ":00" ) );
-					$data['EventEndDate']   = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventEndDate'] . " " . $data['EventEndHour'] . ":" . $data['EventEndMinute'] . ":00" ) );
+					$data['EventStartDate'] = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventStartDate'] . ' ' . $data['EventStartHour'] . ':' . $data['EventStartMinute'] . ':00 ' ) );
+					$data['EventEndDate']   = date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, strtotime( $data['EventEndDate'] . ' ' . $data['EventEndHour'] . ':' . $data['EventEndMinute'] . ':00 ' ) );
 				}
 			}
 

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -101,11 +101,11 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 
 			$datepicker_format = Tribe__Events__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
 			if ( isset( $data['EventStartDate'] ) ){
-				$data['EventStartDate'] = Tribe__Events__Date_Utils::time_from_format( $datepicker_format, $data['EventStartDate'] );
+				$data['EventStartDate'] = Tribe__Events__Date_Utils::datetime_from_format( $datepicker_format, $data['EventStartDate'] );
 			}
 
 			if ( isset( $data['EventEndDate'] ) ){
-				$data['EventEndDate'] = Tribe__Events__Date_Utils::time_from_format( $datepicker_format, $data['EventEndDate'] );
+				$data['EventEndDate'] = Tribe__Events__Date_Utils::datetime_from_format( $datepicker_format, $data['EventEndDate'] );
 			}
 
 			if ( isset( $data['EventAllDay'] ) && ( 'yes' === $data['EventAllDay'] || ! isset( $data['EventStartDate'] ) ) ) {

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 		 *
 		 * @return string         A DB formated Date, includes time if possible
 		 */
-		public static function time_from_format( $format, $date ) {
+		public static function datetime_from_format( $format, $date ) {
 			// Reverse engineer the relevant date formats
 			$keys = array(
 				// Year with 4 Digits
@@ -72,7 +72,7 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 				'n' => array( 'month', '\d{1,2}' ),
 
 				// Month ABBR 3 letters
-				'M' => array( 'month', '[A-Z][a-z]{3}' ),
+				'M' => array( 'month', '[A-Z][a-z]{2}' ),
 
 				// Month Name
 				'F' => array( 'month', '[A-Z][a-z]{2,8}' ),
@@ -87,7 +87,7 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 				'D' => array( 'day', '[A-Z][a-z]{2}' ),
 
 				// Day Name
-				'l' => array( 'day', '[A-Z][a-z]{6,9}' ),
+				'l' => array( 'day', '[A-Z][a-z]{5,8}' ),
 
 				// Hour 12h formatted, with leading 0
 				'h' => array( 'hour', '\d{2}' ),

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 	class Tribe__Events__Date_Utils {
-		// default formats, they are overridden by WP options or by arguments to date methods
+		// Default formats, they are overridden by WP options or by arguments to date methods
 		const DATEONLYFORMAT        = 'F j, Y';
 		const TIMEFORMAT            = 'g:i A';
 		const HOURFORMAT            = 'g';
@@ -20,7 +20,6 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 		const DBDATETIMEFORMAT      = 'Y-m-d H:i:s';
 		const DBTIMEFORMAT          = 'H:i:s';
 		const DBYEARMONTHTIMEFORMAT = 'Y-m';
-
 
 		/**
 		 * Get the datepicker format, that is used to translate the option from the DB to a string
@@ -46,6 +45,109 @@ if ( ! class_exists( 'Tribe__Events__Date_Utils' ) ) {
 			}
 
 			return isset( $formats[ $translate ] ) ? $formats[ $translate ] : $formats[0];
+		}
+
+		/**
+		 * As PHP 5.2 doesn't have a good version of `date_parse_from_format`, this is how we deal with
+		 * possible weird datepicker formats not working
+		 *
+		 * @param  string $format The weird format you are using
+		 * @param  string $date   The date string to parse
+		 *
+		 * @return string         A DB formated Date, includes time if possible
+		 */
+		public static function time_from_format( $format, $date ) {
+			// Reverse engineer the relevant date formats
+			$keys = array(
+				// Year with 4 Digits
+				'Y' => array( 'year', '\d{4}' ),
+
+				// Year with 2 Digits
+				'y' => array( 'year', '\d{2}' ),
+
+				// Month with leading 0
+				'm' => array( 'month', '\d{2}' ),
+
+				// Month without the leading 0
+				'n' => array( 'month', '\d{1,2}' ),
+
+				// Month ABBR 3 letters
+				'M' => array( 'month', '[A-Z][a-z]{3}' ),
+
+				// Month Name
+				'F' => array( 'month', '[A-Z][a-z]{2,8}' ),
+
+				// Day with leading 0
+				'd' => array( 'day', '\d{2}' ),
+
+				// Day without leading 0
+				'j' => array( 'day', '\d{1,2}' ),
+
+				// Day ABBR 3 Letters
+				'D' => array( 'day', '[A-Z][a-z]{2}' ),
+
+				// Day Name
+				'l' => array( 'day', '[A-Z][a-z]{6,9}' ),
+
+				// Hour 12h formatted, with leading 0
+				'h' => array( 'hour', '\d{2}' ),
+
+				// Hour 24h formatted, with leading 0
+				'H' => array( 'hour', '\d{2}' ),
+
+				// Hour 12h formatted, without leading 0
+				'g' => array( 'hour', '\d{1,2}' ),
+
+				// Hour 24h formatted, without leading 0
+				'G' => array( 'hour', '\d{1,2}' ),
+
+				// Minutes with leading 0
+				'i' => array( 'minute', '\d{2}' ),
+
+				// Seconds with leading 0
+				's' => array( 'second', '\d{2}' ),
+			);
+
+			// Convert format string to regex
+			$regex = '';
+			$chars = str_split( $format );
+			foreach ( $chars as $n => $char ) {
+				$last_char = isset( $chars[ $n - 1 ] ) ? $chars[ $n - 1 ] : '';
+				$skip_current = '\\' == $last_char;
+				if ( ! $skip_current && isset( $keys[ $char ] ) ) {
+					$regex .= '(?P<' . $keys[ $char ][0] . '>' . $keys[ $char ][1] . ')';
+				} else if ( '\\' == $char ) {
+					$regex .= $char;
+				} else {
+					$regex .= preg_quote( $char );
+				}
+			}
+
+			$dt = array();
+
+			// Now try to match it
+			if ( preg_match( '#^' . $regex . '$#', $date, $dt ) ){
+				// Remove unwanted Indexes
+				foreach ( $dt as $k => $v ){
+					if ( is_int( $k ) ){
+						unset( $dt[ $k ] );
+					}
+				}
+
+				// We need at least Month + Day + Year to work with
+				if ( ! checkdate( $dt['month'], $dt['day'], $dt['year'] ) ){
+					return false;
+				}
+			} else {
+				return false;
+			}
+
+			$formatted = '{year}-{month}-{day}' . ( isset( $dt['hour'], $dt['minute'], $dt['second'] ) ? ' {hour}:{minute}:{second}' : '' );
+			foreach ( $dt as $key => $value ) {
+				$formatted = str_replace( '{' . $key . '}', $value, $formatted );
+			}
+
+			return $formatted;
 		}
 
 		/**


### PR DESCRIPTION
I was trying a bit more the DatePicker with a few different dates, and I found a bug related to another Pull Request I've created #113.

With formats like `dd/mm/yyyy` or `d/m/yy` it would break the date on saving because our plugin was only passing the dates via `strtotime` which breaks on these formats and return a 1970 date.

Since PHP 5.2 doesn't have a `date_parse_from_format` for us to deal with formatted date parsing I've created a Reversed engineer method on our `Date_Utils` that will get these formats and return a Database formatted String that we can pass to `strtotime`.

 **E.g.:**
- `15/01/2015` to `2015-01-15`
- `2/9/2015` to `2015-9-2`
- `12/09/2012 21h 02m 00s` to `2012-09-12 21:02:00`
