### PR TITLE
Invert the logic for $show_tab so it holds the value we expect

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -767,7 +767,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * only if premium addons are detected.
 		 */
 		protected function do_licenses_tab() {
-			$show_tab = ( ! current_user_can( 'update_plugins' ) || ! $this->have_addons() );
+			$show_tab = ( current_user_can( 'update_plugins' ) && $this->have_addons() );
 
 			/**
 			 * Provides an oppotunity to override the decision to show or hide the licenses tab


### PR DESCRIPTION
`$show_tab` should hold `true` if we want to show the tab rather than false.

See: https://central.tri.be/issues/37677