### PR TITLE
Pass along an organizer_id to the tribe_get_organizer filter

### DIFF
--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -114,7 +114,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$output = esc_html( get_the_title( $organizer_id ) );
 		}
 
-		return apply_filters( 'tribe_get_organizer', $output );
+		return apply_filters( 'tribe_get_organizer', $output, $organizer_id );
 	}
 
 	/**


### PR DESCRIPTION
Related: https://github.com/moderntribe/events-pro/pull/57

See: https://central.tri.be/issues/33808