### PR TITLE
Move base google data markup to abstract class; extend to event

### DIFF
--- a/src/Tribe/Google_Data_Markup.php
+++ b/src/Tribe/Google_Data_Markup.php
@@ -3,52 +3,48 @@
 /**
  * Handles output of Google structured data markup
  */
-class Tribe__Events__Google_Data_Markup {
+abstract class Tribe__Events__Google_Data_Markup {
 
-	/**
-	 * @var $instance
-	 */
-	private static $instance = null;
+	protected $filter = 'tribe_google_data';
 
 	/**
 	 * Compile the schema.org event data into an array
 	 */
-	private function build_data() {
-
+	protected function build_data() {
 		global $post;
-		$id  = $post->ID;
-
-		$events_data = array();
+		$id             = $post->ID;
+		$data           = array();
+		$excerpt_length = apply_filters( 'excerpt_length', 55 );
+		$excerpt        = wp_trim_words( $post->post_content, $excerpt_length, '&hellip;' );
 
 		// Index by ID: this will allow filter code to identify the actual event being referred to
 		// without injecting an additional property
-		$events_data[ $id ]               = new stdClass();
-		$events_data[ $id ]->{'@context'} = 'http://schema.org';
-		$events_data[ $id ]->{'@type'} = 'Event';
-		$events_data[ $id ]->name         = get_the_title();
+		$data[ $id ]               = new stdClass();
+		$data[ $id ]->{'@context'} = 'http://schema.org';
+		$data[ $id ]->{'@type'}    = 'Thing';
+		$data[ $id ]->name         = get_the_title();
+		$data[ $id ]->description  = $excerpt;
 		if ( has_post_thumbnail() ) {
-			$events_data[ $id ]->image = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
+			$data[ $id ]->image = wp_get_attachment_url( get_post_thumbnail_id( $id ) );
 		}
-		$events_data[ $id ]->url       = get_permalink( $post->ID );
-		$events_data[ $id ]->startDate = get_gmt_from_date( tribe_get_start_date( $post, true, Tribe__Events__Date_Utils::DBDATETIMEFORMAT ), 'c' );
-		$events_data[ $id ]->endDate   = get_gmt_from_date( tribe_get_end_date( $post, true, Tribe__Events__Date_Utils::DBDATETIMEFORMAT ), 'c' );
-		if ( tribe_has_venue( $id ) ) {
-			$events_data[ $id ]->location          = new stdClass();
-			$events_data[ $id ]->location->{'@type'} = 'Place';
-			$events_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
-			$events_data[ $id ]->location->address = strip_tags( str_replace( "\n", '', tribe_get_full_address( $post->ID ) ) );
-		}
+		$data[ $id ]->url = get_permalink( $id );
 
+		return $data;
+	}
+
+	protected function filter_data( $data ) {
 		/**
 		 * Allows the event data to be modifed by themes and other plugins.
 		 *
-		 * @param array $events_data objects representing the Google Markup for each event.
+		 * @param array $data objects representing the Google Markup for each event.
 		 */
-		$events_data = apply_filters( 'tribe_google_event_data', $events_data );
+		$data = apply_filters( $this->filter, $data );
 
 		// Strip the post ID indexing before returning
-		$events_data = array_values( $events_data );
-		return $events_data;
+		$data = array_values( $data );
+
+		return $data;
+
 	}
 
 	/**
@@ -56,27 +52,16 @@ class Tribe__Events__Google_Data_Markup {
 	 * @return string
 	 */
 	public function script_block() {
-		$events_data = $this->build_data();
-		$html        = '';
-		if ( ! empty( $events_data ) ) {
+		$data = $this->build_data();
+		$data = $this->filter_data( $data );
+
+		$html = '';
+		if ( ! empty( $data ) ) {
 			$html .= '<script type="application/ld+json">';
-			$html .= str_replace( '\/', '/', json_encode( $events_data ) );
+			$html .= str_replace( '\/', '/', json_encode( $data ) );
 			$html .= '</script>';
 		}
 
 		return $html;
 	}
-
-
-	/**
-	 * @return self
-	 */
-	public static function instance() {
-		if ( empty( self::$instance ) ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
 }

--- a/src/Tribe/Google_Data_Markup/Event.php
+++ b/src/Tribe/Google_Data_Markup/Event.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Handles output of Google structured data markup
+ */
+class Tribe__Events__Google_Data_Markup__Event extends Tribe__Events__Google_Data_Markup {
+
+	protected $filter = 'tribe_google_event_data';
+
+	/**
+	 * Compile the schema.org event data into an array
+	 */
+	protected function build_data() {
+		global $post;
+		$id  = $post->ID;
+
+		$event_data = parent::build_data();
+
+		$event_data[ $id ]->{'@type'} = 'Event';
+		$event_data[ $id ]->startDate = get_gmt_from_date( tribe_get_start_date( $post, true, Tribe__Events__Date_Utils::DBDATETIMEFORMAT ), 'c' );
+		$event_data[ $id ]->endDate   = get_gmt_from_date( tribe_get_end_date( $post, true, Tribe__Events__Date_Utils::DBDATETIMEFORMAT ), 'c' );
+		if ( tribe_has_venue( $id ) ) {
+			$event_data[ $id ]->location          = new stdClass();
+			$event_data[ $id ]->location->{'@type'} = 'Place';
+			$event_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
+			$event_data[ $id ]->location->address = strip_tags( str_replace( "\n", '', tribe_get_full_address( $post->ID ) ) );
+		}
+
+		return $event_data;
+
+	}
+
+}

--- a/src/Tribe/Template/Single_Event.php
+++ b/src/Tribe/Template/Single_Event.php
@@ -28,7 +28,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Single_Event' ) ) {
 		}
 
 		public function google_data_markup() {
-			$html = apply_filters( 'tribe_google_data_markup_json', Tribe__Events__Google_Data_Markup::instance()->script_block() );
+			$event_markup = new Tribe__Events__Google_Data_Markup__Event();
+			$html = apply_filters( 'tribe_google_data_markup_json', $event_markup->script_block() );
 			echo $html;
 		}
 


### PR DESCRIPTION
Moved google data markup to an abstract class, base "thing" properties are set in the abstract class, events, venues, and organizers will extend and add to the base data. Most properties are shared between schema.org objects and are pulled the same way from different wp post types, so this is keeping it DRY.

Also made it not be a singleton anymore because we have to support php 5.2 which doesn't have late static binding.

Ref: [C#39616](http://central.tri.be/issues/39616)