### PR TITLE
Added Filter so Minutes can be in larger or smaller increments than 5

### DIFF
--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -505,7 +505,8 @@ if ( ! class_exists( 'Tribe__Events__View_Helpers' ) ) {
 		 */
 		private static function minutes() {
 			$minutes = array();
-			for ( $minute = 0; $minute < 60; $minute += 5 ) {
+			$incrementer = apply_filters( 'tribe_get_minutes_incrementer', 5 );
+			for ( $minute = 0; $minute < 60; $minute += $incrementer ) {
 				if ( $minute < 10 ) {
 					$minute = '0' . $minute;
 				}


### PR DESCRIPTION
I was working on a client's site where precise minutes needed to be entered the for Event's time, but the Meta Box on the Post Edit Screen only allowed for minutes to be in Increments of 5.

This filter allows you to replace it with whatever number you'd like, or leave it alone at its default of 5 minutes.

I made this Pull Request on the release/120 branch because while the Readme says to do it against the Develop branch, that one hasn't been updated in quite some time and this one has had Pull Requests accepted into it very recently.