### PR TITLE
Performance enhancements that target month view

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -33,7 +33,7 @@ class Tribe__Events__Cost_Utils {
 	public function get_all_costs() {
 		global $wpdb;
 
-		$costs = $wpdb->get_col( "SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_EventCost'" );
+		$costs = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_EventCost'" );
 
 		return $costs;
 	}//end get_all_costs
@@ -158,10 +158,16 @@ class Tribe__Events__Cost_Utils {
 			$costs = array( $costs );
 		}
 
+		$new_costs = array();
+
 		foreach ( $costs as $index => $value ) {
 			$values = $this->parse_cost_range( $value );
-			$costs = array_merge( $costs, $values );
+			foreach ( $values as $val ) {
+				$new_costs[] = $val;
+			}
 		}
+
+		$costs = $new_costs;
 
 		if ( empty( $costs ) ) {
 			return 0;

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -571,7 +571,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			$date = $this->first_grid_date; // Start with the first grid date
 
-
 			// Populate complete date range including leading/trailing days from adjacent months
 			while ( $date <= $this->final_grid_date ) {
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -473,8 +473,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 					// Subtract a day from the $end if it is:
 					// * earlier than the beginning of the start DATE OR
-					// * earlier than the end of the start DATE OR
-					// * earlier than the beginning of the end DATE
+					// * earlier than the beginning of the end DATE OR
+					// * earlier than the end of the start DATE (as long as the beginning of the end DATE is greater than that of the start DATE)
 					//
 					// Example 1:
 					// Assuming a cut-off of 6:00am and an event end date/time of August 2nd @ 7:00am. The
@@ -489,8 +489,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					// (August 1st) (Note: this following if statement conditional would be true)
 					if (
 						$event_end < $beginning_of_start_timestamp
-						|| $event_end < $end_of_start_timestamp
 						|| $event_end < $beginning_of_end_timestamp
+						|| (
+							$event_end < $end_of_start_timestamp
+							&& $beginning_of_end_timestamp > $end_of_start_timestamp
+						)
 					) {
 						$end = date( 'Y-m-d', strtotime( '-1 day', strtotime( $end ) ) );
 					}

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -469,8 +469,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 						}
 					}
 
-					$event_start = strtotime( $event->EventStartDate );
-					$event_end   = strtotime( $event->EventEndDate );
+					$event_start = strtotime( tribe_get_start_date( $event->ID ) );
+					$event_end   = strtotime( tribe_get_end_date( $event->ID ) );
 
 					$start = date( 'Y-m-d', $event_start );
 					$end = date( 'Y-m-d', $event_end );

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -366,7 +366,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			$this->queried_event_cats = $terms;
 		}
 
