### PR TITLE
Assigns the google map object back to tribeEventsSingleMap global JS var

### DIFF
--- a/src/resources/js/embedded-map.js
+++ b/src/resources/js/embedded-map.js
@@ -71,6 +71,9 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 			title   : venueTitle,
 			position: position
 		} );
+
+		// Assign the Google Map to a global variable so themes or plugins can interact with it
+		tribeEventsSingleMap.map = map;
 	}
 
 	// Iterate through available addresses and set up the map for each

--- a/src/resources/js/embedded-map.js
+++ b/src/resources/js/embedded-map.js
@@ -73,7 +73,7 @@ if ( "function" === typeof jQuery ) jQuery( document ).ready( function( $ ) {
 		} );
 
 		// Assign the Google Map to a global variable so themes or plugins can interact with it
-		tribeEventsSingleMap.map = map;
+		tribeEventsSingleMap.map = venueObject.map;
 	}
 
 	// Iterate through available addresses and set up the map for each


### PR DESCRIPTION
This is [a contribution](https://github.com/moderntribe/the-events-calendar/pull/38) by @tddewey (thanks!) that I've twiddled to be PR'd against `release/119`. Here's the original PR description:

> This allows plugin or theme code to modify the map. The tribeEventsSingleMap var will have all the data needed: initial zoom level, addresses, and the google map object itself.

> For example, we may want to disable the scrollwheel. With this commit, the following can be called from outside The Event Calendar:
`tribeEventsSingleMap.map.setOptions({scrollwheel:false});`