### PR TITLE
Set wp-util as a dependency when enqueuing events-admin.js

### DIFF
--- a/src/Tribe/Asset/Admin.php
+++ b/src/Tribe/Asset/Admin.php
@@ -4,7 +4,7 @@
 class Tribe__Events__Asset__Admin extends Tribe__Events__Asset__Abstract_Asset {
 
 	public function handle() {
-		$deps = array_merge( $this->deps, array( 'jquery', 'jquery-ui-datepicker' ) );
+		$deps = array_merge( $this->deps, array( 'jquery', 'jquery-ui-datepicker', 'wp-util' ) );
 		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'events-admin.js' ), true );
 		wp_enqueue_script( $this->prefix . '-admin', $path, $deps, $this->filter_js_version(), true );
 	}

--- a/src/Tribe/Asset/Admin.php
+++ b/src/Tribe/Asset/Admin.php
@@ -1,13 +1,18 @@
 <?php
 
-
 class Tribe__Events__Asset__Admin extends Tribe__Events__Asset__Abstract_Asset {
-
 	public function handle() {
-		$deps = array_merge( $this->deps, array( 'jquery', 'jquery-ui-datepicker', 'wp-util' ) );
+		$deps = array_merge(
+			$this->deps,
+			array(
+				'jquery',
+				'jquery-ui-datepicker',
+				'wp-util',
+			)
+		);
+
 		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'events-admin.js' ), true );
+
 		wp_enqueue_script( $this->prefix . '-admin', $path, $deps, $this->filter_js_version(), true );
 	}
-
-
 }


### PR DESCRIPTION
`events-admin[.min].js` uses `wp.template` - a function found in the `wp-util` js file. To ensure that the object/function is available when `events-admin` executes, set it as a dependency.

See: https://central.tri.be/issues/23902