### PR TITLE
Deprecate public method that's unused in our codebase

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3468,8 +3468,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Allow programmatic override of defaultValueReplace setting
 		 *
 		 * @return boolean
+		 * @deprecated
 		 */
 		public function defaultValueReplaceEnabled() {
+
+			_deprecated_function(__METHOD__, '4.0', "tribe_get_option( 'defaultValueReplace' )");
 
 			if ( ! is_admin() ) {
 				return false;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3469,10 +3469,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @return boolean
 		 * @deprecated
+		 * @todo remove in 4.5
 		 */
 		public function defaultValueReplaceEnabled() {
 
-			_deprecated_function(__METHOD__, '4.0', "tribe_get_option( 'defaultValueReplace' )");
+			_deprecated_function( __METHOD__, '4.0', "tribe_get_option( 'defaultValueReplace' )" );
 
 			if ( ! is_admin() ) {
 				return false;


### PR DESCRIPTION
Searched for this method throughout the codebase, we're not using it. Also seems unnecessary. Deprecating instead of removing because it's public.

Internal Ref: https://central.tri.be/issues/28005