### PR TITLE
Ensure rewrite rules included translated forms for "tag" and "category" (#40579)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -108,9 +108,15 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		protected static $instance;
 		public $rewriteSlug = 'events';
 		public $rewriteSlugSingular = 'event';
-		public $taxRewriteSlug = 'event/category';
-		public $tagRewriteSlug = 'event/tag';
+		public $category_slug = 'category';
+		public $tag_slug = 'tag';
 		public $monthSlug = 'month';
+
+		/** @deprecated 4.0 */
+		public $taxRewriteSlug = 'event/category';
+
+		/** @deprecated 4.0 */
+		public $tagRewriteSlug = 'event/tag';
 
 		/** @var Tribe__Events__Admin__Timezone_Settings */
 		public $timezone_settings;
@@ -667,8 +673,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->pluginName = $this->plugin_name            = esc_html__( 'The Events Calendar', 'the-events-calendar' );
 			$this->rewriteSlug                                = $this->getRewriteSlug();
 			$this->rewriteSlugSingular                        = $this->getRewriteSlugSingular();
-			$this->taxRewriteSlug                             = $this->getTaxRewriteSlug();
-			$this->tagRewriteSlug                             = $this->getTagRewriteSlug();
+			$this->category_slug                              = $this->get_category_slug();
+			$this->tag_slug                                   = $this->get_tag_slug();
+			$this->taxRewriteSlug                             = $this->rewriteSlug . '/' . $this->category_slug;
+			$this->tagRewriteSlug                             = $this->rewriteSlug . '/' . $this->tag_slug;
 			$this->monthSlug                                  = sanitize_title( __( 'month', 'the-events-calendar' ) );
 			$this->listSlug                               	  = sanitize_title( __( 'list', 'the-events-calendar' ) );
 			$this->upcomingSlug                               = sanitize_title( __( 'upcoming', 'the-events-calendar' ) );
@@ -1192,7 +1200,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					'hierarchical'          => true,
 					'update_count_callback' => '',
 					'rewrite'               => array(
-						'slug'         => $this->taxRewriteSlug,
+						'slug'         => $this->rewriteSlug . '/' . $this->category_slug,
 						'with_front'   => false,
 						'hierarchical' => true,
 					),
@@ -1233,25 +1241,75 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Get taxonomy rewrite slug
+		 * Get taxonomy rewrite slug.
 		 *
-		 * @return mixed|void
+		 * This method returns a concatenation of the base rewrite slug (ie "events") and the taxonomy slug
+		 * (ie "category"). If you only wish the taxonomy slug itself, you should call the get_tax_slug()
+		 * method.
+		 *
+		 * @deprecated 4.0 please use getRewriteSlug() and get_category_slug() instead
+		 *
+		 * @return string
 		 */
 		public function getTaxRewriteSlug() {
-			$slug = $this->getRewriteSlug() . '/' . sanitize_title( __( 'category', 'the-events-calendar' ) );
+			_deprecated_function( __CLASS__ . '::' . __METHOD__, '4.0', 'Tribe__Events__Main::get_category_slug' );
 
+			$slug = $this->getRewriteSlug() . '/' . $this->category_slug;
+
+			/**
+			 * @deprecated since 4.0
+			 */
 			return apply_filters( 'tribe_events_category_rewrite_slug', $slug );
 		}
 
 		/**
-		 * Get tag rewrite slug
+		 * Returns the string to be used as the taxonomy slug.
 		 *
-		 * @return mixed|void
+		 * @return string
+		 */
+		public function get_category_slug() {
+			/**
+			 * Provides an opportunity to modify the category slug.
+			 *
+			 * @var string
+			 */
+			return apply_filters( 'tribe_events_category_slug', sanitize_title( __( 'category', 'the-events-calendar' ) ) );
+		}
+
+		/**
+		 * Get tag rewrite slug.
+		 *
+		 * This method returns a concatenation of the base rewrite slug (ie "events") and the tag taxonomy slug
+		 * (ie "tag"). If you only wish the taxonomy slug itself, you should call the get_tag_slug()
+		 * method.
+		 *
+		 * @deprecated 4.0 please use getRewriteSlug() and get_tag_slug() instead
+		 *
+		 * @return string
 		 */
 		public function getTagRewriteSlug() {
-			$slug = $this->getRewriteSlug() . '/' . sanitize_title( __( 'tag', 'the-events-calendar' ) );
+			_deprecated_function( __CLASS__ . '::' . __METHOD__, '4.0', 'Tribe__Events__Main::get_tag_slug' );
 
+			$slug = $this->getRewriteSlug() . '/' . $this->tag_slug;
+
+			/**
+			 * @deprecated since 4.0
+			 */
 			return apply_filters( 'tribe_events_tag_rewrite_slug', $slug );
+		}
+
+		/**
+		 * Returns the string to be used as the tag slug.
+		 *
+		 * @return string
+		 */
+		public function get_tag_slug() {
+			/**
+			 * Provides an opportunity to modify the tag slug.
+			 *
+			 * @var string
+			 */
+			return apply_filters( 'tribe_events_tag_slug', sanitize_title( __( 'tag', 'the-events-calendar' ) ) );
 		}
 
 		/**

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -226,6 +226,8 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 		 * @return object         Return Base Slugs with l10n variations
 		 */
 		public function get_bases( $method = 'regex' ) {
+			$tec = Tribe__Events__Main::instance();
+
 			/**
 			 * If you want to modify the base slugs before the i18n happens filter this use this filter
 			 * All the bases need to have a key and a value, they might be the same or not.
@@ -238,12 +240,12 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 			 * @var array $bases
 			 */
 			$bases = apply_filters( 'tribe_events_rewrite_base_slugs', array(
-				'month' => array( 'month', Tribe__Events__Main::instance()->monthSlug ),
-				'list' => array( 'list', Tribe__Events__Main::instance()->listSlug ),
-				'today' => array( 'today', Tribe__Events__Main::instance()->todaySlug ),
-				'day' => array( 'day', Tribe__Events__Main::instance()->daySlug ),
-				'tag' => (array) 'tag',
-				'tax' => (array) 'category',
+				'month' => array( 'month', $tec->monthSlug ),
+				'list' => array( 'list', $tec->listSlug ),
+				'today' => array( 'today', $tec->todaySlug ),
+				'day' => array( 'day', $tec->daySlug ),
+				'tag' => array( 'tag', $tec->tag_slug ),
+				'tax' => array( 'category', $tec->category_slug ),
 				'page' => (array) 'page',
 				'all' => (array) 'all',
 				'single' => (array) Tribe__Settings_Manager::get_option( 'singleEventSlug', 'event' ),


### PR DESCRIPTION
Previously we were forming links where tag/category was translated, but our rewrite rules only covered the English terms - leading to unexpected results when users try to load taxonomy views in a non-English language setup.

[C#40579](https://central.tri.be/issues/40579)