### PR TITLE
Display proper order_id for ticket orders

### DIFF
--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -121,16 +121,10 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 
 		//back compat
 		if ( empty( $item['order_id_link'] ) ) {
-			$display_id = $item['order_id'];
-			if ( function_exists('wc_get_order') && wc_get_order( $item['order_id'] ) ) {
-				$display_id = wc_get_order( $item['order_id'] )->get_order_number();
-			}
-			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $display_id ) );
-		} else {
-			$id = $item['order_id_link'];
+			$item['order_id_link'] = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $item['order_id'] ) );
 		}
 
-		return $id;
+		return $item['order_id_link'];
 	}
 
 	/**

--- a/src/Tribe/Tickets/Attendees_Table.php
+++ b/src/Tribe/Tickets/Attendees_Table.php
@@ -121,7 +121,11 @@ class Tribe__Events__Tickets__Attendees_Table extends WP_List_Table {
 
 		//back compat
 		if ( empty( $item['order_id_link'] ) ) {
-			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $item['order_id'] ) );
+			$display_id = $item['order_id'];
+			if ( function_exists('wc_get_order') && wc_get_order( $item['order_id'] ) ) {
+				$display_id = wc_get_order( $item['order_id'] )->get_order_number();
+			}
+			$id = sprintf( '<a class="row-title" href="%s">%s</a>', esc_url( get_edit_post_link( $item['order_id'], true ) ), esc_html( $display_id ) );
 		} else {
 			$id = $item['order_id_link'];
 		}


### PR DESCRIPTION
Repointing @aaemnnosttv's [original PR](https://github.com/moderntribe/the-events-calendar/pull/58) to `release/120`. Outputs the order id in the Attendees table as a link.

Related: https://github.com/moderntribe/events-tickets-woo/pull/22

See: https://central.tri.be/issues/37569