### PR TITLE
Move Tribe__Capabilities back to Tribe__Events__Capabilities

### DIFF
--- a/src/Tribe/Capabilities.php
+++ b/src/Tribe/Capabilities.php
@@ -1,0 +1,115 @@
+<?php
+
+class Tribe__Events__Capabilities {
+	private $cap_aliases = array(
+		'editor' => array( // full permissions to a post type
+			'read',
+			'read_private_posts',
+			'edit_posts',
+			'edit_others_posts',
+			'edit_private_posts',
+			'edit_published_posts',
+			'delete_posts',
+			'delete_others_posts',
+			'delete_private_posts',
+			'delete_published_posts',
+			'publish_posts',
+		),
+		'author' => array( // full permissions for content the user created
+			'read',
+			'edit_posts',
+			'edit_published_posts',
+			'delete_posts',
+			'delete_published_posts',
+			'publish_posts',
+		),
+		'contributor' => array( // create, but not publish
+			'read',
+			'edit_posts',
+			'delete_posts',
+		),
+		'subscriber' => array( // read only
+			'read',
+		),
+	);
+
+	/**
+	 * Grant caps for the given post type to the given role
+	 *
+	 * @param string $post_type The post type to grant caps for
+	 * @param string $role_id The role receiving the caps
+	 * @param string $level The capability level to grant (see the list of caps above)
+	 *
+	 * @return bool false if the action failed for some reason, otherwise true
+	 */
+	public function register_post_type_caps( $post_type, $role_id, $level = '' ) {
+		if ( empty( $level ) ) {
+			$level = $role_id;
+		}
+		if ( $level == 'administrator' ) {
+			$level = 'editor';
+		}
+		if ( ! isset( $this->cap_aliases[ $level ] ) ) {
+			return false;
+		}
+		$role = get_role( $role_id );
+		if ( ! $role ) {
+			return false;
+		}
+		$pto = get_post_type_object( $post_type );
+		if ( empty( $pto ) ) {
+			return false;
+		}
+
+		foreach ( $this->cap_aliases[ $level ] as $alias ) {
+			if ( isset( $pto->cap->$alias ) ) {
+				$role->add_cap( $pto->cap->$alias );
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Remove all caps for the given post type from the given role
+	 *
+	 * @param string $post_type The post type to remove caps for
+	 * @param string $role_id The role which is losing caps
+	 *
+	 * @return bool false if the action failed for some reason, otherwise true
+	 */
+	public function remove_post_type_caps( $post_type, $role_id ) {
+		$role = get_role( $role_id );
+		if ( ! $role ) {
+			return false;
+		}
+		foreach ( $role->capabilities as $cap => $has ) {
+			if ( strpos( $cap, $post_type ) !== false ) {
+				$role->remove_cap( $cap );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Set the initial capabilities for events and related post types on default roles
+	 *
+	 * @return void
+	 */
+	public function set_initial_caps() {
+		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
+			$this->register_post_type_caps( Tribe__Events__Main::POSTTYPE, $role );
+		}
+	}
+
+	/**
+	 * Remove capabilities for events and related post types from default roles
+	 *
+	 * @return void
+	 */
+	public function remove_all_caps() {
+		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
+			$this->remove_post_type_caps( Tribe__Events__Main::POSTTYPE, $role );
+		}
+	}
+}

--- a/src/Tribe/Deactivation.php
+++ b/src/Tribe/Deactivation.php
@@ -16,7 +16,7 @@ class Tribe__Events__Deactivation extends Tribe__Abstract_Deactivation {
 	 * Remove event-related capabilities
 	 */
 	private function clear_capabilities() {
-		$capabilities = new Tribe__Capabilities();
+		$capabilities = new Tribe__Events__Capabilities();
 		$capabilities->remove_all_caps();
 	}
 

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -139,7 +139,7 @@ class Tribe__Events__Updater {
 	}
 
 	public function set_capabilities() {
-		$capabilities = new Tribe__Capabilities();
+		$capabilities = new Tribe__Events__Capabilities();
 		add_action( 'wp_loaded', array( $capabilities, 'set_initial_caps' ) );
 		add_action( 'wp_loaded', array( $this, 'reload_current_user' ), 11, 0 );
 	}


### PR DESCRIPTION
It shouldn't be generic

Related: https://github.com/moderntribe/tribe-common/pull/7

See: https://central.tri.be/issues/40455