### PR TITLE
For SEO reasons, use an h1 rather than an h2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -318,6 +318,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [4.1] unreleased =
+
+* Tweak - For SEO reasons, use an <h1> for the title rather than an <h2> (props to wpexplorer for this fix)
+
 = [4.0 beta] unreleased =
 
 * Security - A TON of escaping was added to our codebase thanks to the efforts of Andy Fragen (@afragen)

--- a/src/views/single-event.php
+++ b/src/views/single-event.php
@@ -30,7 +30,7 @@ $event_id = get_the_ID();
 	<!-- Notices -->
 	<?php tribe_the_notices() ?>
 
-	<?php the_title( '<h2 class="tribe-events-single-event-title">', '</h2>' ); ?>
+	<?php the_title( '<h1 class="tribe-events-single-event-title">', '</h1>' ); ?>
 
 	<div class="tribe-events-schedule tribe-clearfix">
 		<?php echo tribe_events_event_schedule_details( $event_id, '<h2>', '</h2>' ); ?>


### PR DESCRIPTION
Original [PR from @wpexplorer](https://github.com/moderntribe/the-events-calendar/pull/419). This is being re-pull-requested to resolve the merge conflicts.

See: https://central.tri.be/issues/41300