### PR TITLE
Use wp_kses as an additional safeguard 

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -428,7 +428,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 				} else {
 					$default_success_msg    = sprintf( __( 'Valid Key! Expires on %s', 'tribe-events-calendar' ), $expiration );
 					$response['status']     = isset( $pluginInfo->api_message ) ? 2 : 1;
-					$response['message']    = isset( $pluginInfo->api_message ) ? wp_kses( $pluginInfo->api_message ) : $default_success_msg;
+					$response['message']    = isset( $pluginInfo->api_message ) ? wp_kses( $pluginInfo->api_message, 'data' ) : $default_success_msg;
 					$response['expiration'] = $expiration;
 				}
 			} else {

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -428,7 +428,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 				} else {
 					$default_success_msg    = sprintf( __( 'Valid Key! Expires on %s', 'tribe-events-calendar' ), $expiration );
 					$response['status']     = isset( $pluginInfo->api_message ) ? 2 : 1;
-					$response['message']    = isset( $pluginInfo->api_message ) ? $pluginInfo->api_message : $default_success_msg;
+					$response['message']    = isset( $pluginInfo->api_message ) ? wp_kses( $pluginInfo->api_message ) : $default_success_msg;
 					$response['expiration'] = $expiration;
 				}
 			} else {


### PR DESCRIPTION
See [#36065](https://central.tri.be/issues/36065) for context. Small enhancement which applies wp_kses() as an extra safeguard before displaying service messages.