### PR TITLE
Only unhook addEventMeta if the function is actually executing

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2851,9 +2851,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function addEventMeta( $postId, $post ) {
 
-			// Remove this hook to avoid an infinite loop, because saveEventMeta calls wp_update_post when the post is set to always show in calendar
-			remove_action( 'save_post', array( $this, 'addEventMeta' ), 15, 2 );
-
 			// only continue if it's an event post
 			if ( $post->post_type !== self::POSTTYPE || defined( 'DOING_AJAX' ) ) {
 				return;
@@ -2879,6 +2876,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			if ( ! current_user_can( 'edit_tribe_events' ) ) {
 				return;
 			}
+
+			// Remove this hook to avoid an infinite loop, because saveEventMeta calls wp_update_post when the post is set to always show in calendar
+			remove_action( 'save_post', array( $this, 'addEventMeta' ), 15, 2 );
 
 			$_POST['Organizer'] = isset( $_POST['organizer'] ) ? stripslashes_deep( $_POST['organizer'] ) : null;
 			$_POST['Venue']     = isset( $_POST['venue'] ) ? stripslashes_deep( $_POST['venue'] ) : null;


### PR DESCRIPTION
The location that this `remove_action` was placed was causing incompatibilities. When `wp_insert_post` was called during hooks like `save_post`/`transition_post_status`/etc (that execute before addEventMeta) those post insertions were triggering the `remove_action` call on `addEventMeta`. When it came time for the actual event to be inserted, the addEventMeta hook was non existent and the meta data wouldn't get inserted. This fixes that.

See: https://central.tri.be/issues/35491