### PR TITLE
Timezones: improve fallback logic

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -276,7 +276,10 @@ class Tribe__Events__Timezones {
 			$offset *= -1;
 		}
 
-		if ( $offset > 0 ) $offset = '+' . $offset;
+		if ( $offset > 0 ) {
+			$offset = '+' . $offset;
+		}
+
 		$offset = $offset . ' minutes';
 
 		$offset_datetime = date_create( $datetime );

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -279,8 +279,13 @@ class Tribe__Events__Timezones {
 		if ( $offset > 0 ) $offset = '+' . $offset;
 		$offset = $offset . ' minutes';
 
-		$datetime = date_create( $datetime )->modify( $offset );
-		return $datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
+		$offset_datetime = date_create( $datetime );
+
+		if ( $offset_datetime && $offset_datetime->modify( $offset ) ) {
+			return $offset_datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
+		}
+
+		return $datetime;
 	}
 
 	/**

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -276,16 +276,11 @@ class Tribe__Events__Timezones {
 			$offset *= -1;
 		}
 
-		try {
-			if ( $offset > 0 ) $offset = '+' . $offset;
-			$offset = $offset . ' minutes';
+		if ( $offset > 0 ) $offset = '+' . $offset;
+		$offset = $offset . ' minutes';
 
-			$datetime = date_create( $datetime )->modify( $offset );
-			return $datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
-		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+		$datetime = date_create( $datetime )->modify( $offset );
+		return $datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
 	}
 
 	/**


### PR DESCRIPTION
Bad datetime/offset data can lead to us trying to call a method on a non-object as described in [C#39204](https://central.tri.be/issues/39204) - this guards against that.