### PR TITLE
Added check for get_current_screen() before trying to use it

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -299,7 +299,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				// Because this method filters out drafts without EventStartDate.
 				// For this screen we're doing the JOIN manually in Tribe__Events__Admin_List
 
-				$screen = ! is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ? null : get_current_screen();
+				$screen = null;
+
+				if ( function_exists( 'get_current_screen' ) ) {
+					$screen = ! is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ? null : get_current_screen();
+				}
 
 				if ( empty( $screen ) || 'edit-tribe_events' !== $screen->id ) {
 					$meta_query[] = array(


### PR DESCRIPTION
Hi,
This is a fix for an issue that I (and several others) have been having where TEC is trying to use `get_current_screen()`, but for some reason it's unavailable, which is breaking the entire admin side when trying to add a new event.

The bug can be recreated by creating a WordPress plugin that use ```WP_Query``` when ```wp_loaded``` is fired.  The ```pre_get_posts``` hook in TEC then fires and tries to use ```get_current_screen()```, which is undefined at this point.  Which is weird because WP_ADMIN *is* defined, so that function should exist.  Oh well.