### PR TITLE
Look up one more level to find the readme.txt file (#39386)

### DIFF
--- a/src/Tribe/Changelog_Reader.php
+++ b/src/Tribe/Changelog_Reader.php
@@ -11,7 +11,7 @@ class Tribe__Events__Changelog_Reader {
 	}
 
 	protected function default_readme_file() {
-		return dirname( dirname( __FILE__ ) ) . '/readme.txt';
+		return dirname( dirname( dirname( __FILE__ ) ) ) . '/readme.txt';
 	}
 
 	public function get_changelog() {


### PR DESCRIPTION
Re [C#39386](https://central.tri.be/issues/39386) the changelog reader was failing to locate the default `readme.txt` file. This can be reviewed but I've applied the hold label since we may wait until MR2 before merging.