### PR TITLE
Add support for a new query var called: tribe_render_context

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -857,10 +857,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 */
 		public static function getEvents( $args = array(), $full = false ) {
 			$defaults = array(
-				'post_type'      => Tribe__Events__Main::POSTTYPE,
-				'orderby'        => 'event_date',
-				'order'          => 'ASC',
-				'posts_per_page' => tribe_get_option( 'postsPerPage', 10 ),
+				'post_type'            => Tribe__Events__Main::POSTTYPE,
+				'orderby'              => 'event_date',
+				'order'                => 'ASC',
+				'posts_per_page'       => tribe_get_option( 'postsPerPage', 10 ),
+				'tribe_render_context' => 'default',
 			);
 			$args     = wp_parse_args( $args, $defaults );
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1665,4 +1665,24 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$value = call_user_func( array( $defaults, $field ) );
 		return $value;
 }
+
+	/**
+	 * Gets the render context of the given query
+	 *
+	 * @param WP_Query $query Query object
+	 * @return string
+	 */
+	function tribe_get_render_context( $query = null ) {
+		global $wp_query;
+
+		if ( ! $query ) {
+			$query = $wp_query;
+		}
+
+		if ( empty( $query->query['tribe_render_context'] ) ) {
+			return 'default';
+		}
+
+		return $query->query['tribe_render_context'];
+	}
 }


### PR DESCRIPTION
Also adding a helper function to fetch render context from queries.

See: https://central.tri.be/issues/35421