### PR TITLE
Provide support for singular.php

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -126,8 +126,27 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 					add_action( 'loop_start', array( __CLASS__, 'setup_ecp_template' ) );
 				}
 
-				$template = locate_template( tribe_get_option( 'tribeEventsTemplate', 'default' ) == 'default' ? 'page.php' : tribe_get_option( 'tribeEventsTemplate', 'default' ) );
+				// Get template setting
+				$tribeEventsTemplate = tribe_get_option( 'tribeEventsTemplate', 'default' );
+				
+				// Default template
+				if ( 'default' == $tribeEventsTemplate ) {
 
+					// Check for singular.php else fallback to page.php
+					if ( ! $template = locate_template( 'page.php' ) ) {
+						$template = locate_template( 'singular.php');
+					}
+
+				}
+
+				// Custom template
+				else {
+
+					$template = $tribeEventsTemplate;
+
+				}
+
+				// Fallback template
 				if ( $template == '' ) {
 					$template = get_index_template();
 				}


### PR DESCRIPTION
Currently if a template is using singular.php and not page.php it will fallback to the index template which can cause issues on a lot of themes. This modification will first check for page.php and if it doesn't exist it will then check for singular.php.

ps: Twenty Sixteen will not have a page.php file - https://github.com/WordPress/twentysixteen