### PR TITLE
Tickets metabox out of place?

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -473,9 +473,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 
-			add_action( 'add_meta_boxes', array( 'Tribe__Tickets__Metabox', 'maybe_add_meta_box' ) );
-			add_action( 'admin_enqueue_scripts', array( 'Tribe__Tickets__Metabox', 'add_admin_scripts'  ) );
-
 			add_action( 'wp', array( $this, 'issue_noindex' ) );
 			add_action( 'plugin_row_meta', array( $this, 'addMetaLinks' ), 10, 2 );
 			// organizer and venue


### PR DESCRIPTION
This Pull request is more of a question to @borkweb in regards to if these lines belong here or not. 
Both @mastromktg and @WayneStratton reported this problem this week. Seem like when you open the administration it gives you the following error;

```
'Tribe__Tickets__Metabox' not found in /wp-includes/plugin.php on line 503
```

Could be:
1. These action were left there, by mistake.
2. The Autoloader is not working properly.

If it's the first one just merge the PR, if not the problem seems to be that our autoloader method doesn't take in consideration `Tribe__Tickets` as a prefix.

https://github.com/moderntribe/the-events-calendar/blob/release/121/src/Tribe/Main.php#L4481-L4502