### PR TITLE
Don't override ORDER BY with a blank string. That's silly.

### DIFF
--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -21,8 +21,6 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 		 */
 		public static function init() {
 			if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-				add_filter( 'tribe_events_query_posts_orderby', array( __CLASS__, 'override_tribe_events_query_orderby' ) );
-
 				// Logic for sorting events by event category or tags
 				add_filter( 'posts_clauses', array( __CLASS__, 'sort_by_tax' ), 10, 2 );
 
@@ -45,14 +43,6 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 				// Registers event start/end date as sortable columns
 				add_action( 'manage_edit-' . Tribe__Events__Main::POSTTYPE . '_sortable_columns', array( __CLASS__, 'register_sortable_columns' ), 10, 2 );
 			}
-		}
-
-		/**
-		 * Override the orderby that is set up in Tribe__Events__Query. The dashboard event list has its own
-		 * orderby rules
-		 */
-		public static function override_tribe_events_query_orderby( $orderby ) {
-			return '';
 		}
 
 		/**


### PR DESCRIPTION
This filter was added during the development cycle of release/120 [by me](https://github.com/moderntribe/the-events-calendar/pull/148) and it was really stupid.

See: https://central.tri.be/issues/38329