### PR TITLE
Bring back tribe_events_resource_url()

### DIFF
--- a/src/Tribe/Asset/Admin.php
+++ b/src/Tribe/Asset/Admin.php
@@ -12,7 +12,7 @@ class Tribe__Events__Asset__Admin extends Tribe__Events__Asset__Abstract_Asset {
 			)
 		);
 
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'events-admin.js' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'events-admin.js' ), true );
 
 		wp_enqueue_script( $this->prefix . '-admin', $path, $deps, $this->filter_js_version(), true );
 	}

--- a/src/Tribe/Asset/Admin_Menu.php
+++ b/src/Tribe/Asset/Admin_Menu.php
@@ -4,7 +4,7 @@
 class Tribe__Events__Asset__Admin_Menu extends Tribe__Events__Asset__Abstract_Asset {
 
 	public function handle() {
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'admin-menu.css' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'admin-menu.css' ), true );
 		wp_enqueue_style( $this->prefix . '-admin-menu', $path, array(), Tribe__Events__Main::VERSION );
 	}
 }

--- a/src/Tribe/Asset/Admin_Ui.php
+++ b/src/Tribe/Asset/Admin_Ui.php
@@ -4,7 +4,7 @@
 class Tribe__Events__Asset__Admin_Ui extends Tribe__Events__Asset__Abstract_Asset {
 
 	public function handle() {
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'events-admin.css' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'events-admin.css' ), true );
 		wp_enqueue_style( $this->prefix . '-admin-ui', $path, array(), Tribe__Events__Main::VERSION );
 	}
 }

--- a/src/Tribe/Asset/Ajax_Calendar.php
+++ b/src/Tribe/Asset/Ajax_Calendar.php
@@ -10,7 +10,7 @@ class Tribe__Events__Asset__Ajax_Calendar extends Tribe__Events__Asset__Abstract
 			$this->prefix . '-calendar-script',
 		) );
 		$ajax_data = array( 'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ) );
-		$path      = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-events-ajax-calendar.js' ), true );
+		$path      = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-events-ajax-calendar.js' ), true );
 
 		$handle = 'the-events-calendar';
 		wp_enqueue_script( $handle, $path, $deps, $this->filter_js_version(), true );

--- a/src/Tribe/Asset/Ajax_Dayview.php
+++ b/src/Tribe/Asset/Ajax_Dayview.php
@@ -8,7 +8,7 @@ class Tribe__Events__Asset__Ajax_Dayview extends Tribe__Events__Asset__Abstract_
 			'ajaxurl'   => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 			'post_type' => Tribe__Events__Main::POSTTYPE,
 		);
-		$path      = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-events-ajax-day.js' ), true );
+		$path      = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-events-ajax-day.js' ), true );
 
 		$handle = 'tribe-events-ajax-day';
 		wp_enqueue_script( $handle, $path, array( 'tribe-events-bar' ), $this->filter_js_version(), true );

--- a/src/Tribe/Asset/Ajax_List.php
+++ b/src/Tribe/Asset/Ajax_List.php
@@ -10,7 +10,7 @@ class Tribe__Events__Asset__Ajax_List extends Tribe__Events__Asset__Abstract_Ass
 			'ajaxurl'     => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 			'tribe_paged' => $tribe_paged,
 		);
-		$path        = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-events-ajax-list.js' ), true );
+		$path        = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-events-ajax-list.js' ), true );
 
 		$handle = 'tribe-events-list';
 		wp_enqueue_script( $handle, $path, $deps, $this->filter_js_version(), true );

