### PR TITLE
Use the declared $calendar_day rather than the non-existent $current_day

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -872,7 +872,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			$today                  = strtotime( current_time( 'Y-m-d' ) );
 
 			// Start by determining which month we're looking at
-			if ( $current_day['month'] == self::CURRENT_MONTH ) {
+			if ( $calendar_day['month'] == self::CURRENT_MONTH ) {
 				$classes = 'tribe-events-thismonth';
 			} else {
 				$classes = 'tribe-events-othermonth';
@@ -888,12 +888,12 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			// The day has some events
-			if ( $current_day['total_events'] > 0 ) {
+			if ( $calendar_day['total_events'] > 0 ) {
 				$classes .= ' tribe-events-has-events';
 			}
 
 			// Needed for mobile js
-			$day_num  = str_pad( $current_day['daynum'], 2, '0', STR_PAD_LEFT );
+			$day_num  = str_pad( $calendar_day['daynum'], 2, '0', STR_PAD_LEFT );
 			$classes .= ' mobile-trigger tribe-event-day-' . date_i18n( 'd', $day_num );
 
 			// Determine which column of the grid the day is in


### PR DESCRIPTION
This block of code changes in `release/121` and `$current_day` becomes a declared variable with useful data. But not in `release/120`

See: https://central.tri.be/issues/40980