### PR TITLE
Adopt suggestion by d4mation- and add minute increment filter

### DIFF
--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -505,7 +505,13 @@ if ( ! class_exists( 'Tribe__Events__View_Helpers' ) ) {
 		 */
 		private static function minutes() {
 			$minutes = array();
-			for ( $minute = 0; $minute < 60; $minute += 5 ) {
+			/**
+			 * Filters the amount of minutes to increment the minutes drop-down by
+			 *
+			 * @param int Increment amount (defaults to 5)
+			 */
+			$increment = apply_filters( 'tribe_minutes_increment', 5 );
+			for ( $minute = 0; $minute < 60; $minute += $increment ) {
 				if ( $minute < 10 ) {
 					$minute = '0' . $minute;
 				}


### PR DESCRIPTION
@d4mation- had [an _excellent_ mod](https://github.com/moderntribe/the-events-calendar/pull/242) that allows sites to filter the increment value for the minutes drop-down boxes rather than always forcing a 5-minute increment. Thank you for the original PR, @d4mation-!

See internal ticket ref: https://central.tri.be/issues/38550