### PR TITLE
Allow version_compare to compare real values rather than (float) vals

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -24,10 +24,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
 
-		const VERSION       = '3.10';
-		const FEED_URL      = 'https://theeventscalendar.com/feed/';
-		const INFO_API_URL  = 'http://wpapi.org/api/plugin/the-events-calendar.php';
-		const WP_PLUGIN_URL = 'http://wordpress.org/extend/plugins/the-events-calendar/';
+		const VERSION           = '3.10';
+		const MIN_ADDON_VERSION = '3.10';
+		const FEED_URL          = 'https://theeventscalendar.com/feed/';
+		const INFO_API_URL      = 'http://wpapi.org/api/plugin/the-events-calendar.php';
+		const WP_PLUGIN_URL     = 'http://wordpress.org/extend/plugins/the-events-calendar/';
 
 		/**
 		 * Notices to be displayed in the admin
@@ -652,16 +653,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					break;
 				}
 
-				// check if addons are at an older minor version
-				$addon_minor_version = $plugin['current_version'];
-				$tec_minor_version   = self::VERSION;
-
-				// If there is a version with 2 dots (e.g. 3.9.3 or 3.9.3rc2), convert it to a one dot version (e.g. 3.9)
-				$version_regex = '/([^\.]+\.[^\.]+).*/';
-				$addon_minor_version = preg_replace( $version_regex, '$1', $addon_minor_version );
-				$tec_minor_version = preg_replace( $version_regex, '$1', $tec_minor_version );
-
-				if ( version_compare( $addon_minor_version, $tec_minor_version, '<' ) ) {
+				// check if the add-on is out of date
+				if ( version_compare( $plugin['current_version'], self::MIN_ADDON_VERSION, '<' ) ) {
 					$out_of_date_addons[] = $plugin['plugin_name'] . ' ' . $plugin['current_version'];
 				}
 			}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -655,6 +655,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				// check if addons are at an older minor version
 				$addon_minor_version = $plugin['current_version'];
 				$tec_minor_version   = self::VERSION;
+
+				// If there is a version with 2 dots (e.g. 3.9.3 or 3.9.3rc2), convert it to a one dot version (e.g. 3.9)
+				$version_regex = '/([^\.]+\.[^\.]+).*/';
+				$addon_minor_version = preg_replace( $version_regex, '$1', $addon_minor_version );
+				$tec_minor_version = preg_replace( $version_regex, '$1', $tec_minor_version );
+
 				if ( version_compare( $addon_minor_version, $tec_minor_version, '<' ) ) {
 					$out_of_date_addons[] = $plugin['plugin_name'] . ' ' . $plugin['current_version'];
 				}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -653,8 +653,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				}
 
 				// check if addons are at an older minor version
-				$addon_minor_version = (float) $plugin['current_version'];
-				$tec_minor_version   = (float) self::VERSION;
+				$addon_minor_version = $plugin['current_version'];
+				$tec_minor_version   = self::VERSION;
 				if ( version_compare( $addon_minor_version, $tec_minor_version, '<' ) ) {
 					$out_of_date_addons[] = $plugin['plugin_name'] . ' ' . $plugin['current_version'];
 				}


### PR DESCRIPTION
Casting as a float butchers the version numbers. Examples:

* `(float) '3.10'` becomes `3.1`
* `(float) '3.9.3'` becomes `3.9`
* `(float) '3.9a'` becomes `3.9`

Right now, if someone has upgraded TEC to 3.10 and they have Pro at 3.9, the version check sees that 3.9 is greater than 3.10 (float value comparison: `3.9 > 3.1`). PHP's `version_compare` function supports the version numbers that we tend to use, so let's not cast. This fix will allow the outdated-plugin notification message to display once again.

~~Add-ons do a good job of making sure TEC is up to snuff. The area of code that is being changed is the reverse check - making sure that add-ons are up to date after core has been updated.  We only care about the first to parts of a version number when checking the add-ons. (e.g. We don't care about the `.4` in `3.10.4`).~~

__UPDATE:__ @barryhughes suggested we add a `MIN_ADDON_VERSION` constant. That simplifies things and will allow us to allow older addon versions if they don't make the world burn.

See: https://central.tri.be/issues/37189