### PR TITLE
Simplify 'show tab' logic - was unnecessarily stupid (#37362)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -767,7 +767,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * only if premium addons are detected.
 		 */
 		protected function do_licenses_tab() {
-			$show_tab = ( ! current_user_can( 'update_plugins' ) || ! $this->have_addons() );
+			$show_tab = current_user_can( 'update_plugins' ) && $this->have_addons();
 
 			/**
 			 * Provides an oppotunity to override the decision to show or hide the licenses tab


### PR DESCRIPTION
No idea why, but I originally was testing for one of two values to be negative instead of both conditions being positive...