### PR TITLE
Enhance venue details on Event Attendees screen

### DIFF
--- a/src/admin-views/tickets/attendees.php
+++ b/src/admin-views/tickets/attendees.php
@@ -27,42 +27,49 @@ $tickets = Tribe__Events__Tickets__Tickets::get_event_tickets( $event_id );
 						<br />
 
 						<strong><?php esc_html_e( 'End Date / Time:', 'tribe-events-calendar' ) ?></strong>
-						<?php echo tribe_get_end_date( $event_id, false, tribe_get_datetime_format( true ) ) ?>
+						<?php
+						echo tribe_get_end_date( $event_id, false, tribe_get_datetime_format( true ) );
 
-						<?php if ( tribe_has_venue( $event_id ) ) : ?>
-							<?php $venue_id = tribe_get_venue_id( $event_id ); ?>
+						if ( tribe_has_venue( $event_id ) ) {
+							$venue_id = tribe_get_venue_id( $event_id );
+							?>
 
 							<div class="venue-name">
-								<strong><?php echo esc_html( __( tribe_get_venue_label_singular(), 'tribe-events-calendar' ) ); ?>: </strong>
+								<strong><?php echo tribe_get_venue_label_singular(); ?>: </strong>
 								<?php echo tribe_get_venue( $event_id ) ?>
 							</div>
 
 							<div class="venue-address">
-								<strong><?php _e('Address:', 'tribe-events-calendar'); ?> </strong>
+								<strong><?php _e( 'Address:', 'tribe-events-calendar' ); ?> </strong>
 								<?php echo tribe_get_full_address( $venue_id ); ?>
 							</div>
 
-							<?php if ( $phone = tribe_get_phone( $venue_id) ) : ?>
+							<?php
+							if ( $phone = tribe_get_phone( $venue_id ) ) {
+								?>
 								<div class="venue-phone">
 									<strong><?php echo esc_html( __( 'Phone:', 'tribe-events-calendar' ) ); ?> </strong>
 									<?php echo esc_html( $phone ); ?>
 								</div>
-							<?php endif; ?>
+								<?php
+							}//end if
 
-							<?php if ( $url = esc_url( get_post_meta( $venue_id, '_VenueURL', true ) ) ) : ?>
+							if ( $url = esc_url( get_post_meta( $venue_id, '_VenueURL', true ) ) ) {
+								?>
 								<div class="venue-url">
 									<strong><?php echo esc_html( __( 'Website:', 'tribe-events-calendar' ) ); ?> </strong>
 									<a target="_blank" href="<?php echo $url; ?>">
 									<?php
-										$display_url  = parse_url( $url, PHP_URL_HOST );
-										$display_url .= parse_url( $url, PHP_URL_PATH ) ? '/&hellip;' : '';
-										echo apply_filters( 'tribe_venue_display_url', $display_url, $url, $venue_id );
+									$display_url  = parse_url( $url, PHP_URL_HOST );
+									$display_url .= parse_url( $url, PHP_URL_PATH ) ? '/&hellip;' : '';
+									echo apply_filters( 'tribe_venue_display_url', $display_url, $url, $venue_id );
 									?>
 									</a>
 								</div>
-							<?php endif; ?>
-
-						<?php endif; // venue ?>
+								<?php
+							}//end if
+						}//end if venue
+						?>
 					</td>
 					<td width="33%" valign="top">
 						<h4><?php esc_html_e( 'Ticket Sales', 'tribe-events-calendar' ); ?></h4>

--- a/src/admin-views/tickets/attendees.php
+++ b/src/admin-views/tickets/attendees.php
@@ -29,41 +29,36 @@ $tickets = Tribe__Events__Tickets__Tickets::get_event_tickets( $event_id );
 						<strong><?php esc_html_e( 'End Date / Time:', 'tribe-events-calendar' ) ?></strong>
 						<?php echo tribe_get_end_date( $event_id, false, tribe_get_datetime_format( true ) ) ?>
 
-						<?php
-						// venue
-						$venue_id = tribe_get_venue_id( $event_id );
-						if ( ! empty( $venue_id ) ) {
-							$venue = get_post( $venue_id );
-						}
+						<?php if ( tribe_has_venue( $event_id ) ) : ?>
+							<?php $venue_id = tribe_get_venue_id( $event_id ); ?>
 
