### PR TITLE
Revert change to admin slug made in ed9e9b6c1d (spotfix)

### DIFF
--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -136,7 +136,7 @@ if ( ! class_exists( 'Tribe__Events__Settings' ) ) {
 			// set instance variables
 			$this->menuName    = apply_filters( 'tribe_settings_menu_name', esc_html__( 'The Events Calendar', 'the-events-calendar' ) );
 			$this->requiredCap = apply_filters( 'tribe_settings_req_cap', 'manage_options' );
-			$this->adminSlug   = apply_filters( 'tribe_settings_admin_slug', 'the-events-calendar' );
+			$this->adminSlug   = apply_filters( 'tribe_settings_admin_slug', 'tribe-events-calendar' );
 			$this->errors      = get_option( 'tribe_settings_errors', array() );
 			$this->major_error = get_option( 'tribe_settings_major_error', false );
 			$this->sent_data   = get_option( 'tribe_settings_sent_data', array() );


### PR DESCRIPTION
Reverting a change to the admin slug made inadvertently in https://github.com/moderntribe/the-events-calendar/commit/ed9e9b6c1d494afde54b067873ffe591a455ecab: Filter Bar tests against this and expects the original value of `tribe_events_calendar` - and so it's also probable other addons/customizations do the same.