### PR TITLE
Label all of the queries in month view as such with eventDisplay

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -151,6 +151,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			$this->final_grid_date = self::calculate_final_cell_date( $this->requested_date );
 
 			$args = array_merge( $args, array(
+				'eventDisplay'   => 'month',
 				'fields'         => 'ids',
 				'start_date'     => tribe_event_beginning_of_day( $this->first_grid_date ),
 				'end_date'       => tribe_event_end_of_day( $this->final_grid_date ),
@@ -308,6 +309,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			$args   = wp_parse_args(
 				array(
+					'eventDisplay'   => 'month',
 					'start_date'     => tribe_event_beginning_of_day( $date ),
 					'end_date'       => tribe_event_end_of_day( $date ),
 					'posts_per_page' => $this->events_per_day,


### PR DESCRIPTION
Queries executed from the confines of the Month View template class should be flagged as such so that other plugins can identify and react to the queries as needed.

The foremost example of this is Pro's ability to suppress recurring events. Without labeling the query as a month view query, those event queries are instead identified as `custom`, causing the recurring events to be hidden.

Related: https://github.com/moderntribe/events-pro/pull/64

See: https://central.tri.be/issues/37629