### PR TITLE
exit early if $_GET['plugins'] not set

### DIFF
--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -24,6 +24,10 @@ class Tribe__Events__Activation_Page {
 	 * @return array          The filtered Links
 	 */
 	public function update_complete_actions( $actions, $plugin ) {
+		if ( ! isset( $_GET['plugins'] ) ) {
+			return $actions;
+		}
+
 		$plugins = esc_attr( $_GET['plugins'] );
 
 		if ( false !== strpos( $plugins, ',' ) ){

--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -24,7 +24,7 @@ class Tribe__Events__Activation_Page {
 	 * @return array          The filtered Links
 	 */
 	public function update_complete_actions( $actions, $plugin ) {
-		if ( ! isset( $_GET['plugins'] ) ) {
+		if ( ! empty( $_GET['plugins'] ) ) {
 			return $actions;
 		}
 		$plugins = esc_attr( $_GET['plugins'] );

--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -27,7 +27,6 @@ class Tribe__Events__Activation_Page {
 		if ( ! isset( $_GET['plugins'] ) ) {
 			return $actions;
 		}
-
 		$plugins = esc_attr( $_GET['plugins'] );
 
 		if ( false !== strpos( $plugins, ',' ) ){

--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -24,7 +24,7 @@ class Tribe__Events__Activation_Page {
 	 * @return array          The filtered Links
 	 */
 	public function update_complete_actions( $actions, $plugin ) {
-		if ( ! empty( $_GET['plugins'] ) ) {
+		if ( empty( $_GET['plugins'] ) ) {
 			return $actions;
 		}
 		$plugins = esc_attr( $_GET['plugins'] );


### PR DESCRIPTION
I stumbled across this PHP notice when `$_GET['plugin']` was defined and not `$_GET['plugins']`