### PR TITLE
Fix #36153 issue where _EventCost would not update when tickets updated

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,6 +312,11 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+
+= [Unreleased] unreleased =
+
+* Bug - Fixed issue with Event Costs not updating when a new ticket was only submitted via Ajax
+
 = [3.11.2] 2015-07-30 =
 
 * Bug - Resolved issue where List View paging into the past only allowed you to go 1 page in the past (thanks to Richard from Prescott Art Store for reporting this!)

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -256,13 +256,9 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		 * @param $event_id
 		 */
 		public static function update_event_cost( $event_id ) {
-			// Load the current event costs: assume the first of these is the "base" cost
-			// which can be set per event when only the core plugin is running
-			$event_cost = (array) get_post_meta( $event_id, '_EventCost' );
-			$base_cost  = array_shift( $event_cost );
-
-			// Allow addons (ie, ticketing plugins) to register additional event costs
-			$event_cost = (array) apply_filters( 'tribe_events_event_costs', array( $base_cost ), $event_id );
+			// Loads current event costs on construct
+			// Tribe__Events__Tickets__Tickets->get_ticket_prices() adds them to the filter 'tribe_events_event_costs'
+			$event_cost = (array) apply_filters( 'tribe_events_event_costs', array(), $event_id );
 
 			// Kill the old cost meta data
 			delete_post_meta( $event_id, '_EventCost' );

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -256,8 +256,8 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		 * @param $event_id
 		 */
 		public static function update_event_cost( $event_id ) {
-			// Loads current event costs on construct
-			// Tribe__Events__Tickets__Tickets->get_ticket_prices() adds them to the filter 'tribe_events_event_costs'
+			// Loads current event costs, on construct
+			// Tribe__Events__Tickets__Tickets->get_ticket_prices() adds them to this filter
 			$event_cost = (array) apply_filters( 'tribe_events_event_costs', array(), $event_id );
 
 			// Kill the old cost meta data


### PR DESCRIPTION
This function is only called when via an ajax request when a user edits a ticket while editing an event. A separate function updates these fields when the page is POSTed (The user clicks the Update button). That function worked flawlessly, but this called via ajax did not.

I am not sure what the code was supposed to do before, why there was an array shift nor why we had a $base_cost variable. However, the filter 'tribe_events_event_costs' is only applied in one other place in all of our plugins, and in that place it passes an empty array exactly like this now does. Now that there are no values passed, it behaves as expected and never has a duplicate value.