### PR TITLE
Feature/ical custom event links

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -317,11 +317,6 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 = [Unreleased] unreleased =
 
-* Performance - Greatly optimized the generation of Month View data
-* Feature - Extended CSV importer fields to include full coverage of Event, Organizer, and Venue fields
-* Tweak - Relocated event recurrence-specific JS to Events PRO where it belongs
-* Tweak - Style nowrap on ticket forms with CSS rather than HTML attributes
-* Bug - Resolved bug where executing wp_insert_post within a hook to publish_tribe_events prevented event meta from being saved appropriately
 * Bug - Fixed issue with event title attributes not always escaping properly on List and Day views
 * Bug - Fixed issue with Event Costs not updating when a new ticket was only submitted via Ajax
 * Bug - Fixed an issue Twenty Fourteen and the event views being hidden in screen sizes smaller then 400px

--- a/readme.txt
+++ b/readme.txt
@@ -320,6 +320,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Bug - Fixed issue with event title attributes not always escaping properly on List and Day views
 * Bug - Fixed issue with Event Costs not updating when a new ticket was only submitted via Ajax
 * Bug - Fixed an issue Twenty Fourteen and the event views being hidden in screen sizes smaller then 400px
+* Feature - Added the ability to genereate iCal links for a custom list of events
 
 = [3.11.2] 2015-07-30 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -317,6 +317,11 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 = [Unreleased] unreleased =
 
+* Performance - Greatly optimized the generation of Month View data
+* Feature - Extended CSV importer fields to include full coverage of Event, Organizer, and Venue fields
+* Tweak - Relocated event recurrence-specific JS to Events PRO where it belongs
+* Tweak - Style nowrap on ticket forms with CSS rather than HTML attributes
+* Bug - Resolved bug where executing wp_insert_post within a hook to publish_tribe_events prevented event meta from being saved appropriately
 * Bug - Fixed issue with event title attributes not always escaping properly on List and Day views
 * Bug - Fixed issue with Event Costs not updating when a new ticket was only submitted via Ajax
 * Bug - Fixed an issue Twenty Fourteen and the event views being hidden in screen sizes smaller then 400px

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -134,7 +134,14 @@ class Tribe__Events__iCal {
 		// hijack to iCal template
 		if ( get_query_var( 'ical' ) || isset( $_GET['ical'] ) ) {
 			global $wp_query;
-			if ( is_single() ) {
+			if ( isset( $_GET['event_ids'] ) ) {
+				if ( empty( $_GET['event_ids'] ) ) {
+					die();
+				}
+				$event_ids = explode( ',', $_GET['event_ids'] );
+				$events    = Tribe__Events__Query::getEvents( [ 'post__in' => $event_ids ] );
+				self::generate_ical_feed( $events );
+			} else if ( is_single() ) {
 				self::generate_ical_feed( $wp_query->post, null );
 			} else {
 				self::generate_ical_feed();

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -210,8 +210,7 @@ class Tribe__Events__iCal {
 		$blogName    = get_bloginfo( 'name' );
 
 		if ( $post ) {
-			$events_posts   = array();
-			$events_posts[] = $post;
+			$events_posts = is_array( $post ) ? $post : array( $post );
 		} else {
 			if ( tribe_is_month() ) {
 				$events_posts = self::get_month_view_events();

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -139,7 +139,7 @@ class Tribe__Events__iCal {
 					die();
 				}
 				$event_ids = explode( ',', $_GET['event_ids'] );
-				$events    = Tribe__Events__Query::getEvents( [ 'post__in' => $event_ids ] );
+				$events    = Tribe__Events__Query::getEvents( array( 'post__in' => $event_ids ) );
 				self::generate_ical_feed( $events );
 			} else if ( is_single() ) {
 				self::generate_ical_feed( $wp_query->post, null );


### PR DESCRIPTION
This proposed change allows for the generation of iCal links for a custom combination of events; the IDs of those events to be passed in the `$_GET` parameter under the proposed `event_ids` key.
Use cases: in custom templates where events are fetched with custom criteria like “all events from this organiser and this organiser” or “all upcoming events from this organiser in this category”.