--- a/src/Tribe/Asset/Calendar_Script.php
+++ b/src/Tribe/Asset/Calendar_Script.php
@@ -5,7 +5,7 @@ class Tribe__Events__Asset__Calendar_Script extends Tribe__Events__Asset__Abstra
 
 	public function handle() {
 		$deps   = array_merge( $this->deps, array( 'jquery' ), Tribe__Events__Template_Factory::get_vendor_scripts() );
-		$path   = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-events.js' ), true );
+		$path   = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-events.js' ), true );
 		$handle = $this->prefix . '-calendar-script';
 		wp_enqueue_script( $handle, $path, $deps, $this->filter_js_version() );
 

--- a/src/Tribe/Asset/Ecp_Plugins.php
+++ b/src/Tribe/Asset/Ecp_Plugins.php
@@ -5,7 +5,7 @@ class Tribe__Events__Asset__Ecp_Plugins extends Tribe__Events__Asset__Abstract_A
 
 	public function handle() {
 		$deps = array_merge( $this->deps, array( 'jquery' ) );
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'jquery-ecp-plugins.js' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'jquery-ecp-plugins.js' ), true );
 		wp_enqueue_script( $this->prefix . '-ecp-plugins', $path, $deps, $this->filter_js_version() );
 	}
 }

--- a/src/Tribe/Asset/Events_Css.php
+++ b/src/Tribe/Asset/Events_Css.php
@@ -55,7 +55,7 @@ class Tribe__Events__Asset__Events_Css extends Tribe__Events__Asset__Abstract_As
 			} else {
 
 				// get full URL
-				$url = tribe_resource_url( $css_file );
+				$url = tribe_events_resource_url( $css_file );
 
 				// get the minified file
 				$url = Tribe__Events__Template_Factory::getMinFile( $url, true );

--- a/src/Tribe/Asset/Settings.php
+++ b/src/Tribe/Asset/Settings.php
@@ -5,7 +5,7 @@ class Tribe__Events__Asset__Settings extends Tribe__Events__Asset__Abstract_Asse
 
 	public function handle() {
 		$deps = array_merge( $this->deps, array( 'jquery' ) );
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-settings.js' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-settings.js' ), true );
 		wp_enqueue_script( $this->prefix . '-settings', $path, $deps, $this->filter_js_version(), true );
 	}
 }

--- a/src/Tribe/Asset/Tribe_Events_Bar.php
+++ b/src/Tribe/Asset/Tribe_Events_Bar.php
@@ -11,7 +11,7 @@ class Tribe__Events__Asset__Tribe_Events_Bar extends Tribe__Events__Asset__Abstr
 			$this->prefix . '-jquery-resize',
 			Tribe__Events__Template_Factory::get_placeholder_handle(),
 		) );
-		$path = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'tribe-events-bar.js' ), true );
+		$path = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'tribe-events-bar.js' ), true );
 		wp_enqueue_script( $this->prefix . '-bar', $path, $deps, $this->filter_js_version() );
 	}
 }

--- a/src/Tribe/Embedded_Maps.php
+++ b/src/Tribe/Embedded_Maps.php
@@ -163,7 +163,7 @@ class Tribe__Events__Embedded_Maps {
 		wp_enqueue_script( 'tribe_events_google_maps_api', $url, array(), false, true );
 
 		// Setup our own script used to initialize each map
-		$url = Tribe__Events__Template_Factory::getMinFile( tribe_resource_url( 'embedded-map.js' ), true );
+		$url = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'embedded-map.js' ), true );
 		wp_enqueue_script( self::MAP_HANDLE, $url, array( 'tribe_events_google_maps_api' ), false, true );
 
 		$this->map_script_enqueued = true;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1774,7 +1774,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			// admin stylesheet - only load admin stylesheet when on Tribe pages
 			if ( $admin_helpers->is_screen() ) {
-				wp_enqueue_style( self::POSTTYPE . '-admin', tribe_resource_url( 'events-admin.css' ), array(), apply_filters( 'tribe_events_css_version', self::VERSION ) );
+				wp_enqueue_style( self::POSTTYPE . '-admin', tribe_events_resource_url( 'events-admin.css' ), array(), apply_filters( 'tribe_events_css_version', self::VERSION ) );
 			}
 
 			// UI admin

