### PR TITLE
Support both the original and translated/custom slugs (#39391)

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -213,12 +213,19 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 			/**
 			 * If you want to modify the base slugs before the i18n happens filter this use this filter
 			 * All the bases need to have a key and a value, they might be the same or not.
+			 *
+			 * Each value is an array of possible slugs: to improve robustness the "original" English
+			 * slug is supported in addition to translated forms for month, list, today and day: this
+			 * way if the forms are altered (whether through i18n or other custom mods) *after* links
+			 * have already been promulgated, there will be less chance of visitors hitting 404s.
+			 *
+			 * @var array $bases
 			 */
 			$bases = apply_filters( 'tribe_events_rewrite_base_slugs', array(
-				'month' => (array) Tribe__Events__Main::instance()->monthSlug,
-				'list' => (array) Tribe__Events__Main::instance()->listSlug,
-				'today' => (array) Tribe__Events__Main::instance()->todaySlug,
-				'day' => (array) Tribe__Events__Main::instance()->daySlug,
+				'month' => array( 'month', Tribe__Events__Main::instance()->monthSlug ),
+				'list' => array( 'list', Tribe__Events__Main::instance()->listSlug ),
+				'today' => array( 'today', Tribe__Events__Main::instance()->todaySlug ),
+				'day' => array( 'day', Tribe__Events__Main::instance()->daySlug ),
 				'tag' => (array) 'tag',
 				'tax' => (array) 'category',
 				'page' => (array) 'page',
@@ -226,6 +233,9 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 				'single' => (array) Tribe__Events__Main::instance()->getOption( 'singleEventSlug', 'event' ),
 				'archive' => (array) Tribe__Events__Main::instance()->getOption( 'eventsSlug', 'events' ),
 			) );
+
+			// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)
+			$bases = array_map( 'array_unique', $bases );
 
 			// By default we always have `en_US` to avoid 404 with older URLs
 			$languages = apply_filters( 'tribe_events_rewrite_i18n_languages', array_unique( array( 'en_US', get_locale() ) ) );


### PR DESCRIPTION
Re [C#39391](https://central.tri.be/issues/39391) makes core consistent with changes re PRO event view slugs ([PR/114 for PRO](https://github.com/moderntribe/events-pro/pull/114)).