### PR TITLE
Do not overwrite the query's found_posts param with the wrong total

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -628,11 +628,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			// we don't need this join since we already checked it
 			unset ( $args[ Tribe__Events__Main::TAXONOMY ] );
 
-			$result = tribe_get_events( $args, true );
-
-			$result->found_posts = count( $event_ids_on_date );
-
-			return $result;
+			return tribe_get_events( $args, true );
 		}
 
 		/**


### PR DESCRIPTION
Ensure we have accurate daily counts in month view. [C#39994](https://central.tri.be/issues/39994)