### PR TITLE
Make spoofing work gracefully when there are no events (#34202)

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -836,7 +836,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			}
 			// If there are no other posts, unset the $post property
 			elseif ( 0 === $wp_query->post_count ) {
-				$wp_query->currenet_post = -1;
+				$wp_query->current_post = -1;
 				unset( $wp_query->post );
 			}
 

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -830,7 +830,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			$wp_query->post_count = count( $wp_query->posts );
 
 			// If we have other posts besides the spoof, rewind and reset
-			if ( $wp_query->post_count > 0  ) {
+			if ( $wp_query->post_count > 0 ) {
 				$wp_query->rewind_posts();
 				wp_reset_postdata();
 			}


### PR DESCRIPTION
Following our changes to stop returning a 404 status for empty views, this PR should resolve an [annoying issue](https://central.tri.be/issues/34202#note-11) triggering a notice level error when empty views were served using something other than the Default Events Template.

* After spoofing the post we bring the loop to a stop via `Tribe__Events__Templates::endQuery()`
* Previously this was setting the query's `post_count` to `1` 
* In a case where no events had actually returned, this meant WP tried to `rewind_posts()` despite having no posts to rewind (result was a notice level error as it attempted to reset the query's `post` property)

As I was working through this, I also flattened out `Tribe__Events__Templates::restoreQuery()` a little.