-
 		/**
 		 * Get all the events in the month by directly querying the postmeta table
 		 * Also caches the postmeta and terms for the found events
@@ -428,6 +427,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 		/**
 		 * Breaks the possible collection of events down by grid date
+		 *
+		 * @param string $date Y-m-d formatted date to retrieve events for
 		 *
 		 * @return array
 		 */

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -572,11 +572,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 */
 		private function get_daily_events( $date ) {
 
-			$beginning_of_day           = tribe_event_beginning_of_day( $date );
-			$beginning_of_day_timestamp = strtotime( $beginning_of_day );
+			$beginning_of_day           = $this->get_cutoff_details( $date, 'beginning' );
+			$beginning_of_day_timestamp = $this->get_cutoff_details( $date, 'beginning_timestamp' );
 
-			$end_of_day           = tribe_event_end_of_day( $date );
-			$end_of_day_timestamp = strtotime( $end_of_day );
+			$end_of_day           = $this->get_cutoff_details( $date, 'end' );
+			$end_of_day_timestamp = $this->get_cutoff_details( $date, 'end_timestamp' );
 
 			$event_ids_on_date = $this->get_event_ids_by_day( $date );
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -426,6 +426,30 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		}
 
 		/**
+		 * Retrieves beginning/end times for a given date
+		 *
+		 * @param string $date Y-m-d date string
+		 * @param string $key Key of cached data to retrieve
+		 *
+		 * return string|int
+		 */
+		private function get_cutoff_details( $date, $key ) {
+			static $beginnings_and_ends = array();
+
+			if ( empty( $beginnings_and_ends[ $date ] ) ) {
+				$beginnings_and_ends[ $date ] = array(
+					'beginning' => tribe_event_beginning_of_day( $date ),
+					'end' => tribe_event_end_of_day( $date ),
+				);
+
+				$beginnings_and_ends[ $date ]['beginning_timestamp'] = strtotime( $beginnings_and_ends[ $date ]['beginning'] );
+				$beginnings_and_ends[ $date ]['end_timestamp'] = strtotime( $beginnings_and_ends[ $date ]['end'] );
+			}
+
+			return $beginnings_and_ends[ $date ][ $key ];
+		}
+
+		/**
 		 * Breaks the possible collection of events down by grid date
 		 *
 		 * @param string $date Y-m-d formatted date to retrieve events for
@@ -451,13 +475,12 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					$start = date( 'Y-m-d', $event_start );
 					$end = date( 'Y-m-d', $event_end );
 
-					$beginning_of_start           = tribe_event_beginning_of_day( $start );
-					$beginning_of_start_timestamp = strtotime( $beginning_of_start );
-					$end_of_start           = tribe_event_end_of_day( $start );
-					$end_of_start_timestamp = strtotime( $end_of_start );
-
-					$beginning_of_end           = tribe_event_beginning_of_day( $end );
-					$beginning_of_end_timestamp = strtotime( $beginning_of_end );
+					$beginning_of_start           = $this->get_cutoff_details( $start, 'beginning' );
+					$beginning_of_start_timestamp = $this->get_cutoff_details( $start, 'beginning_timestamp' );
+					$end_of_start                 = $this->get_cutoff_details( $start, 'end' );
+					$end_of_start_timestamp       = $this->get_cutoff_details( $start, 'end_timestamp' );
+					$beginning_of_end             = $this->get_cutoff_details( $end, 'beginning' );
+					$beginning_of_end_timestamp   = $this->get_cutoff_details( $end, 'beginning_timestamp' );
 
 					// if the start of the event is earlier than the beginning of the day, consider the event
 					// as starting on the day before

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -451,19 +451,47 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					$start = date( 'Y-m-d', $event_start );
 					$end = date( 'Y-m-d', $event_end );
 
-					$beginning_of_day           = tribe_event_beginning_of_day( $start );
-					$beginning_of_day_timestamp = strtotime( $beginning_of_day );
+					$beginning_of_start           = tribe_event_beginning_of_day( $start );
+					$beginning_of_start_timestamp = strtotime( $beginning_of_start );
+					$end_of_start           = tribe_event_end_of_day( $start );
+					$end_of_start_timestamp = strtotime( $end_of_start );
 
-					$end_of_day           = tribe_event_end_of_day( $end );
-					$end_of_day_timestamp = strtotime( $end_of_day );
+					$beginning_of_end           = tribe_event_beginning_of_day( $end );
+					$beginning_of_end_timestamp = strtotime( $beginning_of_end );
 
-					// if the start of the event is earlier than the beginning of the day, consider the event as starting on the day before
-					if ( $event_start < $beginning_of_day_timestamp ) {
+					// if the start of the event is earlier than the beginning of the day, consider the event
+					// as starting on the day before
+					//
+					// Example 1:
+					// Assuming a cut-off of 6:00am and an event start date/time of August 2nd @ 5:00am. The
+					// "start" DATE would be August 2nd and the beginning of the "start" DATE would be August
+					// 2nd @ 6:00am. Therefore, the event start DATE shoud be altered to be a day earlier
+					// (August 1st) (Note: the following if statement conditional would be true)
+					if ( $event_start < $beginning_of_start_timestamp ) {
 						$start = date( 'Y-m-d', strtotime( '-1 day', strtotime( $start ) ) );
 					}
 
-					// if the end of the event is later than the end of the day, consider the event as ending on the next day
-					if ( $event_end < $end_of_day_timestamp ) {
+					// Subtract a day from the $end if it is:
+					// * earlier than the beginning of the start DATE OR
+					// * earlier than the end of the start DATE OR
+					// * earlier than the beginning of the end DATE
+					//
+					// Example 1:
+					// Assuming a cut-off of 6:00am and an event end date/time of August 2nd @ 7:00am. The
+					// "end" DATE would be August 2nd and the beginning of the "end" DATE would be August
+					// 2nd @ 6:00am. Therefore, the event end DATE shoud remain as August 2nd. (Note: the
+					// following if statement conditional would be false)
+					//
+					// Example 2:
+					// Assuming a cut-off of 6:00am and an event end date/time of August 2nd @ 5:00am. The
+					// "end" DATE would be August 2nd and the beginning of the "end" DATE would be August
+					// 2nd @ 6:00am. Therefore, the event end DATE shoud be altered to be a day earlier
+					// (August 1st) (Note: this following if statement conditional would be true)
+					if (
+						$event_end < $beginning_of_start_timestamp
+						|| $event_end < $end_of_start_timestamp
+						|| $event_end < $beginning_of_end_timestamp
+					) {
 						$end = date( 'Y-m-d', strtotime( '-1 day', strtotime( $end ) ) );
 					}
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -215,7 +215,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 */
 		protected function set_args( $args = array() ) {
 
-			$doing_ajax = ( defined('DOING_AJAX') && DOING_AJAX ) ? true : false;
+			$doing_ajax = ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ? true : false;
 
 			if ( empty( $args ) && $doing_ajax ) {
 				$post_status = array( 'publish' );
@@ -463,8 +463,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					}
 
 					// if the end of the event is later than the end of the day, consider the event as ending on the next day
-					if ( $event_end > $end_of_day_timestamp ) {
-						$end = date( 'Y-m-d', strtotime( '+1 day', strtotime( $end ) ) );
+					if ( $event_end < $end_of_day_timestamp ) {
+						$end = date( 'Y-m-d', strtotime( '-1 day', strtotime( $end ) ) );
 					}
 
 					// determine if there's a difference in days between start and end


### PR DESCRIPTION
Note: I'm Pull Requesting this into a feature branch (that is [this PR](https://github.com/moderntribe/the-events-calendar/pull/192)) so the code within this changeset can be reviewed in isolation.

**The Cost_Utils class**

`get_cost_by_func` was pretty slow for two reasons: `array_merge` is kind of slow _and_ when there are a large number of events, fetching every non-unique cost means we have to loop over and parse each one.  That's expensive. Let's select distinct costs and avoid doing `array_merge`.

**Month view class**

When fetching the daily events, we were looping over every event in the month and determining if it fell on the given day. Instead, we could reduce the number of times we loop by _instead_ looping over all the events in the month and breaking them out into the days that they fall on. We get the same data, it is just built in reverse and requires fewer loops.

See: https://github.com/moderntribe/the-events-calendar/pull/192 and https://central.tri.be/issues/32067