### PR TITLE
Use site timezone (not UTC) when selecting current day in month view

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -849,7 +849,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			$calendar_day           = self::get_current_day();
 			$calendar_day_timestamp = strtotime( $calendar_day['date'] );
-			$today                  = strtotime( 'today' );
+			$today                  = strtotime( current_time( 'Y-m-d' ) );
 
 			// Start by determining which month we're looking at
 			if ( $calendar_day['month'] == self::CURRENT_MONTH ) {


### PR DESCRIPTION
Correct code for highlighting the current day (see [C#39420](https://central.tri.be/issues/39420)).