### PR TITLE
Month view speed improvements & code cleanup

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -700,7 +700,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return array The counts array.
 		 */
 		public static function getEventCounts( $args = array() ) {
-			_deprecated_function( __FUNCTION__, '3.11' );
+			_deprecated_function( __METHOD__, '3.11' );
 			global $wpdb;
 			$date     = date( 'Y-m-d' );
 			$defaults = array(

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -708,8 +708,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return array The counts array.
 		 */
 		public static function getEventCounts( $args = array() ) {
+			_deprecated_function( __FUNCTION__, '3.11' );
 			global $wpdb;
-			do_action( 'log', 'getEventCounts() $args', 'tribe-events-query', $args );
 			$date     = date( 'Y-m-d' );
 			$defaults = array(
 				'post_type'         => Tribe__Events__Main::POSTTYPE,
@@ -731,27 +731,20 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			$cache_key = 'daily_counts_and_ids_' . serialize( $args );
 			$found     = $cache->get( $cache_key, 'save_post' );
 			if ( $found ) {
-				do_action( 'log', 'cache hit ' . __LINE__, 'tribe-events-cache', $args );
 
 				return $found;
 			}
-			do_action( 'log', 'no cache hit ' . __LINE__, 'tribe-events-cache', $args );
 
 			$cache_key = 'month_post_ids_' . serialize( $args );
 			$found     = $cache->get( $cache_key, 'save_post' );
 			if ( $found && is_array( $found ) ) {
-				do_action( 'log', 'cache hit ' . __LINE__, 'tribe-events-cache', $args );
 				$post_ids = $found;
 			} else {
-				do_action( 'log', 'no cache hit ' . __LINE__, 'tribe-events-cache', $args );
 				$post_id_query = new WP_Query();
 				$post_ids      = $post_id_query->query( $args );
-				do_action( 'log', 'final args for month view post ids', 'tribe-events-query', $post_id_query->query_vars );
-				do_action( 'log', 'Month view getEventCounts SQL', 'tribe-events-query', $post_id_query->request );
 				$cache->set( $cache_key, $post_ids, Tribe__Events__Cache::NON_PERSISTENT, 'save_post' );
 			}
 
-			do_action( 'log', 'Month view post ids found', 'tribe-events-query', $post_ids );
 			$counts    = array();
 			$event_ids = array();
 			if ( ! empty( $post_ids ) ) {
@@ -760,7 +753,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 					default :
 						global $wp_query;
 						$output_date_format = '%Y-%m-%d %H:%i:%s';
-						do_action( 'log', 'raw counts args', 'tribe-events-query', $args );
 						$raw_counts = $wpdb->get_results(
 							$wpdb->prepare(
 								"
@@ -785,7 +777,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 								implode( ',', array_map( 'intval', $post_ids ) )
 							)
 						);
-						do_action( 'log', 'raw counts query', 'tribe-events-query', $wpdb->last_query );
 						$start_date = new DateTime( $post_id_query->query_vars['start_date'] );
 						$end_date   = new DateTime( $post_id_query->query_vars['end_date'] );
 						$days       = Tribe__Events__Date_Utils::dateDiff( $start_date->format( 'Y-m-d' ), $end_date->format( 'Y-m-d' ) );
@@ -804,8 +795,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 						}
 						for ( $i = 0, $date = $start_date; $i <= $days; $i ++, $date->modify( '+1 day' ) ) {
 							$formatted_date = $date->format( 'Y-m-d' );
-							$start_of_day   = strtotime( $formatted_date );
-							$end_of_day     = strtotime( $formatted_date ) + 1;
 							$count          = 0;
 							$_day_event_ids = array();
 							foreach ( $raw_counts as $record ) {
@@ -835,10 +824,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				}
 
 				// get a unique list of the event IDs that will be displayed, and update all their postmeta and term caches at once
-				$final_event_ids = array();
 				$final_event_ids = call_user_func_array( 'array_merge', $event_ids );
 				$final_event_ids = array_unique( $final_event_ids );
-				do_action( 'log', 'updating term and postmeta caches for events', 'tribe-events-cache', $final_event_ids );
 				update_object_term_cache( $final_event_ids, Tribe__Events__Main::POSTTYPE );
 				update_postmeta_cache( $final_event_ids );
 			}
@@ -847,7 +834,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			$cache     = new Tribe__Events__Cache;
 			$cache_key = 'daily_counts_and_ids_' . serialize( $args );
 			$cache->set( $cache_key, $return, Tribe__Events__Cache::NON_PERSISTENT, 'save_post' );
-			do_action( 'log', 'final event counts result', 'tribe-events-query', $return );
 
 			return $return;
 		}

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -165,20 +165,13 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 					add_filter( 'posts_distinct', array( __CLASS__, 'posts_distinct' ) );
 					add_filter( 'posts_groupby', array( __CLASS__, 'posts_groupby' ), 10, 2 );
 				} else {
+
 					// reduce number of queries triggered by main WP_Query on month view
 					$query->set( 'posts_per_page', 1 );
 					$query->set( 'no_found_rows', true );
 					$query->set( 'cache_results', false );
 					$query->set( 'update_post_meta_cache', false );
 					$query->set( 'update_post_term_cache', false );
-					$query->set(
-						'meta_query', array(
-							array(
-								'key'  => '_EventStartDate',
-								'type' => 'DATETIME'
-							)
-						)
-					);
 					do_action( 'tribe_events_pre_get_posts', $query );
 
 					return $query;
@@ -412,7 +405,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 */
 		public static function posts_fields( $field_sql, $query ) {
 			if ( ! empty( $query->tribe_is_event ) || ! empty( $query->tribe_is_event_category ) ) {
-				global $wpdb;
 				$postmeta_table             = self::postmeta_table( $query );
 				$fields                     = array();
 				$fields['event_start_date'] = "MIN({$postmeta_table}.meta_value) as EventStartDate";

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -700,7 +700,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return array The counts array.
 		 */
 		public static function getEventCounts( $args = array() ) {
-			_deprecated_function( __METHOD__, '3.11' );
+			_deprecated_function( __METHOD__, '3.10.1' );
 			global $wpdb;
 			$date     = date( 'Y-m-d' );
 			$defaults = array(

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -16,37 +16,104 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 	 * Month view template class
 	 */
 	class Tribe__Events__Template__Month extends Tribe__Events__Template_Factory {
-		const PREVIOUS_MONTH = -1;
-		const CURRENT_MONTH  = 0;
-		const NEXT_MONTH     = 1;
 
 		private static $hide_upcoming_ids;
 		private static $today;
 		private static $current_month;
 		private static $current_year;
+		/**
+		 * Month Type Masks
+		 */
+		const PREVIOUS_MONTH = - 1;
+		const CURRENT_MONTH = 0;
+		const NEXT_MONTH = 1;
+
+		/**
+		 * Prefix for month view ajax actions
+		 */
+		const AJAX_HOOK = 'tribe_calendar';
+
+		/**
+		 * Number of events per day of the month
+		 * @var array
+		 */
 		private static $event_daily_counts = array();
 		private static $event_daily_ids = array();
 		private static $posts_per_page_limit = 3;
 		private static $tribe_bar_args = array();
+
+		/**
+		 * Number of events per day
+		 * @var int
+		 * @see tribe_events_month_day_limit
+		 */
+		private static $events_per_day;
+
+		/**
+		 * Array of days of the month
+		 * @var array
+		 */
 		private static $calendar_days = array();
+
+		/**
+		 * Internal pointer to current day in the month view loop
+		 * @var int
+		 */
 		private static $current_day = - 1;
+
+		/**
+		 * Internal pointer to current week in the month view loop
+		 * @var int
+		 */
 		private static $current_week = - 1;
+
+		/**
+		 * Query args
+		 * @var array|null
+		 */
 		protected static $args;
 
 		/**
-		 * Indicates the array indicies marking the first and last entries for
-		 * the current month.
+		 * Indicates the array index marking the first entry for the current month.
+		 * @var int
 		 */
 		protected $current_month_begins;
+
+		/**
+		 * Indicates the array index marking the last entry for the current month.
+		 * @var int
+		 */
 		protected $current_month_ends;
 
+		/**
+		 * CSS class for the month view wrapper
+		 * @var string
+		 */
 		protected $body_class = 'events-gridview';
+
+		/**
+		 * Excerpt length on month view tooltips
+		 * @var int
+		 */
 		protected $excerpt_length = 30;
+
+		/**
+		 * Static asset packages required for month view functionality
+		 * @var array
+		 */
 		protected $asset_packages = array( 'ajax-calendar' );
 
+		/**
+		 * HTML cache holder
+		 * @var Tribe__Events__Template_Part_Cache
+		 */
 		private $html_cache;
 
-		const AJAX_HOOK = 'tribe_calendar';
+		/**
+		 * Whether the HTML cache is enabled
+		 * @var boolean
+		 */
+		private $use_cache;
 
 		/**
 		 * Set the notices used on month view
@@ -74,7 +141,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			self::$args                 = $args;
 			self::$posts_per_page_limit = apply_filters( 'tribe_events_month_day_limit', tribe_get_option( 'monthEventAmount', '3' ) );
 
-			// don't enqueue scripts and js when we're not constructing month view, 
+			// don't enqueue scripts and js when we're not constructing month view,
 			// they'll have to be enqueued separately
 			if ( ! tribe_is_month() ) {
 				$this->asset_packages = array();
@@ -139,7 +206,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				Tribe__Events__Main::setNotice( 'event-search-no-results', sprintf( __( 'There were no results found for <strong>"%s"</strong> this month. Try searching next month.', 'tribe-events-calendar' ), esc_html( $search_term ) ) );
 			} // if attempting to view a category archive.
 			elseif ( ! empty( $tax_term ) ) {
-				Tribe__Events__Main::setNotice( 'events-not-found', sprintf( __( 'No matching %s listed under %s. Please try viewing the full calendar for a complete list of events.', 'tribe-events-calendar' ), strtolower( $events_label_plural ),  $tax_term ) );
+				Tribe__Events__Main::setNotice( 'events-not-found', sprintf( __( 'No matching %s listed under %s. Please try viewing the full calendar for a complete list of events.', 'tribe-events-calendar' ), strtolower( $events_label_plural ), $tax_term ) );
 			} else {
 				Tribe__Events__Main::setNotice( 'event-search-no-results', __( 'There were no results found.', 'tribe-events-calendar' ) );
 			}
@@ -155,11 +222,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 */
 		protected function get_title( $original_title, $sep = null ) {
 			$new_title = parent::get_title( $original_title, $sep );
-			if ( get_query_var( 'eventDate' ) && has_filter('tribe_month_grid_view_title') ) {
+			if ( get_query_var( 'eventDate' ) && has_filter( 'tribe_month_grid_view_title' ) ) {
 				_deprecated_function( "The 'tribe_month_grid_view_title' filter", '3.8', " the 'tribe_get_events_title' filter" );
 				$title_date = date_i18n( tribe_get_option( 'monthAndYearFormat', 'F Y' ), strtotime( get_query_var( 'eventDate' ) ) );
 				$new_title  = apply_filters( 'tribe_month_grid_view_title', $new_title, $sep, $title_date );
-			} else if ( has_filter( 'tribe_events_this_month_title' ) ) {
+			} elseif ( has_filter( 'tribe_events_this_month_title' ) ) {
 				_deprecated_function( "The 'tribe_events_this_month_title' filter", '3.8', " the 'tribe_get_events_title' filter" );
 				$new_title = apply_filters( 'tribe_events_this_month_title', $new_title, $sep );
 			}
@@ -211,7 +278,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @return string
 		 */
 		private static function view_more_link( $date, $args ) {
-			if ( ! empty( self::$event_daily_counts[$date] ) && (int) self::$event_daily_counts[$date] > self::$posts_per_page_limit ) {
+			if ( ! empty( self::$event_daily_counts[ $date ] ) && (int) self::$event_daily_counts[ $date ] > self::$posts_per_page_limit ) {
 				$day_link = tribe_get_day_link( $date );
 				if ( ! empty( $args ) ) {
 					$day_link = add_query_arg( $args, $day_link );
@@ -232,7 +299,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			$args   = wp_parse_args(
 				array(
-					'post__in'       => self::$event_daily_ids[$date],
+					'post__in'       => self::$event_daily_ids[ $date ],
 					'post_type'      => Tribe__Events__Main::POSTTYPE,
 					'start_date'     => tribe_event_beginning_of_day( $date ),
 					'end_date'       => tribe_event_end_of_day( $date ),
@@ -274,7 +341,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			// Populate complete date range including leading/trailing days from adjacent months
 			while ( $date <= $final_grid_date ) {
 				$day  = (int) substr( $date, -2 );
-				$total_events = ! empty( self::$event_daily_counts[$date] ) ? self::$event_daily_counts[$date] : 0;
+				$total_events = ! empty( self::$event_daily_counts[ $date ] ) ? self::$event_daily_counts[ $date ] : 0;
 
 				$prev_month = (int) substr( $date, 5, 2 ) < (int) substr( $requested_date, 5, 2 );
 				$next_month = (int) substr( $date, 5, 2 ) > (int) substr( $requested_date, 5, 2 );
@@ -289,7 +356,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'events'       => $total_events ? self::get_daily_events( $date ) : $empty,
 					'total_events' => $total_events,
 					'view_more'    => self::view_more_link( $date, self::$tribe_bar_args ),
-					'month'        => $month_type
+					'month'        => $month_type,
 				);
 
 				// Record the indicies marking the portion of the array relating to the current month
@@ -339,7 +406,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			if ( empty( self::$tribe_bar_args ) ) {
 				foreach ( $_REQUEST as $key => $value ) {
 					if ( $value && strpos( $key, 'tribe' ) === 0 && $key != 'tribe-bar-date' ) {
-						self::$tribe_bar_args[$key] = $value;
+						self::$tribe_bar_args[ $key ] = $value;
 					}
 				}
 			}
@@ -465,8 +532,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @return int
 		 **/
 		public static function get_current_day() {
-			if ( count( self::$calendar_days ) && self::$current_day < count( self::$calendar_days ) && isset( self::$calendar_days[self::$current_day] ) ) {
-				return self::$calendar_days[self::$current_day];
+			if ( count( self::$calendar_days ) && self::$current_day < count( self::$calendar_days ) && isset( self::$calendar_days[ self::$current_day ] ) ) {
+				return self::$calendar_days[ self::$current_day ];
 			}
 
 			return false;
@@ -478,7 +545,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @return string Classes
 		 **/
 		public static function day_classes() {
-			$calendar_day = self::$calendar_days[self::$current_day];
+			$calendar_day = self::$calendar_days[ self::$current_day ];
 
 			if ( $calendar_day['month'] == self::PREVIOUS_MONTH || $calendar_day['month'] == self::NEXT_MONTH ) {
 				$ppf = 'tribe-events-othermonth';
@@ -576,7 +643,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 *
 		 * @return void
 		 */
-		function ajax_response() {
+		public function ajax_response() {
 
 			if ( isset( $_POST['eventDate'] ) && $_POST['eventDate'] ) {
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @var int
 		 * @see tribe_events_month_day_limit
 		 */
-		private static $events_per_day;
+		private $events_per_day;
 
 		/**
 		 * Array of days of the month
@@ -128,9 +128,9 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 
 		/**
-		 * Set the notices used on month view
+		 * Set the notices used on month view.
 		 *
-		 * @param array $args Set of $wp_query params for the month view, if none passed then will default to $wp_query
+		 * @param array $args Set of $wp_query params for the month view, if none passed then will default to $wp_query.
 		 */
 		public function __construct( $args = null ) {
 			if ( $args === null ) {
@@ -317,6 +317,14 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			// Populate complete date range including leading/trailing days from adjacent months
 			while ( $date <= $this->final_grid_date ) {
+
+				if ( ! empty( $this->events_in_month ) ) {
+					$day_events = self::get_daily_events( $date );
+				} else {
+					$day_events = $empty_query;
+				}
+
+
 				$day = (int) substr( $date, - 2 );
 
 				$prev_month = (int) substr( $date, 5, 2 ) < (int) substr( $this->requested_date, 5, 2 );
@@ -328,12 +336,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				}
 				if ( $next_month ) {
 					$month_type = self::NEXT_MONTH;
-				}
-
-				if ( ! empty( $this->events_in_month ) ) {
-					$day_events = self::get_daily_events( $date );
-				} else {
-					$day_events = $empty_query;
 				}
 
 				$days[] = array(

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -150,7 +150,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				$this->html_cache = new Tribe__Events__Template_Part_Cache( 'month/content.php', serialize( $args ), $cache_expiration, 'save_post' );
 			}
 
-			self::$args            = $args;
+			$args = (array) $args;
+			self::$args            = (array) $args;
 			$this->events_per_day  = apply_filters( 'tribe_events_month_day_limit', tribe_get_option( 'monthEventAmount', '3' ) );
 			$this->requested_date  = $this->requested_date();
 			$this->first_grid_date = $this->calculate_first_cell_date( $this->requested_date );
@@ -399,7 +400,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 *
 		 * @return array
 		 */
-		protected function get_tribe_bar_args() {
+		protected static function get_tribe_bar_args() {
 			$tribe_bar_args = array();
 			foreach ( $_REQUEST as $key => $value ) {
 				if ( $value && strpos( $key, 'tribe' ) === 0 && $key != 'tribe-bar-date' ) {

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Add any special hooks for this view
 		 *
 		 * @return void
-		 **/
+		 */
 		protected function hooks() {
 			parent::hooks();
 
@@ -189,7 +189,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Unhook all the hooks set up on this view
 		 *
 		 * @return void
-		 **/
+		 */
 		protected function unhook() {
 			parent::unhook();
 			remove_filter( 'post_type_archive_title', '__return_false', 10 );
@@ -199,7 +199,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Set the notices used on month view
 		 *
 		 * @return void
-		 **/
+		 */
 		public function set_notices() {
 			// Our focus is on the current month, not the complete range of events included in the current month view
 			// (which may include some leading/trailing days of the next and previous months)
@@ -219,6 +219,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 		/**
 		 * Sets an appropriate no results found message.
+		 *
+		 * @return void
 		 */
 		protected function nothing_found_notice() {
 			$events_label_plural = tribe_get_event_label_plural();
@@ -237,8 +239,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		/**
 		 * Get the title for month view
 		 *
-		 * @param  string $original_title
-		 * @param  null   $sep
+		 * @param string $original_title
+		 * @param string $sep
 		 *
 		 * @return string
 		 */
@@ -259,8 +261,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		/**
 		 * Get the view more link
 		 *
-		 * @param int   $date
-		 * @param array $args
+		 * @param integer $date
 		 *
 		 * @return string
 		 */
@@ -275,6 +276,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		}
 
 		/**
+		 * Get the events for a single day
+		 *
 		 * @param string $date
 		 *
 		 * @return WP_Query
@@ -299,14 +302,14 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Sets up an array of $days based on the current query, that can be used in the calendar loop
 		 *
 		 * @return void
-		 **/
+		 */
 		public function setup_view() {
 
 			if ( $this->use_cache && $this->html_cache->get() !== false ) {
 				return;
 			}
 
-			$days            = array();
+			$days = array();
 
 			$date = $this->first_grid_date; // Start with the first grid date
 
@@ -391,6 +394,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 		}
 
+		/**
+		 * Loop through the $_REQUEST and find all tribe bar args.
+		 *
+		 * @return array
+		 */
 		protected function get_tribe_bar_args() {
 			$tribe_bar_args = array();
 			foreach ( $_REQUEST as $key => $value ) {
@@ -408,8 +416,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * This is not necessarily the 1st of the specified month, rather it is the date of the
 		 * first grid cell which could be anything upto 6 days earlier than the 1st of the month.
 		 *
-		 * @param  string $month
-		 * @param  int    $start_of_week
+		 * @param string  $month
+		 * @param integer $start_of_week
 		 *
 		 * @return bool|string (Y-m-d)
 		 */
@@ -445,8 +453,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * This is not necessarily the last day of the specified month, rather it is the date of
 		 * the final grid cell which could be anything upto 6 days into the next month.
 		 *
-		 * @param  string $month
-		 * @param  int    $start_of_week
+		 * @param string  $month
+		 * @param integer $start_of_week
 		 *
 		 * @return bool|string (Y-m-d)
 		 */
@@ -481,7 +489,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Checks whether there are more calendar days to display
 		 *
 		 * @return bool True if calendar days are available, false if not.
-		 **/
+		 */
 		public static function have_days() {
 			if ( self::$current_day + 1 < count( self::$calendar_days ) ) {
 				return true;
@@ -498,7 +506,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Advances the internal day counter (and week counter, if appropriate)
 		 *
 		 * @return void
-		 **/
+		 */
 		public static function the_day() {
 			if ( self::have_days() ) {
 				self::$current_day ++;
@@ -511,7 +519,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		/**
 		 * Rewind the posts and reset post index.
 		 *
-		 * @access public
+		 * @return void
 		 */
 		public static function rewind_days() {
 			self::$current_day  = - 1;
@@ -521,8 +529,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		/**
 		 * Returns the current day according to self::$current_day
 		 *
-		 * @return int
-		 **/
+		 * @return array|boolean
+		 */
 		public static function get_current_day() {
 			if ( count( self::$calendar_days ) && self::$current_day < count( self::$calendar_days ) && isset( self::$calendar_days[ self::$current_day ] ) ) {
 				return self::$calendar_days[ self::$current_day ];
@@ -535,7 +543,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Generates and returns a set of classes for the current day
 		 *
 		 * @return string Classes
-		 **/
+		 */
 		public static function day_classes() {
 
 			$today         = date_i18n( 'd' );
@@ -568,19 +576,19 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				if ( $current_month > $month && $current_year == $year || $current_year > $year ) {
 					$ppf .= ' tribe-events-past';
 				} else {
+			$ppf .= ' mobile-trigger tribe-event-day-' . $day;
 					if ( $current_month < $month && $current_year == $year || $current_year < $year ) {
 						$ppf .= ' tribe-events-future';
 					}
+
 				}
 			}
 			if ( $calendar_day['total_events'] > 0 ) {
 				$ppf .= ' tribe-events-has-events';
 			}
-			$ppf .= ' mobile-trigger tribe-event-day-' . $day;
 
 
 			$column = ( self::$current_day ) - ( self::$current_week * 7 );
-
 			if ( $column > 0 && ( $column % 4 == 0 || $column % 5 == 0 || $column % 6 == 0 ) ) {
 				$ppf .= ' tribe-events-right';
 			}
@@ -592,7 +600,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Returns self::$current_week
 		 *
 		 * @return int $current_week
-		 **/
+		 */
 		public static function get_current_week() {
 			return self::$current_week;
 		}
@@ -603,7 +611,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @param  string $classes = ''
 		 *
 		 * @return string Classes
-		 **/
+		 */
 		public function event_classes( $classes = '' ) {
 
 			$day = self::get_current_day();

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -546,54 +546,41 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 */
 		public static function day_classes() {
 
-			$today         = date_i18n( 'd' );
-			$current_month = date_i18n( 'm' );
-			$current_year  = date_i18n( 'Y' );
+			$calendar_day           = self::get_current_day();
+			$calendar_day_timestamp = strtotime( $calendar_day['date'] );
+			$today                  = strtotime( 'today' );
 
-			$calendar_day = self::$calendar_days[ self::$current_day ];
-
-			if ( $calendar_day['month'] == self::PREVIOUS_MONTH || $calendar_day['month'] == self::NEXT_MONTH ) {
-				$ppf = 'tribe-events-othermonth';
+			// Start by determining which month we're looking at
+			if ( $calendar_day['month'] == self::CURRENT_MONTH ) {
+				$classes = 'tribe-events-thismonth';
 			} else {
-				$ppf = 'tribe-events-thismonth';
+				$classes = 'tribe-events-othermonth';
 			}
 
-			list ( $year, $month, $day ) = explode( '-', $calendar_day['date'] );
-			if ( $current_month == $month && $current_year == $year ) {
-				// Past, Present, Future class
-				if ( $today == $day ) {
-					$ppf .= ' tribe-events-present';
-				} else {
-					if ( $today > $day ) {
-						$ppf .= ' tribe-events-past';
-					} else {
-						if ( $today < $day ) {
-							$ppf .= ' tribe-events-future';
-						}
-					}
-				}
-			} else {
-				if ( $current_month > $month && $current_year == $year || $current_year > $year ) {
-					$ppf .= ' tribe-events-past';
-				} else {
-			$ppf .= ' mobile-trigger tribe-event-day-' . $day;
-					if ( $current_month < $month && $current_year == $year || $current_year < $year ) {
-						$ppf .= ' tribe-events-future';
-					}
-
-				}
+			// Check if the calendar day is in the past, present, or future
+			if ( $calendar_day_timestamp < $today ) {
+				$classes .= ' tribe-events-past';
+			} elseif ( $calendar_day_timestamp == $today ) {
+				$classes .= ' tribe-events-present';
+			} elseif ( $calendar_day_timestamp > $today ) {
+				$classes .= ' tribe-events-future';
 			}
+
+			// The day has some events
 			if ( $calendar_day['total_events'] > 0 ) {
-				$ppf .= ' tribe-events-has-events';
+				$classes .= ' tribe-events-has-events';
 			}
 
+			// Needed for mobile js
+			$classes .= ' mobile-trigger tribe-event-day-' . date_i18n( 'd', $calendar_day_timestamp );
 
+			// Determine which column of the grid the day is in
 			$column = ( self::$current_day ) - ( self::$current_week * 7 );
 			if ( $column > 0 && ( $column % 4 == 0 || $column % 5 == 0 || $column % 6 == 0 ) ) {
-				$ppf .= ' tribe-events-right';
+				$classes .= ' tribe-events-right';
 			}
 
-			return $ppf;
+			return $classes;
 		}
 
 		/**

--- a/src/views/month/single-day.php
+++ b/src/views/month/single-day.php
@@ -22,11 +22,11 @@ $day = tribe_events_get_current_month_day();
 <!-- Day Header -->
 <div id="tribe-events-daynum-<?php echo $day['daynum'] ?>">
 
-	<?php if ( $day['total_events'] > 0 && tribe_events_is_view_enabled( 'day' ) ) { ?>
+	<?php if ( $day['total_events'] > 0 && tribe_events_is_view_enabled( 'day' ) ) : ?>
 		<a href="<?php echo esc_url( tribe_get_day_link( $day['date'] ) ); ?>"><?php echo $day['daynum'] ?></a>
-	<?php } else { ?>
+	<?php else : ?>
 		<?php echo $day['daynum'] ?>
-	<?php } ?>
+	<?php endif; ?>
 
 </div>
 


### PR DESCRIPTION
I've cherry-picked @jazbek's work from https://github.com/moderntribe/the-events-calendar/pull/144 into an isolated set of changes that we can merge into `release/118` rather than `release/119`.

This has already been code reviewed, and needs a round of QA before merging.

See: https://central.tri.be/issues/32067 and https://central.tri.be/issues/37143