### PR TITLE
Don't rely on the WP hook system to setup the tickets module (#41099)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4626,6 +4626,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			require_once $this->plugin_path . 'vendor/tickets/event-tickets.php';
+			Tribe__Tickets__Main::instance()->plugins_loaded();
 		}
 
 		/**


### PR DESCRIPTION
Partner to [Event Tickets PR/28](https://github.com/moderntribe/event-tickets/pull/28) - we need to set up the main tickets class (when we decide to load the tickets framework as a submodule) directly.

[C#41099](https://central.tri.be/issues/41099)