### PR TITLE
Support the suppression of "Results not found" notices

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -132,6 +132,10 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Sets an appropriate no results found message.
 		 */
 		protected function nothing_found_notice() {
+			if ( ! empty( $this->args['suppress_nothing_found_notice'] ) ) {
+				return;
+			}
+
 			$events_label_plural = tribe_get_event_label_plural();
 			list( $search_term, $tax_term, $geographic_term ) = $this->get_search_terms();
 


### PR DESCRIPTION
This is a sister-commit to one in Pro where the Mini Calendar widget - when no results are found - causes a global notice to be applied to a page despite the presence of results in the main event loop.

Related: https://github.com/moderntribe/events-pro/pull/48

See: https://central.tri.be/issues/37194