### PR TITLE
Msg for Empty field on event post

### DIFF
--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -188,14 +188,12 @@ if ( $post->post_type != Tribe__Events__Main::VENUE_POST_TYPE ) {
 			function (result) {
 				if (jQuery('[name=venue\\[Venue\\]]').get(0).value == "") {
 					jQuery('.tribe-venue-error').remove();
-					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Can Not be Empty', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Can Not Be Empty', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+				} else if (result == 1) {
+					jQuery('.tribe-venue-error').remove();
 				} else {
-					if (result == 1) {
-						jQuery('.tribe-venue-error').remove();
-					} else {
-						jQuery('.tribe-venue-error').remove();
-						jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
-					}
+					jQuery('.tribe-venue-error').remove();
+					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
 				}
 
 			}

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -188,12 +188,12 @@ if ( $post->post_type != Tribe__Events__Main::VENUE_POST_TYPE ) {
 			function (result) {
 				if (jQuery('[name=venue\\[Venue\\]]').get(0).value == "") {
 					jQuery('.tribe-venue-error').remove();
-					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Can Not Be Empty', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php echo esc_html( sprintf( __( '%s Name Can Not Be Empty', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ) ); ?></div>');
 				} else if (result == 1) {
 					jQuery('.tribe-venue-error').remove();
 				} else {
 					jQuery('.tribe-venue-error').remove();
-					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php echo esc_html( sprintf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ) ); ?></div>');
 				}
 
 			}

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -186,12 +186,18 @@ if ( $post->post_type != Tribe__Events__Main::VENUE_POST_TYPE ) {
 				name  : jQuery('[name=venue\\[Venue\\]]').get(0).value
 			},
 			function (result) {
-				if (result == 1) {
+				if (jQuery('[name=venue\\[Venue\\]]').get(0).value == "") {
 					jQuery('.tribe-venue-error').remove();
+					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Can Not be Empty', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
 				} else {
-					jQuery('.tribe-venue-error').remove();
-					jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+					if (result == 1) {
+						jQuery('.tribe-venue-error').remove();
+					} else {
+						jQuery('.tribe-venue-error').remove();
+						jQuery( '[name=venue\\[Venue\\]]' ).after('<div class="tribe-venue-error error form-invalid"><?php printf( __( '%s Name Already Exists', 'tribe-events-calendar' ), tribe_get_venue_label_singular() ); ?></div>');
+					}
 				}
+
 			}
 		);
 	});


### PR DESCRIPTION
In the Add New Event, if I keep the Event name meta box empty and press Tab then it shows "Event Name Already Exist" which is ambiguous. I fixed this with a "Evant name Can Not be Empty" msg.

Signed-off-by: Tapan Kumer Das <tapan@innovativebd.net>

Internal reference: https://central.tri.be/issues/40223