### PR TITLE
restoring the accidentally removed tribe_get_render_context

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1375,4 +1375,21 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$value = call_user_func( array( $defaults, $field ) );
 		return $value;
 	}
+
+	/**
+	 * Gets the render context of the given query
+	 *
+	 * @param WP_Query $query Query object
+	 * @return string
+	 */
+	function tribe_get_render_context( $query = null ) {
+		global $wp_query;
+		if ( ! $query instanceof WP_Query ) {
+			$query = $wp_query;
+		}
+		if ( empty( $query->query['tribe_render_context'] ) ) {
+			return 'default';
+		}
+		return $query->query['tribe_render_context'];
+	}
 }


### PR DESCRIPTION
Somewhere along the way this was accidentally removed.

See: https://central.tri.be/issues/38488