### PR TITLE
Restore expected day classes in month view | #41258

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -879,11 +879,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			// Check if the calendar day is in the past, present, or future
-			if ( $calendar_day < $today ) {
+			if ( $calendar_day_timestamp < $today ) {
 				$classes .= ' tribe-events-past';
-			} elseif ( $calendar_day === $today ) {
+			} elseif ( $calendar_day_timestamp === $today ) {
 				$classes .= ' tribe-events-present';
-			} elseif ( $calendar_day > $today ) {
+			} elseif ( $calendar_day_timestamp > $today ) {
 				$classes .= ' tribe-events-future';
 			}
 
@@ -894,7 +894,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			// Needed for mobile js
 			$day_num  = str_pad( $calendar_day['daynum'], 2, '0', STR_PAD_LEFT );
-			$classes .= ' mobile-trigger tribe-event-day-' . date_i18n( 'd', $day_num );
+			$classes .= ' mobile-trigger tribe-event-day-' . $day_num;
 
 			// Determine which column of the grid the day is in
 			$column = ( self::$current_day ) - ( self::$current_week * 7 );


### PR DESCRIPTION
Restores the expected CSS classes for each day in month view:

* Compares timestamps with timestamps (was comparing a timestamp with an array)
* Drops unneeded use of `date_i18n()` for day numbers (was effectively converting them all to `01`)

[C#41258](https://central.tri.be/issues/41258)