### PR TITLE
Alter query to respect events that are set to be 'sticky in month view' (#32067)

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -475,6 +475,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => true,
+					'orderby'                => 'menu_order',
 				), $this->args
 			);
 


### PR DESCRIPTION
We need to respect events that have been set as 'sticky in month view' (ie, they have a negative menu_order to float them to the top). Like [PR/259](https://github.com/moderntribe/the-events-calendar/pull/259) this targets an existing feature branch.