### PR TITLE
Fix/39180 list view queries pagination

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -471,7 +471,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			$event_start_key = '_EventStartDate';
 			$event_end_key   = '_EventEndDate';
 
-			if ( Tribe__Events__Timezones::mode( 'site' ) ) {
+			if ( Tribe__Events__Timezones::is_mode( 'site' ) ) {
 				$event_start_key .= 'UTC';
 				$event_end_key   .= 'UTC';
 			}

--- a/src/functions/template-tags/loop.php
+++ b/src/functions/template-tags/loop.php
@@ -132,16 +132,16 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		// If there's a date selected in the tribe bar, show the date range of the currently showing events
 		if ( isset( $_REQUEST['tribe-bar-date'] ) && $wp_query->have_posts() ) {
+			$first_returned_date = tribe_get_start_date( $wp_query->posts[0], false, Tribe__Events__Date_Utils::DBDATEFORMAT );
+			$first_event_date    = tribe_get_start_date( $wp_query->posts[0], false );
+			$last_event_date     = tribe_get_end_date( $wp_query->posts[ count( $wp_query->posts ) - 1 ], false );
 
-			if ( $wp_query->get( 'paged' ) > 1 ) {
-				// if we're on page 1, show the selected tribe-bar-date as the first date in the range
-				$first_event_date = tribe_get_start_date( $wp_query->posts[0], false );
-			} else {
-				//otherwise show the start date of the first event in the results
+			// If we are on page 1 then we may wish to use the *selected* start date in place of the
+			// first returned event date
+			if ( 1 == $wp_query->get( 'paged' ) && $_REQUEST['tribe-bar-date'] < $first_returned_date ) {
 				$first_event_date = tribe_event_format_date( $_REQUEST['tribe-bar-date'], false );
 			}
 
-			$last_event_date = tribe_get_end_date( $wp_query->posts[ count( $wp_query->posts ) - 1 ], false );
 			$title = sprintf( __( '%1$s for %2$s - %3$s', 'tribe-events-calendar' ), $events_label_plural, $first_event_date, $last_event_date );
 		} elseif ( tribe_is_past() ) {
 			$title = sprintf( __( 'Past %s', 'tribe-events-calendar' ), $events_label_plural );


### PR DESCRIPTION
Fixes two unrelated problems that were both impacting list pagination (and list titles). A) the query wasn't consistently referencing the correct date fields (according to the timezone mode) and B) the list title didn't always use the *selected* date when appropriate.