### PR TITLE
added removed test

### DIFF
--- a/tests/functional/functions/template-tags/metaTest.php
+++ b/tests/functional/functions/template-tags/metaTest.php
@@ -30,4 +30,10 @@ class metaTest extends \WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider separated_field_inputs
+	 */
+	public function test_tribe_separated_field( $body, $sep, $field, $expected ) {
+		$this->assertEquals( $expected, tribe_separated_field( $body, $sep, $field ) );
+	}
 }


### PR DESCRIPTION
A test from the branch `feature/38899-better-field-separators` has been removed, this PR re-adds it.
Ticket: https://central.tri.be/issues/36584