### PR TITLE
Improve handling of errors where timezone conversion cannot be made (#39204)

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -195,16 +195,17 @@ class Tribe__Events__Timezones {
 			return self::apply_offset( $datetime, $tzstring, true );
 		}
 
-		try {
-			$local = self::get_timezone( $tzstring );
-			$utc   = self::get_timezone( 'UTC' );
+		$local = self::get_timezone( $tzstring );
+		$utc   = self::get_timezone( 'UTC' );
 
-			$datetime = date_create( $datetime, $local )->setTimezone( $utc );
-			return $datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
+		$new_datetime = date_create( $datetime, $local );
+
+		if ( $new_datetime && $new_datetime->setTimezone( $utc ) ) {
+			return $new_datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
 		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+
+		// Fallback to the unmodified datetime if there was a failure during conversion
+		return $datetime;
 	}
 
 	/**
@@ -223,16 +224,17 @@ class Tribe__Events__Timezones {
 			return self::apply_offset( $datetime, $tzstring );
 		}
 
-		try {
-			$local = self::get_timezone( $tzstring );
-			$utc   = self::get_timezone( 'UTC' );
+		$local = self::get_timezone( $tzstring );
+		$utc   = self::get_timezone( 'UTC' );
 
-			$datetime = date_create( $datetime, $utc )->setTimezone( $local );
-			return $datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
+		$new_datetime = date_create( $datetime, $utc );
+
+		if ( $new_datetime && $new_datetime->setTimezone( $local ) ) {
+			return $new_datetime->format( Tribe__Events__Date_Utils::DBDATETIMEFORMAT );
 		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+
+		// Fallback to the unmodified datetime if there was a failure during conversion
+		return $datetime;
 	}
 
 	/**


### PR DESCRIPTION
We're making use of procedural datetime functions for brevity: the try/catch isn't appropriate here and means we're potentially missing some errors during conversion that we could otherwise handle fairly gracefully.

See: https://central.tri.be/issues/39204