### PR TITLE
Adjust default for $default_to_original arg to true (spotfix)

### DIFF
--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -611,7 +611,7 @@ if ( ! class_exists( 'Tribe__Events__Template_Factory' ) ) {
 		 *
 		 * @return string|false The path/url to minified version or false, if file not found.
 		 */
-		public static function getMinFile( $url, $default_to_original = false ) {
+		public static function getMinFile( $url, $default_to_original = true ) {
 			if ( ! defined( 'SCRIPT_DEBUG' ) || SCRIPT_DEBUG === false ) {
 				if ( substr( $url, - 3, 3 ) == '.js' ) {
 					$url_new = substr_replace( $url, '.min', - 3, 0 );


### PR DESCRIPTION
`Tribe__Events__Template_Factory::getMinFile()` will fallback to the unminified asset whenever `$default_to_original` is true. All calls to this method I can find across our suite accordingly set that to true (as the default, bizarrely, is false). This PR changes that default to help avoid annoying bugs when laying out new code.

