### PR TITLE
Require update_plugins cap before showing the licenses tab (#37362)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -766,7 +766,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * only if premium addons are detected.
 		 */
 		protected function do_licenses_tab() {
-			if ( ! $this->have_addons() ) {
+			if ( ! current_user_can( 'update_plugins' ) || ! $this->have_addons() ) {
 				return;
 			}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -766,7 +766,17 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * only if premium addons are detected.
 		 */
 		protected function do_licenses_tab() {
-			if ( ! current_user_can( 'update_plugins' ) || ! $this->have_addons() ) {
+			$show_tab = ( ! current_user_can( 'update_plugins' ) || ! $this->have_addons() );
+
+			/**
+			 * Provides an oppotunity to override the decision to show or hide the licenses tab
+			 *
+			 * Normally it will only show if the current user has the "update_plugins" capability
+			 * and there are some currently-activated premium plugins.
+			 *
+			 * @var bool
+			 */
+			if ( ! apply_filters( 'tribe_events_show_licenses_tab', $show_tab ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Context: https://central.tri.be/issues/37362