### PR TITLE
Prevent fatal when TEC is upgraded and other plugins are not

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -242,7 +242,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			$this->maybe_set_common_lib_info();
 
-			add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 1 );
+			// let's initialize tec silly-early to avoid fatals with upgrades from 3.x to 4.x
+			add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 0 );
 		}
 
 		public function plugins_loaded() {


### PR DESCRIPTION
TEC's plugins_loaded was firing at the same time as some of our other plugins which wasn't early enough to initialize the new autoloader for 4.0. This ensures that TEC is initialized before any other plugin regardless of 3.x or 4.x release.

See: https://central.tri.be/issues/40281