### PR TITLE
Fix pathinfo support (#39736)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2432,7 +2432,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			// account for semi-pretty permalinks
 			if ( false !== strpos( get_option( 'permalink_structure' ), 'index.php' ) ) {
-				$event_url = home_url( '/index.php' );
+				$event_url = home_url( '/index.php/' );
 			} else {
 				$event_url = home_url( '/' );
 			}


### PR DESCRIPTION
Re [C#39736](https://central.tri.be/issues/39736), ensure there are slashes in all the right places for pathinfo-based permalinks.