### PR TITLE
Explicitly set no_found_rows to false so we get a useful found_posts …

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -620,7 +620,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'end_date'               => $end_of_day,
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
-					'no_found_rows'          => true,
+					'no_found_rows'          => false,
 					'orderby'                => 'menu_order',
 				), $this->args
 			);


### PR DESCRIPTION
Try to ensure `set_found_posts()` works its magic and provides us with meaningful `found_posts` counts in our month view queries. 

[C#39994](https://central.tri.be/issues/39994)