### PR TITLE
Feature/39045 daynum ids

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -644,7 +644,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 				$days[] = array(
 					'daynum'       => $day,
-					'daynum-id' => Tribe__Events__Utils__Id_Generator::generate_id( $day, 'css-ids' ),
+					'daynum-id' => Tribe__Events__Utils__Id_Generator::generate_id( $day, $day ),
 					'date'         => $date,
 					'events'       => $day_events,
 					'total_events' => $day_events->found_posts,

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -644,6 +644,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 				$days[] = array(
 					'daynum'       => $day,
+					'daynum-id' => Tribe__Events__Utils__Id_Generator::generate_id( $day, 'css-ids' ),
 					'date'         => $date,
 					'events'       => $day_events,
 					'total_events' => $day_events->found_posts,

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -7,8 +7,8 @@ class Tribe__Events__Utils__Id_Generator {
 
 	public static function generate_id( $string, $group = 'default' ) {
 
-		if ( ! is_string( $string ) ) {
-			throw new \InvalidArgumentException( 'First argument must be a string' );
+		if ( ! ( is_string( $string ) || ( is_int( $string ) ) ) ) {
+			throw new \InvalidArgumentException( 'First argument must be a string or an int' );
 		}
 
 		if ( ! is_string( $group ) ) {

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -25,7 +25,11 @@ class Tribe__Events__Utils__Id_Generator {
 		return $out;
 	}
 
-	public static function reset() {
-		self::$count = array();
+	public static function reset( $group = null ) {
+		if ( empty( $group ) ) {
+			self::$count = array();
+		} else {
+			self::$count[ $group ] = 0;
+		}
 	}
 }

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -3,4 +3,12 @@
 
 class Tribe__Events__Utils__Id_Generator {
 
+	protected static $count;
+
+	public static function generate_id( $string ) {
+		$out = $string . '-' . self::$count;
+		self::$count ++;
+
+		return $out;
+	}
 }

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -1,11 +1,15 @@
 <?php
 
-
 class Tribe__Events__Utils__Id_Generator {
 
 	protected static $count = array();
 
 	public static function generate_id( $string, $group = 'default' ) {
+
+		if (!is_string($string)) {
+			throw new \InvalidArgumentException('First argument must be a string');
+		}
+
 		if ( ! isset( self::$count[ $group ] ) ) {
 			self::$count[ $group ] = 0;
 		}

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -1,0 +1,6 @@
+<?php
+
+
+class Tribe__Events__Utils__Id_Generator {
+
+}

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -24,4 +24,8 @@ class Tribe__Events__Utils__Id_Generator {
 
 		return $out;
 	}
+
+	public static function reset() {
+		self::$count = array();
+	}
 }

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -1,5 +1,6 @@
 <?php
 
+
 class Tribe__Events__Utils__Id_Generator {
 
 	protected static $count = array();
@@ -8,6 +9,10 @@ class Tribe__Events__Utils__Id_Generator {
 
 		if ( ! is_string( $string ) ) {
 			throw new \InvalidArgumentException( 'First argument must be a string' );
+		}
+
+		if ( ! is_string( $group ) ) {
+			throw new \InvalidArgumentException( 'Group argument must be a string' );
 		}
 
 		if ( ! isset( self::$count[ $group ] ) ) {

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -11,7 +11,7 @@ class Tribe__Events__Utils__Id_Generator {
 			throw new \InvalidArgumentException( 'First argument must be a string or an int' );
 		}
 
-		if ( ! is_string( $group ) ) {
+		if ( ! ( is_string( $group ) || is_int( $group ) ) ) {
 			throw new \InvalidArgumentException( 'Group argument must be a string' );
 		}
 

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -3,11 +3,15 @@
 
 class Tribe__Events__Utils__Id_Generator {
 
-	protected static $count;
+	protected static $count = array();
 
-	public static function generate_id( $string ) {
-		$out = $string . '-' . self::$count;
-		self::$count ++;
+	public static function generate_id( $string, $group = 'default' ) {
+		if ( ! isset( self::$count[ $group ] ) ) {
+			self::$count[ $group ] = 0;
+		}
+
+		$out = $string . '-' . self::$count[ $group ];
+		self::$count[ $group ] ++;
 
 		return $out;
 	}

--- a/src/Tribe/Utils/Id_Generator.php
+++ b/src/Tribe/Utils/Id_Generator.php
@@ -6,8 +6,8 @@ class Tribe__Events__Utils__Id_Generator {
 
 	public static function generate_id( $string, $group = 'default' ) {
 
-		if (!is_string($string)) {
-			throw new \InvalidArgumentException('First argument must be a string');
+		if ( ! is_string( $string ) ) {
+			throw new \InvalidArgumentException( 'First argument must be a string' );
 		}
 
 		if ( ! isset( self::$count[ $group ] ) ) {

--- a/src/views/month/single-day.php
+++ b/src/views/month/single-day.php
@@ -18,7 +18,7 @@ $events_label = ( 1 === $day['total_events'] ) ? tribe_get_event_label_singular(
 ?>
 
 <!-- Day Header -->
-<div id="tribe-events-daynum-<?php echo $day['daynum'] ?>">
+<div id="tribe-events-daynum-<?php echo $day['daynum-id'] ?>">
 
 	<?php if ( $day['total_events'] > 0 && tribe_events_is_view_enabled( 'day' ) ) : ?>
 		<a href="<?php echo esc_url( tribe_get_day_link( $day['date'] ) ); ?>"><?php echo $day['daynum'] ?></a>

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -98,10 +98,15 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
 		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
 		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'tec', 'bar' );
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'tec', 'bar' );
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'tec', 'bar' );
 
 		\Tribe__Events__Utils__Id_Generator::reset( 'baz' );
 
-		$out = \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
-		$this->assertEquals( 'foo-0', $out );
+		$baz_out = \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+		$bar_out = \Tribe__Events__Utils__Id_Generator::generate_id( 'tec', 'bar' );
+		$this->assertEquals( 'foo-0', $baz_out );
+		$this->assertEquals( 'tec-4', $bar_out );
 	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -35,6 +35,7 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 	public function nonStringArguments() {
 		return [
 			[ array() ],
+			[ 12.9 ],
 			[ new \stdClass() ],
 			[ array( 'foo' ) ],
 			[ null ],

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -3,6 +3,11 @@ namespace TEC\Tests\Utils;
 
 class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 
+	public function tearDown() {
+		\Tribe__Events__Utils__Id_Generator::reset();
+		parent::tearDown();
+	}
+
 	/**
 	 * @test
 	 * it should be instantiatable

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -1,0 +1,13 @@
+<?php
+namespace TEC\Tests\Utils;
+
+class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$this->assertInstanceOf( 'Tribe__Events__Utils__Id_Generator', new \Tribe__Events__Utils__Id_Generator() );
+	}
+}

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -10,4 +10,16 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 	public function it_should_be_instantiatable() {
 		$this->assertInstanceOf( 'Tribe__Events__Utils__Id_Generator', new \Tribe__Events__Utils__Id_Generator() );
 	}
+
+	/**
+	 * @test
+	 * it should generate unique ids
+	 */
+	public function it_should_generate_unique_ids() {
+		$count = 5;
+		for ( $i = 0; $i < $count; $i ++ ) {
+			$generated_ids[] = \Tribe__Events__Utils__Id_Generator::generate_id( 'tec' );
+		}
+		$this->assertCount( $count, array_unique( $generated_ids ) );
+	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -35,7 +35,7 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 	public function nonStringArguments() {
 		return [
 			[ array() ],
-			[23],
+			[ 23 ],
 			[ new \stdClass() ],
 			[ array( 'foo' ) ],
 			[ null ],
@@ -49,9 +49,19 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 	 * @dataProvider nonStringArguments
 	 */
 	public function it_should_throw_when_passing_a_non_string_argument( $non_string_argument ) {
-
 		$this->setExpectedException( 'InvalidArgumentException' );
 
 		\Tribe__Events__Utils__Id_Generator::generate_id( $non_string_argument );
+	}
+
+	/**
+	 * @test
+	 * it should throw when passing a non string argument for group
+	 * @dataProvider nonStringArguments
+	 */
+	public function it_should_throw_when_passing_a_non_string_argument_for_group( $non_string_argument ) {
+		$this->setExpectedException( 'InvalidArgumentException' );
+
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', $non_string_argument );
 	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -35,7 +35,6 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 	public function nonStringArguments() {
 		return [
 			[ array() ],
-			[ 23 ],
 			[ new \stdClass() ],
 			[ array( 'foo' ) ],
 			[ null ],
@@ -63,5 +62,15 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		$this->setExpectedException( 'InvalidArgumentException' );
 
 		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', $non_string_argument );
+	}
+
+	/**
+	 * @test
+	 * it should accept an int as string arg
+	 */
+	public function it_should_accept_an_int_as_string_arg() {
+		$out = \Tribe__Events__Utils__Id_Generator::generate_id( 23 );
+
+		$this->assertEquals( '23-0', $out );
 	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -31,4 +31,16 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		$this->assertEquals( 'foo-0', \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'group-1' ) );
 		$this->assertEquals( 'baz-0', \Tribe__Events__Utils__Id_Generator::generate_id( 'baz', 'group-2' ) );
 	}
+
+	/**
+	 * @test
+	 * it should throw when passing a non string argument
+	 */
+	public function it_should_throw_when_passing_a_non_string_argument() {
+		$non_string_argument = array();
+
+		$this->setExpectedException('InvalidArgumentException');
+
+		\Tribe__Events__Utils__Id_Generator::generate_id( $non_string_argument );
+	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -32,14 +32,20 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		$this->assertEquals( 'baz-0', \Tribe__Events__Utils__Id_Generator::generate_id( 'baz', 'group-2' ) );
 	}
 
+	public function nonStringArguments() {
+		return [
+			[ array() ]
+		];
+	}
+
 	/**
 	 * @test
 	 * it should throw when passing a non string argument
+	 * @dataProvider nonStringArguments
 	 */
-	public function it_should_throw_when_passing_a_non_string_argument() {
-		$non_string_argument = array();
+	public function it_should_throw_when_passing_a_non_string_argument( $non_string_argument ) {
 
-		$this->setExpectedException('InvalidArgumentException');
+		$this->setExpectedException( 'InvalidArgumentException' );
 
 		\Tribe__Events__Utils__Id_Generator::generate_id( $non_string_argument );
 	}

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -89,4 +89,19 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 
 		$this->assertEquals( 'foo-0', $out );
 	}
+
+	/**
+	 * @test
+	 * it should allow for group resets
+	 */
+	public function it_should_allow_for_group_resets() {
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+		\Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+
+		\Tribe__Events__Utils__Id_Generator::reset( 'baz' );
+
+		$out = \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
+		$this->assertEquals( 'foo-0', $out );
+	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -79,4 +79,14 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 
 		$this->assertEquals( '23-0', $out );
 	}
+
+	/**
+	 * @test
+	 * it should accept an int as group arg
+	 */
+	public function it_should_accept_an_int_as_group_arg() {
+		$out = \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 23 );
+
+		$this->assertEquals( 'foo-0', $out );
+	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -22,4 +22,13 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		}
 		$this->assertCount( $count, array_unique( $generated_ids ) );
 	}
+
+	/**
+	 * @test
+	 * it should allow for the definition of an id group
+	 */
+	public function it_should_allow_for_the_definition_of_an_id_group() {
+		$this->assertEquals( 'foo-0', \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'group-1' ) );
+		$this->assertEquals( 'baz-0', \Tribe__Events__Utils__Id_Generator::generate_id( 'baz', 'group-2' ) );
+	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -107,6 +107,6 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 		$baz_out = \Tribe__Events__Utils__Id_Generator::generate_id( 'foo', 'baz' );
 		$bar_out = \Tribe__Events__Utils__Id_Generator::generate_id( 'tec', 'bar' );
 		$this->assertEquals( 'foo-0', $baz_out );
-		$this->assertEquals( 'tec-4', $bar_out );
+		$this->assertEquals( 'tec-3', $bar_out );
 	}
 }

--- a/tests/functional/Utils/Id_GeneratorTest.php
+++ b/tests/functional/Utils/Id_GeneratorTest.php
@@ -34,7 +34,12 @@ class Id_GeneratorTest extends \Tribe__Events__WP_UnitTestCase {
 
 	public function nonStringArguments() {
 		return [
-			[ array() ]
+			[ array() ],
+			[23],
+			[ new \stdClass() ],
+			[ array( 'foo' ) ],
+			[ null ],
+			[ false ]
 		];
 	}
 


### PR DESCRIPTION
Addresses https://central.tri.be/issues/39045

“On pages with both the main calendar and mini calendar widget, there will be multiple daynum-2, daynum-3, etc. style ID attributes in the markup which causes W3C validation to fail :(

It can also happen with months that don't fill up the full square grid of month view or the mini calendar, i.e. for months that have days from the preceding and following month on the calendar grid with it. So, e.g., a daynum-1 in two places on main calendar and in two places in the mini calendar widget, all 4 ids potentially on the same page.

Maybe better as a data attribute or something?”