### PR TITLE
Events title tag should be an h1

### DIFF
--- a/src/views/single-event.php
+++ b/src/views/single-event.php
@@ -30,7 +30,7 @@ $event_id = get_the_ID();
 	<!-- Notices -->
 	<?php tribe_events_the_notices() ?>
 
-	<?php the_title( '<h2 class="tribe-events-single-event-title summary entry-title">', '</h2>' ); ?>
+	<?php the_title( '<h1 class="tribe-events-single-event-title summary entry-title">', '</h1>' ); ?>
 
 	<div class="tribe-events-schedule updated published tribe-clearfix">
 		<?php echo tribe_events_event_schedule_details( $event_id, '<h3>', '</h3>' ); ?>


### PR DESCRIPTION
For SEO reasons it makes more sense for the title to be an H1 tag and not an h2.