### PR TITLE
Change month view query so it uses EOD cutoff

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -153,13 +153,13 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			$this->args            = $args;
 			$this->events_per_day  = apply_filters( 'tribe_events_month_day_limit', tribe_get_option( 'monthEventAmount', '3' ) );
 			$this->requested_date  = $this->requested_date();
-			$this->first_grid_date = self::calculate_first_cell_date( $this->requested_date ) . ' 00:00:00';
-			$this->final_grid_date = self::calculate_final_cell_date( $this->requested_date ) . ' 23:59:59';
+			$this->first_grid_date = self::calculate_first_cell_date( $this->requested_date );
+			$this->final_grid_date = self::calculate_final_cell_date( $this->requested_date );
 
 			$args = array_merge( $args, array(
 				'fields'         => 'ids',
-				'start_date'     => $this->first_grid_date,
-				'end_date'       => $this->final_grid_date,
+				'start_date'     => tribe_event_beginning_of_day( $this->first_grid_date ),
+				'end_date'       => tribe_event_end_of_day( $this->final_grid_date ),
 				'post_status'    => array( 'publish' ),
 				'posts_per_page' => - 1,
 			) );


### PR DESCRIPTION
Change query so it uses EOD cutoff instead of midnight
Change dates on the query only because the first_grid_date is expected in Y-m-d format

Updates #37867