### PR TITLE
Repoint tickets submodule to new tickets repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "common"]
 	path = common
 	url = git@github.com:moderntribe/tribe-common.git
+[submodule "vendor/tickets"]
+	path = vendor/tickets
+	url = git@github.com:moderntribe/event-tickets.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "vendor/select2"]
 	path = vendor/select2
 	url = git://github.com/ivaynberg/select2.git
-[submodule "vendor/tickets"]
-	path = vendor/tickets
-	url = git@github.com:moderntribe/tickets.git
 [submodule "common"]
 	path = common
 	url = git@github.com:moderntribe/tribe-common.git


### PR DESCRIPTION
Now that the ticket repo has been renamed, let's point to the new GitHub repo.