### PR TITLE
Support wp_get_document_title in response to WP 4.4 deprecated wp_title

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -317,6 +317,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [unreleased] unreleased =
+
+* Tweak - Add support for wp_get_document_title in response to the WordPress 4.4 deprecation of wp_title
+
 = [3.12.3] 2015-10-01 =
 
 * Fix - Ensure daily counts in month view are accurate (our thanks to @communityanswers in the support forums for highlighting this)

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -339,7 +339,7 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 	 * @return mixed|void
 	 */
 	final public function title_tag( $title, $sep = null ) {
-		// WP >= 4.4 has deprecated wp_title. This conditional (and the lower onw) adds support for
+		// WP >= 4.4 has deprecated wp_title. This conditional (and the lower one) adds support for
 		// the new and improved wp_get_document_title method and subsequent document_title_parts filter
 		if ( 'document_title_parts' === current_filter() ) {
 			$sep = apply_filters( 'document_title_separator', '-' );

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -95,8 +95,11 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 		// hide sensitive event info if post is password protected
 		add_action( 'the_post', array( $this, 'manage_sensitive_info' ) );
 
-		// implement a filter for the page title
+		// implement a filter for the page title. Support WordPress < 4.4
 		add_filter( 'wp_title', array( $this, 'title_tag' ), 10, 2 );
+
+		// implement a filter for the page title. Support WordPress >= 4.4
+		add_filter( 'document_title_parts', array( $this, 'title_tag' ) );
 
 		// add body class
 		add_filter( 'body_class', array( $this, 'body_class' ) );
@@ -330,15 +333,30 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 	/**
 	 * Apply filter to the title tag
 	 *
-	 * @param string      $title
+	 * @param string|array $title
 	 * @param string|null $sep
 	 *
 	 * @return mixed|void
 	 */
 	final public function title_tag( $title, $sep = null ) {
-		$new_title = $this->get_title( $title, $sep );
+		// WP >= 4.4 has deprecated wp_title. This conditional (and the lower onw) adds support for
+		// the new and improved wp_get_document_title method and subsequent document_title_parts filter
+		if ( 'document_title_parts' === current_filter() ) {
+			$sep = apply_filters( 'document_title_separator', '-' );
+			$the_title = $title['title'];
+		} else {
+			$the_title = $title;
+		}
 
-		return apply_filters( 'tribe_events_title_tag', $new_title, $title, $sep );
+		$new_title = $this->get_title( $the_title, $sep );
+		$the_title = apply_filters( 'tribe_events_title_tag', $new_title, $the_title, $sep );
+
+		if ( 'document_title_parts' === current_filter() ) {
+			$title['title'] = $the_title;
+			return $title;
+		}
+
+		return $the_title;
 	}
 
 	/**

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -332,8 +332,9 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 				return;
 			}
 
-			// Wait until late in the wp_title hook to actually make a change - this should allow single event titles
+			// Wait until late in the wp_title|document_title_parts hook to actually make a change - this should allow single event titles
 			// to be used within the title element itself
+			add_filter( 'document_title_parts', array( __CLASS__, 'modify_global_post_title' ), 1000 );
 			add_filter( 'wp_title', array( __CLASS__, 'modify_global_post_title' ), 1000 );
 		}
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -597,7 +597,14 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	function tribe_events_the_header_attributes( $current_view = null ) {
 		$attrs               = array();
 		$current_view        = ! empty( $current_view ) ? $current_view : basename( tribe_get_current_template() );
-		$attrs['data-title'] = wp_title( '|', false, 'right' );
+
+		// wp_title was deprecated in WordPress 4.4. Fetch the document title with the new function (added in 4.4) if available
+		if ( function_exists( 'wp_get_document_title' ) ) {
+			$attrs['data-title'] = wp_get_document_title();
+		} else {
+			$attrs['data-title'] = wp_title( '|', false, 'right' );
+		}
+
 		switch ( $current_view ) {
 			case 'month.php' :
 				$attrs['data-view']    = 'month';


### PR DESCRIPTION
See: https://central.tri.be/issues/40833