### PR TITLE
Type Check fix for saving Event Meta

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -158,13 +158,13 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 			}
 
 			// Set sticky state for calendar view.
-			if ( isset( $data['EventShowInCalendar'] ) && $data['EventShowInCalendar'] == 'yes' && $event->menu_order != '-1' ) {
+			if ( isset( $data['EventShowInCalendar'] ) && $data['EventShowInCalendar'] == 'yes' && is_object($event) && $event->menu_order != '-1' ) {
 				$update_event = array(
 					'ID'         => $event_id,
 					'menu_order' => '-1',
 				);
 				wp_update_post( $update_event );
-			} elseif ( ( ! isset( $data['EventShowInCalendar'] ) || $data['EventShowInCalendar'] != 'yes' ) && $event->menu_order == '-1' ) {
+			} elseif ( ( ! isset( $data['EventShowInCalendar'] ) || $data['EventShowInCalendar'] != 'yes' ) && is_object($event) && $event->menu_order == '-1' ) {
 				$update_event = array(
 					'ID'         => $event_id,
 					'menu_order' => '0',


### PR DESCRIPTION
Adding check for optional Object that is permitted to be passed as an array in Tribe__Events__Api::saveEventMeta()