### PR TITLE
Form correct strings for start/end date (spotfix | props: jazbek)

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -314,16 +314,16 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 
 		// If the event-specific timezone is suitable, we can obtain it without any conversion work
 		if ( $use_event_tz || ( $use_site_tz && $site_zone_is_event_zone ) ) {
-			$datetime = isset( $event->{"Event{$type}StartDate"} )
-				? $event->{"Event{$type}StartDate"}
+			$datetime = isset( $event->{"Event{$type}Date"} )
+				? $event->{"Event{$type}Date"}
 				: get_post_meta( $event->ID, "_Event{$type}Date", true );
 
 			return strtotime( $datetime );
 		}
 
 		// Otherwise lets load the event's UTC time and convert it
-		$datetime = isset( $event->{"Event{$type}StartDateUTC"} )
-			? $event->{"Event{$type}StartDateUTC"}
+		$datetime = isset( $event->{"Event{$type}DateUTC"} )
+			? $event->{"Event{$type}DateUTC"}
 			: get_post_meta( $event->ID, "_Event{$type}DateUTC", true );
 
 		$tzstring = ( self::SITE_TIMEZONE === $timezone )


### PR DESCRIPTION
As Jessica highlighted - we were testing for the existence of properties but weren't forming the property name correctly (ie, instead of checking for `EventStartDate` we were checking for `EventStartStartDate`) ... this fixes that.