### PR TITLE
Prevent throwing function declaration fatals when running event-tickets

### DIFF
--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -10,284 +10,287 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-if ( class_exists( 'Tribe__Events__Main' ) ) {
+if ( ! class_exists( 'Tribe__Events__Main' ) ) {
+	return;
+}
 
-	/**
-	 * Start Time
-	 *
-	 * Returns the event start time
-	 *
-	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
-	 *
-	 * @return string|null Time
-	 */
-	function tribe_get_start_time( $event = null, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
-		}
-
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return;
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			return;
-		}
-
-		$start_date = Tribe__Events__Timezones::event_start_timestamp( $event->ID, $timezone );
-
-		if ( '' == $dateFormat ) {
-			$dateFormat = tribe_get_time_format();
-		}
-
-		return tribe_event_format_date( $start_date, false, $dateFormat );
+/**
+ * Start Time
+ *
+ * Returns the event start time
+ *
+ * @category Events
+ * @param int    $event       (optional)
+ * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
+ *
+ * @return string|null Time
+ */
+function tribe_get_start_time( $event = null, $dateFormat = '', $timezone = null ) {
+	if ( is_null( $event ) ) {
+		global $post;
+		$event = $post;
 	}
 
-	/**
-	 * End Time
-	 *
-	 * Returns the event end time
-	 *
-	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
-	 *
-	 * @return string|null Time
-	 */
-	function tribe_get_end_time( $event = null, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
-		}
-
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return;
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			return;
-		}
-
-		$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
-
-		if ( '' == $dateFormat ) {
-			$dateFormat = tribe_get_time_format();
-		}
-
-		return tribe_event_format_date( $end_date, false, $dateFormat );
+	if ( is_numeric( $event ) ) {
+		$event = get_post( $event );
 	}
 
-	/**
-	 * Start Date
-	 *
-	 * Returns the event start date and time
-	 *
-	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param bool   $displayTime If true shows date and time, if false only shows date
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
-	 * @return string|null Date
-	 */
-	function tribe_get_start_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
-		}
-
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return '';
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			$displayTime = false;
-		}
-
-		$start_date = Tribe__Events__Timezones::event_start_timestamp( $event->ID, $timezone );
-		return tribe_event_format_date( $start_date, $displayTime, $dateFormat );
+	if ( ! is_object( $event ) ) {
+		return;
 	}
 
-	/**
-	 * End Date
-	 *
-	 * Returns the event end date
-	 *
-	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param bool   $displayTime If true shows date and time, if false only shows date
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
-	 *
-	 * @return string|null Date
-	 */
-	function tribe_get_end_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
-		}
-
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return '';
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			$displayTime = false;
-		}
-
-		$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
-		return tribe_event_format_date( $end_date, $displayTime, $dateFormat );
+	if ( tribe_event_is_all_day( $event ) ) {
+		return;
 	}
 
