### PR TITLE
a few testing and test-ability changes

### DIFF
--- a/src/Tribe/Capabilities.php
+++ b/src/Tribe/Capabilities.php
@@ -1,6 +1,7 @@
 <?php
 
 class Tribe__Events__Capabilities {
+	public $set_initial_caps = false;
 	private $cap_aliases = array(
 		'editor' => array( // full permissions to a post type
 			'read',
@@ -70,6 +71,7 @@ class Tribe__Events__Capabilities {
 				$role->add_cap( $pto->cap->$alias );
 			}
 		}
+
 		return true;
 	}
 
@@ -101,6 +103,8 @@ class Tribe__Events__Capabilities {
 	 * @return void
 	 */
 	public function set_initial_caps() {
+		// this is a flag for testing purposes to make sure this function is firing
+		$this->set_initial_caps = true;
 		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' ) as $role ) {
 			$this->register_post_type_caps( Tribe__Events__Main::POSTTYPE, $role );
 			$this->register_post_type_caps( Tribe__Events__Main::VENUE_POST_TYPE, $role );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -345,6 +345,19 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
+		 * Updater object accessor method
+		 */
+		public function updater() {
+			static $updater;
+
+			if ( ! $updater ) {
+				$updater = new Tribe__Events__Updater( self::VERSION );
+			}
+
+			return $updater;
+		}
+
+		/**
 		 * before_html_data_wrapper adds a persistant tag to wrap the event display with a
 		 * way for jQuery to maintain state in the dom. Also has a hook for filtering data
 		 * attributes for inclusion in the dom
@@ -4512,9 +4525,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		public function run_updates() {
-			$updater = new Tribe__Events__Updater( self::VERSION );
-			if ( $updater->update_required() ) {
-				$updater->do_updates();
+			if ( $this->updater()->update_required() ) {
+				$this->updater()->do_updates();
 			}
 		}
 

--- a/tests/functional/Capabilities_Test.php
+++ b/tests/functional/Capabilities_Test.php
@@ -151,9 +151,12 @@ class Tribe__Events__Capabilities_Test extends Tribe__Events__WP_UnitTestCase {
 	 * @param string $role
 	 * @param bool $can
 	 *
-	 * @dataProvider editor_or_higher
+	 * @dataProvider contributor_or_higher
 	 */
 	public function tests_role_can_edit_venues( $role, $can ) {
+		$caps = new Tribe__Events__Capabilities();
+		$caps->register_post_type_caps( Tribe__Events__Main::VENUE_POST_TYPE, $role );
+
 		/** @var WP_User $user */
 		$user = $this->factory->user->create_and_get( array(
 			'role' => $role,
@@ -166,7 +169,7 @@ class Tribe__Events__Capabilities_Test extends Tribe__Events__WP_UnitTestCase {
 	 * @param string $role
 	 * @param bool $can
 	 *
-	 * @dataProvider editor_or_higher
+	 * @dataProvider contributor_or_higher
 	 */
 	public function tests_role_can_edit_organizers( $role, $can ) {
 		/** @var WP_User $user */

--- a/tests/functional/Updater_Test.php
+++ b/tests/functional/Updater_Test.php
@@ -5,6 +5,83 @@
  */
 class Tribe__Events__Updater_Test extends Tribe__Events__WP_UnitTestCase {
 
+	/**
+	 * This test should run first, confirms that it is running on a fresh install
+	 */
+	public function test_is_new_install() {
+		$updater = Tribe__Events__Main::instance()->updater();
+
+		$this->assertTrue( $updater->capabilities->set_initial_caps );
+
+		$this->assertTrue( $updater->is_new_install(), 'Check if this is reporting as a new install' );
+	}
+
+	public function test_update_required() {
+		$current_version = Tribe__Events__Main::VERSION;
+		$updater = Tribe__Events__Main::instance()->updater();
+
+		$update_required = $updater->update_required();
+		$this->assertTrue( $update_required, "Checking that initial version in database is less than $current_version" );
+
+		$version_in_db = $updater->get_version_from_db();
+		$this->assertEmpty( $version_in_db, 'Checking that the initial version is an empty string' );
+
+		// set the existing version to be "old"
+		$updater->update_version_option( '3.12' );
+
+		$update_required = $updater->update_required();
+		$this->assertTrue( $update_required, "Checking that 3.12 is less than $current_version" );
+
+		// set the existing version to be current
+		$updater->update_version_option( $current_version );
+
+		$update_required = $updater->update_required();
+		$this->assertFalse( $update_required, 'Checking that no upgrade is required when the versions match' );
+	}
+
+	public function test_get_version_from_db() {
+		$version_from_settings_manager = Tribe__Settings_Manager::get_option( 'schema-version' );
+
+		$updater = Tribe__Events__Main::instance()->updater();
+		$version_from_updater = $updater->get_version_from_db();
+
+		$this->assertEquals( $version_from_updater, $version_from_settings_manager, 'checking that the version from Settings Manager matches the version from Updater' );
+	}
+
+	public function test_update_version_option() {
+		$current_version = Tribe__Events__Main::VERSION;
+		$updater = Tribe__Events__Main::instance()->updater();
+		$updater->update_version_option( $current_version );
+
+		$version_in_db = $updater->get_version_from_db();
+
+		$this->assertEquals( $version_in_db, $current_version, "checking that the version in the database was set to $current_version" );
+
+		$updater->reset();
+
+		$version_in_db = $updater->get_version_from_db();
+		$this->assertEquals( $version_in_db, 3.9, 'checking that the version in the database was set to 3.9' );
+	}
+
+	public function test_get_updates() {
+		$current_version = Tribe__Events__Main::VERSION;
+		$updater = Tribe__Events__Main::instance()->updater();
+
+		$updates = $updater->get_updates();
+		foreach ( $updates as $version => $update_callable ) {
+			$this->assertTrue( is_callable( $update_callable ), "checking defined update function is callable ($version)" );
+		}
+	}
+
+	public function test_constant_updates() {
+		$current_version = Tribe__Events__Main::VERSION;
+		$updater = Tribe__Events__Main::instance()->updater();
+
+		$contant_updates = $updater->constant_updates();
+		foreach ( $contant_updates as $contant_update_callable ) {
+			$this->assertTrue( is_callable( $contant_update_callable ), 'checking constant update function is callable' );
+		}
+	}
 
 	public function test_constant_updates_applied() {
 		$settings = Tribe__Settings_Manager::instance();


### PR DESCRIPTION
* bugfix in the Updater so it does not run the upgrade functions on a new install
* changing functions from `protected` to `public` to make them more testable
* capturing the updater object in a `static` variable to make it more testable
* fix the Capabilities Venue/Organizer tests to use the right data provider
* add a bunch of Updater tests