### PR TITLE
Undo string change inadvertently applied to non-textdomains (#37716)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4124,7 +4124,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					add_query_arg(
 						array(
 							'post_type' => self::POSTTYPE,
-							'page'      => 'the-events-calendar',
+							'page'      => 'tribe-events-calendar',
 						),
 						admin_url( 'edit.php' )
 					)
@@ -4151,7 +4151,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				add_query_arg(
 					array(
 						'post_type' => self::POSTTYPE,
-						'page'      => 'the-events-calendar',
+						'page'      => 'tribe-events-calendar',
 						'tab'       => 'help',
 					),
 					'edit.php'

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'Tribe__Events__Settings' ) ) {
 			// set instance variables
 			$this->menuName    = apply_filters( 'tribe_settings_menu_name', __( 'The Events Calendar', 'the-events-calendar' ) );
 			$this->requiredCap = apply_filters( 'tribe_settings_req_cap', 'manage_options' );
-			$this->adminSlug   = apply_filters( 'tribe_settings_admin_slug', 'the-events-calendar' );
+			$this->adminSlug   = apply_filters( 'tribe_settings_admin_slug', 'tribe-events-calendar' );
 			$this->errors      = get_option( 'tribe_settings_errors', array() );
 			$this->major_error = get_option( 'tribe_settings_major_error', false );
 			$this->sent_data   = get_option( 'tribe_settings_sent_data', array() );


### PR DESCRIPTION
Fixes a great catch by @leahkoerper (re [C#37716](https://central.tri.be/issues/37716)) - a couple of references to `tribe-events-calendar` were updated in [PR/305](https://github.com/moderntribe/the-events-calendar/pull/305) but should have been left alone.