-						if ( ! empty( $venue ) ) : ?>
-							<br />
-							<strong>
-								<?php echo tribe_get_venue_label_singular() ?>
-							</strong>
-							<?php echo $venue->post_title; ?>
+							<div class="venue-name">
+								<strong><?php echo esc_html( __( tribe_get_venue_label_singular(), 'tribe-events-calendar' ) ); ?>: </strong>
+								<?php echo tribe_get_venue( $event_id ) ?>
+							</div>
 
-							<?php
-							// phone
-							$phone = get_post_meta( $venue_id, '_VenuePhone', true );
+							<div class="venue-address">
+								<strong><?php _e('Address:', 'tribe-events-calendar'); ?> </strong>
+								<?php echo tribe_get_full_address( $venue_id ); ?>
+							</div>
 
-							if ( ! empty( $phone ) ) : ?>
-								<br />
-								<strong><?php esc_html_e( 'Phone:', 'tribe-events-calendar' ); ?></strong>
-								<?php echo esc_html( $phone );
-							endif; ?>
-
-							<?php
-							// website
-							$website = get_post_meta( $venue_id, '_VenueURL', true );
-							if ( ! empty( $website ) ) : ?>
-								<br />
-								<strong><?php esc_html_e( 'Website:', 'tribe-events-calendar' ) ?></strong>
-								<a target="_blank" href="<?php echo esc_url( $website ) ?>"><?php echo esc_html( $website ) ?></a>
+							<?php if ( $phone = tribe_get_phone( $venue_id) ) : ?>
+								<div class="venue-phone">
+									<strong><?php echo esc_html( __( 'Phone:', 'tribe-events-calendar' ) ); ?> </strong>
+									<?php echo esc_html( $phone ); ?>
+								</div>
 							<?php endif; ?>
 
-						<?php endif; // if ( $venue ) ?>
+							<?php if ( $website = esc_url( get_post_meta( $venue_id, '_VenueURL', true ) ) ) : ?>
+								<div class="venue-url">
+									<strong><?php echo esc_html( __( 'Website:', 'tribe-events-calendar' ) ); ?> </strong>
+									<a target="_blank" href="<?php echo $website; ?>">
+										<?php echo parse_url( $website, PHP_URL_HOST ) . '/&hellip;'; ?>
+									</a>
+								</div>
+							<?php endif; ?>
 
+						<?php endif; // venue ?>
 					</td>
 					<td width="33%" valign="top">
 						<h4><?php esc_html_e( 'Ticket Sales', 'tribe-events-calendar' ); ?></h4>

--- a/src/admin-views/tickets/attendees.php
+++ b/src/admin-views/tickets/attendees.php
@@ -49,11 +49,15 @@ $tickets = Tribe__Events__Tickets__Tickets::get_event_tickets( $event_id );
 								</div>
 							<?php endif; ?>
 
-							<?php if ( $website = esc_url( get_post_meta( $venue_id, '_VenueURL', true ) ) ) : ?>
+							<?php if ( $url = esc_url( get_post_meta( $venue_id, '_VenueURL', true ) ) ) : ?>
 								<div class="venue-url">
 									<strong><?php echo esc_html( __( 'Website:', 'tribe-events-calendar' ) ); ?> </strong>
-									<a target="_blank" href="<?php echo $website; ?>">
-										<?php echo parse_url( $website, PHP_URL_HOST ) . '/&hellip;'; ?>
+									<a target="_blank" href="<?php echo $url; ?>">
+									<?php
+										$display_url  = parse_url( $url, PHP_URL_HOST );
+										$display_url .= parse_url( $url, PHP_URL_PATH ) ? '/&hellip;' : '';
+										echo apply_filters( 'tribe_venue_display_url', $display_url, $url, $venue_id );
+									?>
 									</a>
 								</div>
 							<?php endif; ?>


### PR DESCRIPTION
Repointing @aaemnnosttv's [excellent work](https://github.com/moderntribe/the-events-calendar/pull/56) at our `release/120` branch. Description from the original PR:
>This PR does a few things:

> - Cleaner markup, and more readable php
  - Uses `div` instead of `br` for vertical separation
  - Add classes to venue divs to easier allow for potential alternate styling / custom JS
- Adds full venue address (it can be very difficult to discern between venues with the same name without it.  e.g. "Holiday Inn")
- Displays the venue's website in a much cleaner way, especially for long URLs:
  - yuck: http://cl.ly/image/3E3v2y3r282m
  - much better: http://cl.ly/image/3a3I1w2B1y2B