### PR TITLE
Fix/34216 ical month view

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -258,8 +258,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			$requested_date     = $this->requested_date();
-			$first_grid_date    = $this->calculate_first_cell_date( $requested_date );
-			$final_grid_date    = $this->calculate_final_cell_date( $requested_date );
+			$first_grid_date    = self::calculate_first_cell_date( $requested_date );
+			$final_grid_date    = self::calculate_final_cell_date( $requested_date );
 			$days               = array();
 
 			$this->setup_tribe_bar_args();
@@ -362,7 +362,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 *
 		 * @return bool|string (Y-m-d)
 		 */
-		protected function calculate_first_cell_date( $month, $start_of_week = null ) {
+		public static function calculate_first_cell_date( $month, $start_of_week = null ) {
 			if ( null === $start_of_week ) {
 				$start_of_week = (int) get_option( 'start_of_week', 0 );
 			}
@@ -395,7 +395,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 *
 		 * @return bool|string (Y-m-d)
 		 */
-		protected function calculate_final_cell_date( $month, $start_of_week = null ) {
+		public static function calculate_final_cell_date( $month, $start_of_week = null ) {
 			if ( null === $start_of_week ) {
 				$start_of_week = (int) get_option( 'start_of_week', 0 );
 			}

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -164,7 +164,7 @@ class Tribe__Events__iCal {
 		$args = array(
 			'eventDisplay' => 'custom',
 			'start_date'   => Tribe__Events__Template__Month::calculate_first_cell_date( $month ),
-			'end_date'     => Tribe__Events__Template__Month::calculate_final_cell_date( $month )
+			'end_date'     => Tribe__Events__Template__Month::calculate_final_cell_date( $month ),
 		);
 
 		/**

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -144,24 +144,44 @@ class Tribe__Events__iCal {
 	}
 
 	/**
-	 * Gets all events in the month
+	 * Gets all events in the current month, matching those presented in month view
+	 * by default (and therefore potentially including some events from the tail end
+	 * of the previous month and start of the following month).
 	 *
-	 * @static
+	 * We build a fresh 'custom'-type query here rather than taking advantage of the
+	 * main query since page spoofing can render the actual query and results
+	 * inaccessible (and it cannot be recovered via a query reset).
 	 *
 	 * @return array events in the month
 	 */
 	private static function get_month_view_events() {
-		do_action( 'tribe_events_before_view' ); // this will trigger the month view query setup
-		$events_posts = array();
-		while ( tribe_events_have_month_days() ) {
-			tribe_events_the_month_day();
-			$month_day = tribe_events_get_current_month_day();
-			if ( isset( $month_day['events'] ) && $month_day['total_events'] > 0 ) {
-				$events_posts = array_merge( $month_day['events']->posts, $events_posts );
-			}
-		}
+		global $wp_query;
 
-		return $events_posts;
+		$month = empty( $wp_query->get( 'eventDate' ) )
+			? tribe_get_month_view_date()
+			: $wp_query->get( 'eventDate' );
+
+		$args = array(
+			'eventDisplay' => 'custom',
+			'start_date'   => Tribe__Events__Template__Month::calculate_first_cell_date( $month ),
+			'end_date'     => Tribe__Events__Template__Month::calculate_final_cell_date( $month )
+		);
+
+		/**
+		 * Provides an opportunity to modify the query args used to build a list of events
+		 * to export from month view.
+		 *
+		 * This could be useful where its desirable to limit the exported data set to only
+		 * those events taking place in the specific month being viewed (rather than an exact
+		 * match of the events shown in month view itself, which may include events from
+		 * adjacent months).
+		 *
+		 * @var array  $args
+		 * @var string $month
+		 */
+		$args = (array) apply_filters( 'tribe_ical_feed_month_view_query_args', $args, $month );
+
+		return tribe_get_events( $args );
 	}
 
 	/**


### PR DESCRIPTION
The month view ical feed did a [bad job of handling multiday events](https://central.tri.be/issues/34216) by repeating those events for as many days as they were visible in month view itself - triggering the creation of many duplicates when imported into some calendar apps. This change should resolve that.