-	/**
-	 * Formatted Date
-	 *
-	 * Returns formatted date
-	 *
-	 * @category Events
-	 * @param string $date        String representing the datetime, assumed to be UTC (relevant if timezone conversion is used)
-	 * @param bool   $displayTime If true shows date and time, if false only shows date
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 *
-	 * @return string
-	 */
-	function tribe_event_format_date( $date, $displayTime = true, $dateFormat = '' ) {
+	$start_date = Tribe__Events__Timezones::event_start_timestamp( $event->ID, $timezone );
 
-		if ( ! Tribe__Events__Date_Utils::is_timestamp( $date ) ) {
-			$date = strtotime( $date );
-		}
+	if ( '' == $dateFormat ) {
+		$dateFormat = tribe_get_time_format();
+	}
 
-		if ( $dateFormat ) {
-			$format = $dateFormat;
+	return tribe_event_format_date( $start_date, false, $dateFormat );
+}
+
+/**
+ * End Time
+ *
+ * Returns the event end time
+ *
+ * @category Events
+ * @param int    $event       (optional)
+ * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
+ *
+ * @return string|null Time
+ */
+function tribe_get_end_time( $event = null, $dateFormat = '', $timezone = null ) {
+	if ( is_null( $event ) ) {
+		global $post;
+		$event = $post;
+	}
+
+	if ( is_numeric( $event ) ) {
+		$event = get_post( $event );
+	}
+
+	if ( ! is_object( $event ) ) {
+		return;
+	}
+
+	if ( tribe_event_is_all_day( $event ) ) {
+		return;
+	}
+
+	$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
+
+	if ( '' == $dateFormat ) {
+		$dateFormat = tribe_get_time_format();
+	}
+
+	return tribe_event_format_date( $end_date, false, $dateFormat );
+}
+
+/**
+ * Start Date
+ *
+ * Returns the event start date and time
+ *
+ * @category Events
+ * @param int    $event       (optional)
+ * @param bool   $displayTime If true shows date and time, if false only shows date
+ * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
+ * @return string|null Date
+ */
+function tribe_get_start_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
+	if ( is_null( $event ) ) {
+		global $post;
+		$event = $post;
+	}
+
+	if ( is_numeric( $event ) ) {
+		$event = get_post( $event );
+	}
+
+	if ( ! is_object( $event ) ) {
+		return '';
+	}
+
+	if ( tribe_event_is_all_day( $event ) ) {
+		$displayTime = false;
+	}
+
+	$start_date = Tribe__Events__Timezones::event_start_timestamp( $event->ID, $timezone );
+	return tribe_event_format_date( $start_date, $displayTime, $dateFormat );
+}
+
+/**
+ * End Date
+ *
+ * Returns the event end date
+ *
+ * @category Events
+ * @param int    $event       (optional)
+ * @param bool   $displayTime If true shows date and time, if false only shows date
+ * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
+ *
+ * @return string|null Date
+ */
+function tribe_get_end_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
+	if ( is_null( $event ) ) {
+		global $post;
+		$event = $post;
+	}
+
+	if ( is_numeric( $event ) ) {
+		$event = get_post( $event );
+	}
+
+	if ( ! is_object( $event ) ) {
+		return '';
+	}
+
+	if ( tribe_event_is_all_day( $event ) ) {
+		$displayTime = false;
+	}
+
+	$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
+	return tribe_event_format_date( $end_date, $displayTime, $dateFormat );
+}
+
+/**
+ * Formatted Date
+ *
+ * Returns formatted date
+ *
+ * @category Events
+ * @param string $date        String representing the datetime, assumed to be UTC (relevant if timezone conversion is used)
+ * @param bool   $displayTime If true shows date and time, if false only shows date
+ * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ *
+ * @return string
+ */
+function tribe_event_format_date( $date, $displayTime = true, $dateFormat = '' ) {
+
+	if ( ! Tribe__Events__Date_Utils::is_timestamp( $date ) ) {
+		$date = strtotime( $date );
+	}
+
+	if ( $dateFormat ) {
+		$format = $dateFormat;
+	} else {
+		$date_year = date( 'Y', $date );
+		$cur_year  = date( 'Y', current_time( 'timestamp' ) );
+
+		// only show the year in the date if it's not in the current year
+		$with_year = $date_year == $cur_year ? false : true;
+
+		if ( $displayTime ) {
+			$format = tribe_get_datetime_format( $with_year );
 		} else {
-			$date_year = date( 'Y', $date );
-			$cur_year  = date( 'Y', current_time( 'timestamp' ) );
-
-			// only show the year in the date if it's not in the current year
-			$with_year = $date_year == $cur_year ? false : true;
-
-			if ( $displayTime ) {
-				$format = tribe_get_datetime_format( $with_year );
-			} else {
-				$format = tribe_get_date_format( $with_year );
-			}
+			$format = tribe_get_date_format( $with_year );
 		}
-
-		$date = date_i18n( $format, $date );
-
-		return apply_filters( 'tribe_event_formatted_date', $date, $displayTime, $dateFormat );
-
 	}
 
-	/**
-	 * Returns formatted date for the official beginning of the day according to the Multi-day cutoff time option
-	 *
-	 * @category Events
-	 * @param string $date   The date to find the beginning of the day, defaults to today
-	 * @param string $format Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 *
-	 * @return string
+	$date = date_i18n( $format, $date );
+
+	return apply_filters( 'tribe_event_formatted_date', $date, $displayTime, $dateFormat );
+
+}
+
+/**
+ * Returns formatted date for the official beginning of the day according to the Multi-day cutoff time option
+ *
+ * @category Events
+ * @param string $date   The date to find the beginning of the day, defaults to today
+ * @param string $format Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ *
+ * @return string
+ */
+function tribe_event_beginning_of_day( $date = null, $format = 'Y-m-d H:i:s' ) {
+	$multiday_cutoff = explode( ':', tribe_get_option( 'multiDayCutoff', '00:00' ) );
+	$hours_to_add    = $multiday_cutoff[0];
+	$minutes_to_add  = $multiday_cutoff[1];
+	if ( is_null( $date ) || empty( $date ) ) {
+		return apply_filters( 'tribe_event_beginning_of_day', date( $format, strtotime( date( 'Y-m-d' ) . ' +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) ) );
+	} else {
+		return apply_filters( 'tribe_event_beginning_of_day', date( $format, strtotime( date( 'Y-m-d', strtotime( $date ) ) . ' +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) ) );
+	}
+}
+
+/**
+ * Returns formatted date for the official end of the day according to the Multi-day cutoff time option
+ *
+ * @category Events
+ * @param string $date   The date to find the end of the day, defaults to today
+ * @param string $format Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+ *
+ * @return string
+ */
+function tribe_event_end_of_day( $date = null, $format = 'Y-m-d H:i:s' ) {
+	$multiday_cutoff = explode( ':', tribe_get_option( 'multiDayCutoff', '00:00' ) );
+	$hours_to_add    = $multiday_cutoff[0];
+	$minutes_to_add  = $multiday_cutoff[1];
+	if ( is_null( $date ) || empty( $date ) ) {
+		return apply_filters( 'tribe_event_end_of_day', date( $format, strtotime( 'tomorrow  +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) - 1 ) );
+	} else {
+		return apply_filters( 'tribe_event_end_of_day', date( $format, strtotime( date( 'Y-m-d', strtotime( $date ) ) . ' +1 day ' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) - 1 ) );
+	}
+}
+
+/**
+ * Given a date and an event, returns true or false if the event is happening on that date
+ * This function properly adjusts for the EOD cutoff and multi-day events
+ *
+ * @param null $date
+ * @param null $event
+ *
+ * @return mixed|void
+ */
+function tribe_event_is_on_date( $date = null, $event = null ) {
+
+	if ( null === $date ) {
+		$date = current_time( 'mysql' );
+	}
+
+	if ( null === $event ) {
+		global $post;
+		$event = $post;
+		if ( empty( $event ) ) {
+			_doing_it_wrong( __FUNCTION__, __( 'The function needs to be passed an $event or used in the loop.', 'the-events-calendar' ) );
+			return false;
+		}
+	}
+
+	$start_of_day     = tribe_event_beginning_of_day( $date, 'U' );
+	$end_of_day       = tribe_event_end_of_day( $date, 'U' );
+	$event_start      = tribe_get_start_date( $event, null, 'U' );
+	$event_end        = tribe_get_end_date( $event, null, 'U' );
+
+	// kludge
+	if ( ! empty( $event->_end_date_fixed ) ) {
+		// @todo remove this once we can have all day events without a start / end time
+		$event_end = date_create( date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, $event_end ) );
+		$event_end->modify( '+1 day' );
+		$event_end    = $event_end->format( 'U' );
+	}
+
+	/* note:
+	 * events that start exactly on the EOD cutoff will count on the following day
+	 * events that end exactly on the EOD cutoff will count on the previous day
 	 */
-	function tribe_event_beginning_of_day( $date = null, $format = 'Y-m-d H:i:s' ) {
-		$multiday_cutoff = explode( ':', tribe_get_option( 'multiDayCutoff', '00:00' ) );
-		$hours_to_add    = $multiday_cutoff[0];
-		$minutes_to_add  = $multiday_cutoff[1];
-		if ( is_null( $date ) || empty( $date ) ) {
-			return apply_filters( 'tribe_event_beginning_of_day', date( $format, strtotime( date( 'Y-m-d' ) . ' +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) ) );
-		} else {
-			return apply_filters( 'tribe_event_beginning_of_day', date( $format, strtotime( date( 'Y-m-d', strtotime( $date ) ) . ' +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) ) );
-		}
-	}
 
-	/**
-	 * Returns formatted date for the official end of the day according to the Multi-day cutoff time option
-	 *
-	 * @category Events
-	 * @param string $date   The date to find the end of the day, defaults to today
-	 * @param string $format Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 *
-	 * @return string
-	 */
-	function tribe_event_end_of_day( $date = null, $format = 'Y-m-d H:i:s' ) {
-		$multiday_cutoff = explode( ':', tribe_get_option( 'multiDayCutoff', '00:00' ) );
-		$hours_to_add    = $multiday_cutoff[0];
-		$minutes_to_add  = $multiday_cutoff[1];
-		if ( is_null( $date ) || empty( $date ) ) {
-			return apply_filters( 'tribe_event_end_of_day', date( $format, strtotime( 'tomorrow  +' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) - 1 ) );
-		} else {
-			return apply_filters( 'tribe_event_end_of_day', date( $format, strtotime( date( 'Y-m-d', strtotime( $date ) ) . ' +1 day ' . $hours_to_add . ' hours ' . $minutes_to_add . ' minutes' ) - 1 ) );
-		}
-	}
+	$event_is_on_date = Tribe__Events__Date_Utils::range_coincides( $start_of_day, $end_of_day, $event_start, $event_end );
 
-	/**
-	 * Given a date and an event, returns true or false if the event is happening on that date
-	 * This function properly adjusts for the EOD cutoff and multi-day events
-	 *
-	 * @param null $date
-	 * @param null $event
-	 *
-	 * @return mixed|void
-	 */
-	function tribe_event_is_on_date( $date = null, $event = null ) {
+	return apply_filters( 'tribe_event_is_on_date', $event_is_on_date, $date, $event );
 
-		if ( null === $date ) {
-			$date = current_time( 'mysql' );
-		}
-
-		if ( null === $event ) {
-			global $post;
-			$event = $post;
-			if ( empty( $event ) ) {
-				_doing_it_wrong( __FUNCTION__, __( 'The function needs to be passed an $event or used in the loop.', 'the-events-calendar' ) );
-				return false;
-			}
-		}
-
-		$start_of_day     = tribe_event_beginning_of_day( $date, 'U' );
-		$end_of_day       = tribe_event_end_of_day( $date, 'U' );
-		$event_start      = tribe_get_start_date( $event, null, 'U' );
-		$event_end        = tribe_get_end_date( $event, null, 'U' );
-
-		// kludge
-		if ( ! empty( $event->_end_date_fixed ) ) {
-			// @todo remove this once we can have all day events without a start / end time
-			$event_end = date_create( date( Tribe__Events__Date_Utils::DBDATETIMEFORMAT, $event_end ) );
-			$event_end->modify( '+1 day' );
-			$event_end    = $event_end->format( 'U' );
-		}
-
-		/* note:
-		 * events that start exactly on the EOD cutoff will count on the following day
-		 * events that end exactly on the EOD cutoff will count on the previous day
-		 */
-
-		$event_is_on_date = Tribe__Events__Date_Utils::range_coincides( $start_of_day, $end_of_day, $event_start, $event_end );
-
-		return apply_filters( 'tribe_event_is_on_date', $event_is_on_date, $date, $event );
-
-	}
+}
 
 
+if ( ! function_exists( 'tribe_get_datetime_separator' ) ) {
 	/**
 	 * Get the datetime saparator from the database option with escaped characters or not ;)
 	 *
@@ -306,5 +309,4 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 		return apply_filters( 'tribe_datetime_separator', $separator );
 	}
-
-}
+}//end if

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -117,23 +117,25 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		do_action( 'tribe_post_get_template_part_' . $slug, $slug, $name, $data );
 	}
 
-	/**
-	 * Get Options
-	 *
-	 * Retrieve specific key from options array, optionally provide a default return value
-	 *
-	 * @category Events
-	 * @param string $optionName Name of the option to retrieve.
-	 * @param string $default    Value to return if no such option is found.
-	 *
-	 * @return mixed Value of the option if found.
-	 * @todo Abstract this function out of template tags or otherwise secure it from other namespace conflicts.
-	 */
-	function tribe_get_option( $optionName, $default = '' ) {
-		$tribe_ecp = Tribe__Events__Main::instance();
+	if ( ! function_exists( 'tribe_get_option' ) ) {
+		/**
+		 * Get Options
+		 *
+		 * Retrieve specific key from options array, optionally provide a default return value
+		 *
+		 * @category Events
+		 * @param string $optionName Name of the option to retrieve.
+		 * @param string $default    Value to return if no such option is found.
+		 *
+		 * @return mixed Value of the option if found.
+		 * @todo Abstract this function out of template tags or otherwise secure it from other namespace conflicts.
+		 */
+		function tribe_get_option( $optionName, $default = '' ) {
+			$tribe_ecp = Tribe__Events__Main::instance();
 
-		return apply_filters( 'tribe_get_option', $tribe_ecp->getOption( $optionName, $default ), $optionName, $default );
-	}
+			return apply_filters( 'tribe_get_option', $tribe_ecp->getOption( $optionName, $default ), $optionName, $default );
+		}
+	}//end if
 
 	/**
 	 * Check if the current request is for a tribe view via ajax
@@ -164,39 +166,43 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_is_ajax_view_request', $is_ajax_view_request, $view );
 	}
 
-	/**
-	 * Update Option
-	 *
-	 * Set specific key from options array, optionally provide a default return value
-	 *
-	 * @category Events
-	 * @param string $optionName Name of the option to retrieve.
-	 * @param string $value      Value to save
-	 *
-	 * @return void
-	 */
-	function tribe_update_option( $optionName, $value ) {
-		$tribe_ecp = Tribe__Events__Main::instance();
-		$tribe_ecp->setOption( $optionName, $value );
-	}
+	if ( ! function_exists( 'tribe_update_option' ) ) {
+		/**
+		 * Update Option
+		 *
+		 * Set specific key from options array, optionally provide a default return value
+		 *
+		 * @category Events
+		 * @param string $optionName Name of the option to retrieve.
+		 * @param string $value      Value to save
+		 *
+		 * @return void
+		 */
+		function tribe_update_option( $optionName, $value ) {
+			$tribe_ecp = Tribe__Events__Main::instance();
+			$tribe_ecp->setOption( $optionName, $value );
+		}
+	}//end if
 
-	/**
-	 * Get Network Options
-	 *
-	 * Retrieve specific key from options array, optionally provide a default return value
-	 *
-	 * @category Events
-	 * @param string $optionName Name of the option to retrieve.
-	 * @param string $default    Value to return if no such option is found.
-	 *
-	 * @return mixed Value of the option if found.
-	 * @todo Abstract this function out of template tags or otherwise secure it from other namespace conflicts.
-	 */
-	function tribe_get_network_option( $optionName, $default = '' ) {
-		$tribe_ecp = Tribe__Events__Main::instance();
+	if ( ! function_exists( 'tribe_get_network_option' ) ) {
+		/**
+		 * Get Network Options
+		 *
+		 * Retrieve specific key from options array, optionally provide a default return value
+		 *
+		 * @category Events
+		 * @param string $optionName Name of the option to retrieve.
+		 * @param string $default    Value to return if no such option is found.
+		 *
+		 * @return mixed Value of the option if found.
+		 * @todo Abstract this function out of template tags or otherwise secure it from other namespace conflicts.
+		 */
+		function tribe_get_network_option( $optionName, $default = '' ) {
+			$tribe_ecp = Tribe__Events__Main::instance();
 
-		return $tribe_ecp->getNetworkOption( $optionName, $default );
-	}
+			return $tribe_ecp->getNetworkOption( $optionName, $default );
+		}
+	}//end if
 
 	/**
 	 * Event Type Test
@@ -807,47 +813,49 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_get_formatted_cost', tribe_get_cost( $postId, true ) );
 	}
 
-	/**
-	 * Receives a float and formats it with a currency symbol
-	 *
-	 * @category Cost
-	 * @param string $cost pricing to format
-	 * @param null|int $postId
-	 * @param null|string $currency_symbol
-	 * @param null|bool $reverse_position
-	 *
-	 * @return string
-	 */
-	function tribe_format_currency( $cost, $postId = null, $currency_symbol = null, $reverse_position = null ) {
+	if ( ! function_exists( 'tribe_format_currency' ) ) {
+		/**
+		 * Receives a float and formats it with a currency symbol
+		 *
+		 * @category Cost
+		 * @param string $cost pricing to format
+		 * @param null|int $postId
+		 * @param null|string $currency_symbol
+		 * @param null|bool $reverse_position
+		 *
+		 * @return string
+		 */
+		function tribe_format_currency( $cost, $postId = null, $currency_symbol = null, $reverse_position = null ) {
 
-		$postId = Tribe__Events__Main::postIdHelper( $postId );
+			$postId = Tribe__Events__Main::postIdHelper( $postId );
 
-		// if no currency symbol was passed, and we're looking at a particular event,
-		// let's check if there was a currency symbol set on that event
-		if ( $postId && $currency_symbol == null ) {
-			$currency_symbol = tribe_get_event_meta( $postId, '_EventCurrencySymbol', true );
+			// if no currency symbol was passed, and we're looking at a particular event,
+			// let's check if there was a currency symbol set on that event
+			if ( $postId && $currency_symbol == null ) {
+				$currency_symbol = tribe_get_event_meta( $postId, '_EventCurrencySymbol', true );
+			}
+
+			// if no currency symbol was passed, or we're not looking at a particular event,
+			// let's get the default currency symbol
+			if ( ! $postId || ! $currency_symbol ) {
+				$currency_symbol = tribe_get_option( 'defaultCurrencySymbol', '$' );
+			}
+
+			if ( $postId && $reverse_position == null ) {
+				$reverse_position = tribe_get_event_meta( $postId, '_EventCurrencyPosition', true );
+				$reverse_position = ( 'suffix' === $reverse_position );
+			}
+
+			if ( ! $reverse_position || ! $postId ) {
+				$reverse_position = tribe_get_option( 'reverseCurrencyPosition', false );
+			}
+
+			$cost = $reverse_position ? $cost . $currency_symbol : $currency_symbol . $cost;
+
+			return $cost;
+
 		}
-
-		// if no currency symbol was passed, or we're not looking at a particular event,
-		// let's get the default currency symbol
-		if ( ! $postId || ! $currency_symbol ) {
-			$currency_symbol = tribe_get_option( 'defaultCurrencySymbol', '$' );
-		}
-
-		if ( $postId && $reverse_position == null ) {
-			$reverse_position = tribe_get_event_meta( $postId, '_EventCurrencyPosition', true );
-			$reverse_position = ( 'suffix' === $reverse_position );
-		}
-
-		if ( ! $reverse_position || ! $postId ) {
-			$reverse_position = tribe_get_option( 'reverseCurrencyPosition', false );
-		}
-
-		$cost = $reverse_position ? $cost . $currency_symbol : $currency_symbol . $cost;
-
-		return $cost;
-
-	}
+	}//end if
 
 	/**
 	 * Get the minimum cost of all events.
@@ -925,19 +933,21 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 	}
 
-	/**
-	 * helper function to remove empty lines from multi-line strings
-	 *
-	 * @category Events
-	 * @link http://stackoverflow.com/questions/709669/how-do-i-remove-blank-lines-from-text-in-php
-	 *
-	 * @param string $multi_line_string a multiline string
-	 *
-	 * @return string the same string without empty lines
-	 */
-	function tribe_multi_line_remove_empty_lines( $multi_line_string ) {
-		return preg_replace( "/^\n+|^[\t\s]*\n+/m", '', $multi_line_string );
-	}
+	if ( ! function_exists( 'tribe_multi_line_remove_empty_lines' ) ) {
+		/**
+		 * helper function to remove empty lines from multi-line strings
+		 *
+		 * @category Events
+		 * @link http://stackoverflow.com/questions/709669/how-do-i-remove-blank-lines-from-text-in-php
+		 *
+		 * @param string $multi_line_string a multiline string
+		 *
+		 * @return string the same string without empty lines
+		 */
+		function tribe_multi_line_remove_empty_lines( $multi_line_string ) {
+			return preg_replace( "/^\n+|^[\t\s]*\n+/m", '', $multi_line_string );
+		}
+	}//end if
 
 	/**
 	 * return the featured image html to an event (within the loop automatically will get event ID)
@@ -967,56 +977,62 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_event_featured_image', $featured_image, $post_id, $size );
 	}
 
-	/**
-	 * Get the date format specified in the tribe options
-	 *
-	 * @category Events
-	 * @param bool $with_year
-	 *
-	 * @return mixed
-	 */
-	function tribe_get_date_format( $with_year = false ) {
-		if ( $with_year ) {
-			$format = tribe_get_option( 'dateWithYearFormat', get_option( 'date_format' ) );
-		} else {
-			$format = tribe_get_option( 'dateWithoutYearFormat', 'F j' );
+	if ( ! function_exists( 'tribe_get_date_format' ) ) {
+		/**
+		 * Get the date format specified in the tribe options
+		 *
+		 * @category Events
+		 * @param bool $with_year
+		 *
+		 * @return mixed
+		 */
+		function tribe_get_date_format( $with_year = false ) {
+			if ( $with_year ) {
+				$format = tribe_get_option( 'dateWithYearFormat', get_option( 'date_format' ) );
+			} else {
+				$format = tribe_get_option( 'dateWithoutYearFormat', 'F j' );
+			}
+
+			// Strip slashes - otherwise the slashes for escaped characters will themselves be escaped
+			return apply_filters( 'tribe_date_format', stripslashes( $format ) );
 		}
+	}//end if
 
-		// Strip slashes - otherwise the slashes for escaped characters will themselves be escaped
-		return apply_filters( 'tribe_date_format', stripslashes( $format ) );
-	}
+	if ( ! function_exists( 'tribe_get_datetime_format' ) ) {
+		/**
+		 * Get the Datetime Format
+		 *
+		 * @category Events
+		 *
+		 * @param bool $with_year
+		 *
+		 * @return mixed|void
+		 */
+		function tribe_get_datetime_format( $with_year = false ) {
+			$separator = (array) str_split( tribe_get_option( 'dateTimeSeparator', ' @ ' ) );
 
-	/**
-	 * Get the Datetime Format
-	 *
-	 * @category Events
-	 *
-	 * @param bool $with_year
-	 *
-	 * @return mixed|void
-	 */
-	function tribe_get_datetime_format( $with_year = false ) {
-		$separator = (array) str_split( tribe_get_option( 'dateTimeSeparator', ' @ ' ) );
+			$format = tribe_get_date_format( $with_year );
+			$format .= ( ! empty( $separator ) ? '\\' : '' ) . implode( '\\', $separator );
+			$format .= get_option( 'time_format' );
 
-		$format = tribe_get_date_format( $with_year );
-		$format .= ( ! empty( $separator ) ? '\\' : '' ) . implode( '\\', $separator );
-		$format .= get_option( 'time_format' );
+			return apply_filters( 'tribe_datetime_format', $format );
 
-		return apply_filters( 'tribe_datetime_format', $format );
+		}
+	}//end if
 
-	}
-
-	/**
-	 * Get the time format
-	 *
-	 * @category Events
-	 *
-	 * @return mixed|void
-	 */
-	function tribe_get_time_format( ) {
-		$format = get_option( 'time_format' );
-		return apply_filters( 'tribe_time_format', $format );
-	}
+	if ( ! function_exists( 'tribe_get_time_format' ) ) {
+		/**
+		 * Get the time format
+		 *
+		 * @category Events
+		 *
+		 * @return mixed|void
+		 */
+		function tribe_get_time_format( ) {
+			$format = get_option( 'time_format' );
+			return apply_filters( 'tribe_time_format', $format );
+		}
+	}//end if
 
 	/**
 	 * Return the details of the start/end date/time.
@@ -1151,80 +1167,86 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_events_event_schedule_details', $schedule, $event->ID, $before, $after );
 	}
 
-	/**
-	 * Accepts two dates and returns the number of days between them
-	 *
-	 * @category Events
-	 *
-	 * @param string      $start_date
-	 * @param string      $end_date
-	 * @param string|bool $day_cutoff
-	 *
-	 * @return int
-	 * @see Tribe__Events__Date_Utils::date_diff()
-	 **/
-	function tribe_get_days_between( $start_date, $end_date, $day_cutoff = '00:00' ) {
-		if ( $day_cutoff === false ) {
-			$day_cutoff = '00:00';
-		} elseif ( $day_cutoff === true ) {
-			$day_cutoff = tribe_get_option( 'multiDayCutoff', '00:00' );
-		}
-
-		$start_date = new DateTime( $start_date );
-		if ( $start_date < new DateTime( $start_date->format( 'Y-m-d ' . $day_cutoff ) ) ) {
-			$start_date->modify( '-1 day' );
-		}
-		$end_date = new DateTime( $end_date );
-		if ( $end_date <= new DateTime( $end_date->format( 'Y-m-d ' . $day_cutoff ) ) ) {
-			$end_date->modify( '-1 day' );
-		}
-
-		return Tribe__Events__Date_Utils::date_diff( $start_date->format( 'Y-m-d ' . $day_cutoff ), $end_date->format( 'Y-m-d ' . $day_cutoff ) );
-	}
-
-	/**
-	 * Function to prepare content for use as a value in a json encoded string destined for storage on a html data attribute.
-	 * Hence the double quote fun, especially in case they pass html encoded &quot; along. Any of those getting through to the data att will break jquery's parseJSON method.
-	 * Themers can use this function to prepare data they may want to send to tribe_events_template_data() in the templates, and we use it in that function ourselves.
-	 *
-	 * @category Events
-	 *
-	 * @param $string
-	 *
-	 * @return string
-	 */
-
-	function tribe_prepare_for_json( $string ) {
-
-		$value = trim( htmlspecialchars( $string, ENT_QUOTES, 'UTF-8' ) );
-		$value = str_replace( '&quot;', '"', $value );
-
-		return $value;
-	}
-
-	/**
-	 * Recursively iterate through an nested structure, calling
-	 * tribe_prepare_for_json() on all scalar values
-	 *
-	 * @category Events
-	 *
-	 * @param mixed $value The data to be cleaned
-	 *
-	 * @return mixed The clean data
-	 */
-	function tribe_prepare_for_json_deep( $value ) {
-		if ( is_array( $value ) ) {
-			$value = array_map( 'tribe_prepare_for_json_deep', $value );
-		} elseif ( is_object( $value ) ) {
-			$vars = get_object_vars( $value );
-			foreach ( $vars as $key => $data ) {
-				$value->{$key} = tribe_prepare_for_json_deep( $data );
+	if ( ! function_exists( 'tribe_get_days_between' ) ) {
+		/**
+		 * Accepts two dates and returns the number of days between them
+		 *
+		 * @category Events
+		 *
+		 * @param string      $start_date
+		 * @param string      $end_date
+		 * @param string|bool $day_cutoff
+		 *
+		 * @return int
+		 * @see Tribe__Events__Date_Utils::date_diff()
+		 **/
+		function tribe_get_days_between( $start_date, $end_date, $day_cutoff = '00:00' ) {
+			if ( $day_cutoff === false ) {
+				$day_cutoff = '00:00';
+			} elseif ( $day_cutoff === true ) {
+				$day_cutoff = tribe_get_option( 'multiDayCutoff', '00:00' );
 			}
-		} elseif ( is_string( $value ) ) {
-			$value = tribe_prepare_for_json( $value );
+
+			$start_date = new DateTime( $start_date );
+			if ( $start_date < new DateTime( $start_date->format( 'Y-m-d ' . $day_cutoff ) ) ) {
+				$start_date->modify( '-1 day' );
+			}
+			$end_date = new DateTime( $end_date );
+			if ( $end_date <= new DateTime( $end_date->format( 'Y-m-d ' . $day_cutoff ) ) ) {
+				$end_date->modify( '-1 day' );
+			}
+
+			return Tribe__Events__Date_Utils::date_diff( $start_date->format( 'Y-m-d ' . $day_cutoff ), $end_date->format( 'Y-m-d ' . $day_cutoff ) );
 		}
-		return $value;
-	}
+	}//end if
+
+	if ( ! function_exists( 'tribe_prepare_for_json' ) ) {
+		/**
+		 * Function to prepare content for use as a value in a json encoded string destined for storage on a html data attribute.
+		 * Hence the double quote fun, especially in case they pass html encoded &quot; along. Any of those getting through to the data att will break jquery's parseJSON method.
+		 * Themers can use this function to prepare data they may want to send to tribe_events_template_data() in the templates, and we use it in that function ourselves.
+		 *
+		 * @category Events
+		 *
+		 * @param $string
+		 *
+		 * @return string
+		 */
+
+		function tribe_prepare_for_json( $string ) {
+
+			$value = trim( htmlspecialchars( $string, ENT_QUOTES, 'UTF-8' ) );
+			$value = str_replace( '&quot;', '"', $value );
+
+			return $value;
+		}
+	}//end if
+
+	if ( ! function_exists( 'tribe_prepare_for_json_deep' ) ) {
+		/**
+		 * Recursively iterate through an nested structure, calling
+		 * tribe_prepare_for_json() on all scalar values
+		 *
+		 * @category Events
+		 *
+		 * @param mixed $value The data to be cleaned
+		 *
+		 * @return mixed The clean data
+		 */
+		function tribe_prepare_for_json_deep( $value ) {
+			if ( is_array( $value ) ) {
+				$value = array_map( 'tribe_prepare_for_json_deep', $value );
+			} elseif ( is_object( $value ) ) {
+				$vars = get_object_vars( $value );
+				foreach ( $vars as $key => $data ) {
+					$value->{$key} = tribe_prepare_for_json_deep( $data );
+				}
+			} elseif ( is_string( $value ) ) {
+				$value = tribe_prepare_for_json( $value );
+			}
+			return $value;
+		}
+	}//end if
 
 	/**
 	 * Returns json for javascript templating functions throughout the plugin.
@@ -1437,42 +1459,44 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return $disabled;
 	}
 
-	/**
-	 * tribe_is_bot checks if the visitor is a bot and returns status
-	 *
-	 * @category Events
-	 *
-	 * @return bool
-	 */
-	function tribe_is_bot() {
-		// get the current user agent
-		$user_agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
+	if ( ! function_exists( 'tribe_is_bot' ) ) {
+		/**
+		 * tribe_is_bot checks if the visitor is a bot and returns status
+		 *
+		 * @category Events
+		 *
+		 * @return bool
+		 */
+		function tribe_is_bot() {
+			// get the current user agent
+			$user_agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
 
-		// check if the user agent is empty since most browsers identify themselves, so possibly a bot
-		if ( empty( $user_agent ) ) {
-			return apply_filters( 'tribe_is_bot_status', true, $user_agent, null );
-		}
-
-		// declare known bot user agents (lowercase)
-		$user_agent_bots = (array) apply_filters(
-			'tribe_is_bot_list', array(
-				'bot',
-				'slurp',
-				'spider',
-				'crawler',
-				'yandex',
-			)
-		);
-
-		foreach ( $user_agent_bots as $bot ) {
-			if ( stripos( $user_agent, $bot ) !== false ) {
-				return apply_filters( 'tribe_is_bot_status', true, $user_agent, $bot );
+			// check if the user agent is empty since most browsers identify themselves, so possibly a bot
+			if ( empty( $user_agent ) ) {
+				return apply_filters( 'tribe_is_bot_status', true, $user_agent, null );
 			}
-		}
 
-		// we think this is probably a real human
-		return apply_filters( 'tribe_is_bot_status', false, $user_agent, null );
-	}
+			// declare known bot user agents (lowercase)
+			$user_agent_bots = (array) apply_filters(
+				'tribe_is_bot_list', array(
+					'bot',
+					'slurp',
+					'spider',
+					'crawler',
+					'yandex',
+				)
+			);
+
+			foreach ( $user_agent_bots as $bot ) {
+				if ( stripos( $user_agent, $bot ) !== false ) {
+					return apply_filters( 'tribe_is_bot_status', true, $user_agent, $bot );
+				}
+			}
+
+			// we think this is probably a real human
+			return apply_filters( 'tribe_is_bot_status', false, $user_agent, null );
+		}
+	}//end if
 
 	/**
 	 * Display the Events Calendar promo banner
@@ -1529,33 +1553,37 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_events_get_current_filter_url', $url );
 	}
 
-	/**
-	 * Count keys in a hierarchical array
-	 *
-	 * @param $value
-	 * @param $key
-	 * @todo - remove, only used in the meta walker
-	 */
-	function tribe_count_hierarchical_keys( $value, $key ) {
-		global $tribe_count_hierarchical_increment;
-		$tribe_count_hierarchical_increment++;
-	}
+	if ( ! function_exists( 'tribe_count_hierarchical_keys' ) ) {
+		/**
+		 * Count keys in a hierarchical array
+		 *
+		 * @param $value
+		 * @param $key
+		 * @todo - remove, only used in the meta walker
+		 */
+		function tribe_count_hierarchical_keys( $value, $key ) {
+			global $tribe_count_hierarchical_increment;
+			$tribe_count_hierarchical_increment++;
+		}
+	}//end if
 
-	/**
-	 * Count items in a hierarchical array
-	 *
-	 * @param array $walk
-	 *
-	 * @return int
-	 * @todo - remove, only used in the meta walker
-	 */
-	function tribe_count_hierarchical( array $walk ) {
-		global $tribe_count_hierarchical_increment;
-		$tribe_count_hierarchical_increment = 0;
-		array_walk_recursive( $walk, 'tribe_count_hierarchical_keys' );
+	if ( ! function_exists( 'tribe_count_hierarchical' ) ) {
+		/**
+		 * Count items in a hierarchical array
+		 *
+		 * @param array $walk
+		 *
+		 * @return int
+		 * @todo - remove, only used in the meta walker
+		 */
+		function tribe_count_hierarchical( array $walk ) {
+			global $tribe_count_hierarchical_increment;
+			$tribe_count_hierarchical_increment = 0;
+			array_walk_recursive( $walk, 'tribe_count_hierarchical_keys' );
 
-		return $tribe_count_hierarchical_increment;
-	}
+			return $tribe_count_hierarchical_increment;
+		}
+	}//end if
 
 	/**
 	 * Get and increment tab index in form fields
@@ -1613,20 +1641,22 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return preg_replace( '#\[.+\]#U', '', get_the_excerpt() );
 	}
 
-	/**
-	 * Mobile breakpoint
-	 *
-	 * Get the breakpoint for switching to mobile styles. Defaults to 768.
-	 *
-	 * @category Events
-	 *
-	 * @param int $default The default width (in pixels) at which to break into mobile styles
-	 *
-	 * @return int
-	 */
-	function tribe_get_mobile_breakpoint( $default = 768 ) {
-		return apply_filters( 'tribe_events_mobile_breakpoint', $default );
-	}
+	if ( ! function_exists( 'tribe_get_mobile_breakpoint' ) ) {
+		/**
+		 * Mobile breakpoint
+		 *
+		 * Get the breakpoint for switching to mobile styles. Defaults to 768.
+		 *
+		 * @category Events
+		 *
+		 * @param int $default The default width (in pixels) at which to break into mobile styles
+		 *
+		 * @return int
+		 */
+		function tribe_get_mobile_breakpoint( $default = 768 ) {
+			return apply_filters( 'tribe_events_mobile_breakpoint', $default );
+		}
+	}//end if
 
 	/**
 	 * Returns the latest known event end date, which can be expected to be a string

--- a/src/functions/template-tags/tickets.php
+++ b/src/functions/template-tags/tickets.php
@@ -11,165 +11,181 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-/**
- * Determines if any tickets exist for the current event (a specific event
- * may be specified, though, by passing the post ID or post object).
- *
- * @param $event
- *
- * @return bool
- */
-function tribe_events_has_tickets( $event = null ) {
-	if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
-		return false;
-	}
-
-	$tickets = Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID );
-	return ! empty( $tickets );
-}
-
-/**
- * Determines if the event has sold out of tickets.
- *
- * Note that this will also return true if the event has no tickets
- * whatsoever, and so it may be best to test with tribe_events_has_tickets()
- * before using this to avoid ambiguity.
- *
- * @param null $event
- *
- * @return bool
- */
-function tribe_events_has_soldout( $event = null ) {
-	$has_tickets = tribe_events_has_tickets( $event );
-	$no_stock = tribe_events_count_available_tickets( $event ) < 1;
-	$unlimited_inventory_items = tribe_events_has_unlimited_stock_tickets( $event );
-
-	return ( $has_tickets && $no_stock && ! $unlimited_inventory_items );
-}
-
-/**
- * Indicates if one or more of the tickets available for this event (but not
- * all) have sold out.
- *
- * This is useful to indicate if for example 2 out of three ticket types
- * have soldout but one still has stock remaining.
- *
- * @param null $event
- *
- * @return bool
- */
-function tribe_events_partially_soldout( $event = null ) {
-	if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
-		return false;
-	}
-
-	$stock_is_available = false;
-	$some_have_soldout = false;
-
-	foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-		if ( ! $stock_is_available && 0 < $ticket->stock ) {
-			$stock_is_available = true;
+if ( ! function_exists( 'tribe_events_has_tickets' ) ) {
+	/**
+	 * Determines if any tickets exist for the current event (a specific event
+	 * may be specified, though, by passing the post ID or post object).
+	 *
+	 * @param $event
+	 *
+	 * @return bool
+	 */
+	function tribe_events_has_tickets( $event = null ) {
+		if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
+			return false;
 		}
 
-		if ( ! $some_have_soldout && 0 == $ticket->stock ) {
-			$some_have_soldout = true;
+		$tickets = Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID );
+		return ! empty( $tickets );
+	}
+}
+
+if ( ! function_exists( 'tribe_events_has_soldout' ) ) {
+	/**
+	 * Determines if the event has sold out of tickets.
+	 *
+	 * Note that this will also return true if the event has no tickets
+	 * whatsoever, and so it may be best to test with tribe_events_has_tickets()
+	 * before using this to avoid ambiguity.
+	 *
+	 * @param null $event
+	 *
+	 * @return bool
+	 */
+	function tribe_events_has_soldout( $event = null ) {
+		$has_tickets = tribe_events_has_tickets( $event );
+		$no_stock = tribe_events_count_available_tickets( $event ) < 1;
+		$unlimited_inventory_items = tribe_events_has_unlimited_stock_tickets( $event );
+
+		return ( $has_tickets && $no_stock && ! $unlimited_inventory_items );
+	}
+}//end if
+
+if ( ! function_exists( 'tribe_events_partially_soldout' ) ) {
+	/**
+	 * Indicates if one or more of the tickets available for this event (but not
+	 * all) have sold out.
+	 *
+	 * This is useful to indicate if for example 2 out of three ticket types
+	 * have soldout but one still has stock remaining.
+	 *
+	 * @param null $event
+	 *
+	 * @return bool
+	 */
+	function tribe_events_partially_soldout( $event = null ) {
+		if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
+			return false;
 		}
+
+		$stock_is_available = false;
+		$some_have_soldout = false;
+
+		foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
+			if ( ! $stock_is_available && 0 < $ticket->stock ) {
+				$stock_is_available = true;
+			}
+
+			if ( ! $some_have_soldout && 0 == $ticket->stock ) {
+				$some_have_soldout = true;
+			}
+		}
+
+		return $some_have_soldout && $stock_is_available;
 	}
+}//end if
 
-	return $some_have_soldout && $stock_is_available;
-}
+if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
+	/**
+	 * Counts the total number of tickets still available for sale for a
+	 * specific event.
+	 *
+	 * @param null $event
+	 *
+	 * @return int
+	 */
+	function tribe_events_count_available_tickets( $event = null ) {
+		$count = 0;
 
-/**
- * Counts the total number of tickets still available for sale for a
- * specific event.
- *
- * @param null $event
- *
- * @return int
- */
-function tribe_events_count_available_tickets( $event = null ) {
-	$count = 0;
+		if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
+			return 0;
+		}
 
-	if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
-		return 0;
+		foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
+			$count += $ticket->stock;
+		}
+
+		return $count;
 	}
+}//end if
 
-	foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-		$count += $ticket->stock;
+if ( ! function_exists( 'tribe_events_has_unlimited_stock_tickets' ) ) {
+	/**
+	 * Returns true if the event contains one or more tickets which are not
+	 * subject to any inventory limitations.
+	 *
+	 * @param null $event
+	 *
+	 * @return bool
+	 */
+	function tribe_events_has_unlimited_stock_tickets( $event = null ) {
+		if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
+			return 0;
+		}
+
+		foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
+			if ( Tribe__Events__Tickets__Ticket_Object::UNLIMITED_STOCK === $ticket->stock ) return true;
+		}
+
+		return false;
 	}
+}//end if
 
-	return $count;
-}
-
-/**
- * Returns true if the event contains one or more tickets which are not
- * subject to any inventory limitations.
- *
- * @param null $event
- *
- * @return bool
- */
-function tribe_events_has_unlimited_stock_tickets( $event = null ) {
-	if ( null === ( $event = tribe_events_get_event( $event ) ) ) {
-		return 0;
+if ( ! function_exists( 'tribe_events_product_is_ticket' ) ) {
+	/**
+	 * Determines if the product object (or product ID) represents a ticket for
+	 * an event.
+	 *
+	 * @param $product
+	 *
+	 * @return bool
+	 */
+	function tribe_events_product_is_ticket( $product ) {
+		$matching_event = tribe_events_get_ticket_event( $product );
+		return ( false !== $matching_event );
 	}
+}//end if
 
-	foreach ( Tribe__Events__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-		if ( Tribe__Events__Tickets__Ticket_Object::UNLIMITED_STOCK === $ticket->stock ) return true;
+if ( ! function_exists( 'tribe_events_get_ticket_event' ) ) {
+	/**
+	 * Accepts the post object or ID for a product and, if it represents an event
+	 * ticket, returns the corresponding event object.
+	 *
+	 * If this cannot be determined boolean false will be returned instead.
+	 *
+	 * @param $possible_ticket
+	 *
+	 * @return bool|WP_Post
+	 */
+	function tribe_events_get_ticket_event( $possible_ticket ) {
+		return Tribe__Events__Tickets__Tickets::find_matching_event( $possible_ticket );
 	}
+}//end if
 
-	return false;
-}
+if ( ! function_exists( 'tribe_events_ticket_is_on_sale' ) ) {
+	/**
+	 * Checks if the ticket is on sale (in relation to it's start/end sale dates).
+	 *
+	 * @param Tribe__Events__Tickets__Ticket_Object $ticket
+	 *
+	 * @return bool
+	 */
+	function tribe_events_ticket_is_on_sale( Tribe__Events__Tickets__Ticket_Object $ticket ) {
+		// No dates set? Then it's on sale!
+		if ( empty( $ticket->start_date ) && empty( $ticket->end_date ) ) {
+			return true;
+		}
 
-/**
- * Determines if the product object (or product ID) represents a ticket for
- * an event.
- *
- * @param $product
- *
- * @return bool
- */
-function tribe_events_product_is_ticket( $product ) {
-	$matching_event = tribe_events_get_ticket_event( $product );
-	return ( false !== $matching_event );
-}
+		// Timestamps for comparison purposes
+		$now    = time();
+		$start  = strtotime( $ticket->start_date );
+		$finish = strtotime( $ticket->end_date );
 
-/**
- * Accepts the post object or ID for a product and, if it represents an event
- * ticket, returns the corresponding event object.
- *
- * If this cannot be determined boolean false will be returned instead.
- *
- * @param $possible_ticket
- *
- * @return bool|WP_Post
- */
-function tribe_events_get_ticket_event( $possible_ticket ) {
-	return Tribe__Events__Tickets__Tickets::find_matching_event( $possible_ticket );
-}
+		// Are we within the applicable date range?
+		$has_started = ( empty( $ticket->start_date ) || ( $start && $now > $start ) );
+		$not_ended   = ( empty( $ticket->end_date ) || ( $finish && $now < $finish ) );
 
-/**
- * Checks if the ticket is on sale (in relation to it's start/end sale dates).
- *
- * @param Tribe__Events__Tickets__Ticket_Object $ticket
- *
- * @return bool
- */
-function tribe_events_ticket_is_on_sale( Tribe__Events__Tickets__Ticket_Object $ticket ) {
-	// No dates set? Then it's on sale!
-	if ( empty( $ticket->start_date ) && empty( $ticket->end_date ) ) {
-		return true;
+		// Result
+		return ( $has_started && $not_ended );
 	}
-
-	// Timestamps for comparison purposes
-	$now    = time();
-	$start  = strtotime( $ticket->start_date );
-	$finish = strtotime( $ticket->end_date );
-
-	// Are we within the applicable date range?
-	$has_started = ( empty( $ticket->start_date ) || ( $start && $now > $start ) );
-	$not_ended   = ( empty( $ticket->end_date ) || ( $finish && $now < $finish ) );
-
-	// Result
-	return ( $has_started && $not_ended );
-}
+}//end if


### PR DESCRIPTION
In an effort to prevent fatals when running event-tickets and a pre-4.0 version of the-events-calendar, we need to wrap a number of functions with if statements. While this won't help any TEC install less than 3.12.4, we can at least prevent the issue with the latest version.

See: https://central.tri.be/issues/40986