### PR TITLE
Deprecated tribe_event_link(). Unified behavior of tribe_get_*_link()…

### DIFF
--- a/src/functions/template-tags/deprecated.php
+++ b/src/functions/template-tags/deprecated.php
@@ -296,6 +296,22 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			return tribe_get_events( $numResults, $catName );
 		}
 	}
+	if ( ! function_exists( 'tribe_event_link' ) ) {
+		/**
+		 * @deprecated
+		 *
+		 * Display link to a single event
+		 *
+		 * @param null|int $post Optional post ID
+		 *
+		 * @return string Link html
+		 */
+		function tribe_event_link( $post = null ) {
+			_deprecated_function( __FUNCTION__, '4.0', 'tribe_get_event_link()' );
+
+			echo apply_filters( 'tribe_event_link', tribe_get_event_link( $post ) );
+		}
+	}
 	if ( ! function_exists( 'events_displaying_past' ) ) {
 		/**
 		 * @deprecated

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -256,34 +256,31 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Single Event Link (Display)
-	 *
-	 * Display link to a single event
-	 *
-	 * @param null|int $post Optional post ID
-	 *
-	 * @return string Link html
-	 */
-	function tribe_event_link( $post = null ) {
-		// pass in whole post object to retain start date
-		echo apply_filters( 'tribe_event_link', tribe_get_event_link( $post ) );
-	}
-
-	/**
 	 * Single Event Link
 	 *
 	 * Get link to a single event
 	 *
-	 * @param int $event Optional post ID
+	 * @param int $postId Optional post ID
+	 * @param bool $full_link If true outputs a complete HTML <a> link, otherwise only the URL is output
 	 *
 	 * @return string
 	 */
-	function tribe_get_event_link( $event = null ) {
-		if ( '' == get_option( 'permalink_structure' ) ) {
-			return apply_filters( 'tribe_get_event_link', Tribe__Events__Main::instance()->getLink( 'single', $event ), $event );
+	function tribe_get_event_link( $postId = null, $full_link = false ) {
+
+		$url = Tribe__Events__Main::instance()->getLink( 'single', $postId );
+
+		if ( '' != get_option( 'permalink_structure' ) ) $url = trailingslashit( $url );
+
+		if ( $full_link ) {
+			$title_args = array( 'post' => $postId, 'echo' => false );
+			$name = the_title( $title_args );
+			$attr_title = the_title_attribute( $title_args );
+			$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '" title="'.$attr_title.'"">' . $name . '</a>' : false;
 		} else {
-			return trailingslashit( apply_filters( 'tribe_get_event_link', Tribe__Events__Main::instance()->getLink( 'single', $event ), $event ) );
+			$link = $url;
 		}
+
+		return apply_filters( 'tribe_get_event_link', $link, $postId, $full_link, $url );
 	}
 
 	/**

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -155,26 +155,33 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * Returns the event Organizer Name with a link to their single organizer page
 	 *
 	 * @param int  $postId    Can supply either event id or organizer id, if none specified, current post is used
-	 * @param bool $full_link If true displays full html links around organizers name, if false returns just the link without displaying it
+	 * @param bool $full_link If true outputs a complete HTML <a> link, otherwise only the URL is output
 	 * @param bool $echo      If true, echo the link, otherwise return
 	 *
 	 * @return string Organizer Name and Url
 	 */
-	function tribe_get_organizer_link( $postId = null, $full_link = true, $echo = true ) {
-		$postId = Tribe__Events__Main::postIdHelper( $postId );
+	function tribe_get_organizer_link( $postId = null, $full_link = true, $echo = false ) {
+
+		// As of TEC 4.0 this argument is deprecated
+		// If needed precede the call to this function with echo
+		if ( $echo != false ) _deprecated_argument( __FUNCTION__, '4.0' );
+
+		$org_id = tribe_get_organizer_id( $postId );
 		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
-			$url = esc_url_raw( get_permalink( tribe_get_organizer_id( $postId ) ) );
+			$url = esc_url_raw( get_permalink( $org_id ) );
 			if ( $full_link ) {
-				$name = tribe_get_organizer( $postId );
-				$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '">' . $name . '</a>' : false;
-				$link = apply_filters( 'tribe_get_organizer_link', $link, $postId, $echo, $url, $name );
+				$name = tribe_get_organizer( $org_id );
+				$attr_title = the_title_attribute( array( 'post' => $org_id, 'echo' => false ) );
+				$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '" title="'.$attr_title.'"">' . $name . '</a>' : false;
 			} else {
 				$link = $url;
 			}
+
+			// Remove this in or before 5.x to fully deprecate the echo arg
 			if ( $echo ) {
-				echo $link;
+				echo apply_filters( 'tribe_get_organizer_link', $link, $postId, $echo, $url );
 			} else {
-				return $link;
+				return apply_filters( 'tribe_get_organizer_link', $link, $postId, $full_link, $url );
 			}
 		}
 	}

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -89,31 +89,24 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * Returns or display the event Venue Name with a link to the venue
 	 *
 	 * @param int  $postId  Can supply either event id or venue id, if none specified, current post is used
-	 * @param bool $display If true displays full html links around venue's name, if false returns just the link without displaying it
+	 * @param bool $full_link If true outputs a complete HTML <a> link, otherwise only the URL is output
 	 *
 	 * @return string Venue if $display is set to false, void if it's set to true.
 	 */
-	function tribe_get_venue_link( $postId = null, $display = true ) {
+	function tribe_get_venue_link( $postId = null, $full_link = true ) {
 
-		$url = '';
+		$ven_id = tribe_get_venue_id( $postId );
+		$url = esc_url_raw( get_permalink( $ven_id ) );
 
-		if ( $venue_id = tribe_get_venue_id( $postId ) ) {
-			$url = esc_url_raw( get_permalink( $venue_id ) );
-		}
-
-		if ( $display && $url != '' ) {
-			$venue_name = tribe_get_venue( $postId );
-			$link       = '<a href="' . esc_url( $url ) . '">' . $venue_name . '</a>';
+		if ( $full_link ) {
+			$name = tribe_get_venue( $ven_id );
+			$attr_title = the_title_attribute( array( 'post' => $ven_id, 'echo' => false ) );
+			$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '" title="'.$attr_title.'"">' . $name . '</a>' : false;
 		} else {
 			$link = $url;
 		}
-		$link = apply_filters( 'tribe_get_venue_link', $link, $postId, $display, $url );
 
-		if ( $display ) {
-			echo $link;
-		} else {
-			return $link;
-		}
+		return apply_filters( 'tribe_get_venue_link', $link, $postId, $full_link, $url );
 	}
 
 	/**


### PR DESCRIPTION
Modified the behavior of tribe_get_event_link(), tribe_get_organizer_link(), and tribe_get_venue_link() to make them consistent and always filterable.

Ref: [C#38492](https://central.tri.be/issues/38492)

Rel: https://github.com/moderntribe/the-events-calendar/pull/357, https://github.com/moderntribe/events-pro/pull/155. https://github.com/moderntribe/events-eventbrite/pull/82