### PR TITLE
Avoid a notice when _GET['plugins'] isn't set on the update page

### DIFF
--- a/src/Tribe/Activation_Page.php
+++ b/src/Tribe/Activation_Page.php
@@ -24,12 +24,11 @@ class Tribe__Events__Activation_Page {
 	 * @return array          The filtered Links
 	 */
 	public function update_complete_actions( $actions, $plugin ) {
-		$plugins = esc_attr( $_GET['plugins'] );
+		$plugins = array();
 
-		if ( false !== strpos( $plugins, ',' ) ){
-			$plugins = explode( ',', $plugins );
+		if ( ! empty( $_GET['plugins'] ) ) {
+			$plugins = explode( ',', esc_attr( $_GET['plugins'] ) );
 		}
-		$plugins = (array) $plugins;
 
 		if ( ! in_array( Tribe__Events__Main::instance()->pluginDir . 'the-events-calendar.php', $plugins ) ){
 			return $actions;


### PR DESCRIPTION
See: https://central.tri.be/issues/38061