--- a/src/functions/template-tags/deprecated.php
+++ b/src/functions/template-tags/deprecated.php
@@ -1461,20 +1461,6 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Returns or echoes a url to a file in the Events Calendar plugin resources directory
-	 *
-	 * @category Events
-	 * @param string $resource the filename of the resource
-	 * @param bool   $echo     whether or not to echo the url
-	 *
-	 * @return string
-	 **/
-	function tribe_events_resource_url( $resource, $echo = false ) {
-		_deprecated_function( __FUNCTION__, '4.0', 'tribe_resource_url' );
-		return tribe_resource_url( $resource, $echo );
-	}
-
-	/**
 	 * Formatted Date
 	 *
 	 * Returns formatted date

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1435,7 +1435,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$url = apply_filters( 'tribe_events_resource_url', $url, $resource );
 
 		if ( $echo ) {
-			echo $url;
+			echo esc_url( $url );
 		}
 
 		return $url;

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -505,7 +505,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$before = wpautop( $before );
 		$before = do_shortcode( stripslashes( shortcode_unautop( $before ) ) );
 		$before = '<div class="tribe-events-before-html">' . $before . '</div>';
-		$before = $before . '<span class="tribe-events-ajax-loading"><img class="tribe-events-spinner-medium" src="' . tribe_resource_url( 'images/tribe-loading.gif' ) . '" alt="' . sprintf( esc_html__( 'Loading %s', 'the-events-calendar' ), $events_label_plural ) . '" /></span>';
+		$before = $before . '<span class="tribe-events-ajax-loading"><img class="tribe-events-spinner-medium" src="' . tribe_events_resource_url( 'images/tribe-loading.gif' ) . '" alt="' . sprintf( esc_html__( 'Loading %s', 'the-events-calendar' ), $events_label_plural ) . '" /></span>';
 
 		echo apply_filters( 'tribe_events_before_html', $before );
 	}
@@ -1391,5 +1391,53 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			return 'default';
 		}
 		return $query->query['tribe_render_context'];
+	}
+	/**
+	 * Returns or echoes a url to a file in the Events Calendar plugin resources directory
+	 *
+	 * @category Events
+	 * @param string $resource the filename of the resource
+	 * @param bool   $echo     whether or not to echo the url
+	 * @param string $root_dir directory to hunt for resource files (src or common)
+	 *
+	 * @return string
+	 **/
+	function tribe_events_resource_url( $resource, $echo = false, $root_dir = 'src' ) {
+		$extension = pathinfo( $resource, PATHINFO_EXTENSION );
+
+		if ( 'src' !== $root_dir ) {
+			return tribe_resource_url( $resource, $echo, $root_dir );
+		}
+
+		$resources_path = $root_dir . '/resources/';
+		switch ( $extension ) {
+			case 'css':
+				$resource_path = $resources_path .'css/';
+				break;
+			case 'js':
+				$resource_path = $resources_path .'js/';
+				break;
+			case 'scss':
+				$resource_path = $resources_path .'scss/';
+				break;
+			default:
+				$resource_path = $resources_path;
+				break;
+		}
+
+		$path = $resource_path . $resource;
+
+		$url  = plugins_url( Tribe__Events__Main::instance()->plugin_dir . $path );
+
+		/**
+		 * Deprected the tribe_events_resource_url filter in 4.0 in favor of tribe_resource_url. Remove in 5.0
+		 */
+		$url = apply_filters( 'tribe_events_resource_url', $url, $resource );
+
+		if ( $echo ) {
+			echo $url;
+		}
+
+		return $url;
 	}
 }


### PR DESCRIPTION
When The Events Calendar and Event Tickets are both active, the common library's tribe_resource_url() function returns an incorrect URL for TEC resources when Tickets is the plugin that runs common libs.

See: https://central.tri.be/issues/40451