### PR TITLE
Remove some capability checks that should have been held back until r/121

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [3.12.6] 2015-11-10 =
+
+* Fix - Remove constraints on defining new venues and organizers that were added prematurely (our thanks to Jeramey for highlighting this)
+
 = [3.12.5] 2015-11-05 =
 
 * Fix - Restore styling and full mobile functionality to month view (our thanks to Rich Cottee for highlighting this)

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1578,7 +1578,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			if ( $venues || $my_venues ) {
 				echo '<select class="chosen venue-dropdown" name="' . esc_attr( $name ) . '" id="saved_venue">';
 				echo '<option value="0">' . esc_html( sprintf( __( 'Use New %s', 'the-events-calendar' ), $this->singular_venue_label ) ) . '</option>';
-				
+
 				if ( $my_venues ) {
 					echo $venues ? '<optgroup label="' . esc_attr( apply_filters( 'tribe_events_saved_venues_dropdown_my_optgroup', sprintf( __( 'My %s', 'the-events-calendar' ), $this->plural_venue_label ) ) ) . '">' : '';
 					echo $my_venue_options;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1576,15 +1576,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				);
 			}
 			if ( $venues || $my_venues ) {
-				$venue_pto = get_post_type_object( self::VENUE_POST_TYPE );
 				echo '<select class="chosen venue-dropdown" name="' . esc_attr( $name ) . '" id="saved_venue">';
-
-				if (
-					! empty( $venue_pto->cap->create_posts )
-					&& current_user_can( $venue_pto->cap->create_posts )
-				) {
-					echo '<option value="0">' . esc_html( sprintf( __( 'Use New %s', 'tribe-events-calendar' ), $this->singular_venue_label ) ) . '</option>';
-				}
+				echo '<option value="0">' . esc_html( sprintf( __( 'Use New %s', 'the-events-calendar' ), $this->singular_venue_label ) ) . '</option>';
+				
 				if ( $my_venues ) {
 					echo $venues ? '<optgroup label="' . esc_attr( apply_filters( 'tribe_events_saved_venues_dropdown_my_optgroup', sprintf( __( 'My %s', 'the-events-calendar' ), $this->plural_venue_label ) ) ) . '">' : '';
 					echo $my_venue_options;
@@ -1665,15 +1659,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				);
 			}
 			if ( $organizers || $my_organizers ) {
-				$oganizer_pto = get_post_type_object( self::ORGANIZER_POST_TYPE );
 				echo '<select class="chosen organizer-dropdown" name="' . esc_attr( $name ) . '" id="saved_organizer">';
+				echo '<option value="0">' . esc_html( sprintf( __( 'Use New %s', 'the-events-calendar' ), $this->singular_organizer_label ) ) . '</option>';
 
-				if (
-					! empty( $oganizer_pto->cap->create_posts )
-					&& current_user_can( $oganizer_pto->cap->create_posts )
-				) {
-					echo '<option value="0">' . esc_html( sprintf( __( 'Use New %s', 'the-events-calendar' ), $this->singular_organizer_label ) ) . '</option>';
-				}
 				if ( $my_organizers ) {
 					echo $organizers ? '<optgroup label="' . esc_attr( apply_filters( 'tribe_events_saved_organizers_dropdown_my_optgroup', sprintf( __( 'My %s', 'the-events-calendar' ), $this->plural_organizer_label ) ) ) . '">' : '';
 					echo $my_organizers_options;

--- a/src/admin-views/new-organizer-meta-section.php
+++ b/src/admin-views/new-organizer-meta-section.php
@@ -13,12 +13,6 @@ $organizer_pto = get_post_type_object( Tribe__Events__Main::ORGANIZER_POST_TYPE 
 ?>
 <script type="text/template" id="tmpl-tribe-create-organizer">
 <tbody class="new-organizer">
-<?php
-if (
-	! empty( $organizer_pto->cap->create_posts )
-	&& current_user_can( $organizer_pto->cap->create_posts )
-) {
-	?>
 	<tr class="organizer">
 		<td><?php printf( __( '%s Name:', 'the-events-calendar' ), tribe_get_organizer_label_singular() ); ?></td>
 		<td>
@@ -54,9 +48,6 @@ if (
 			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='organizer[Email][]' class='organizer-email' size='25' value='' />
 		</td>
 	</tr>
-<?php } else { ?>
-	<tr><td></td></tr>
-<?php } ?>
 </tbody>
 </script>
 


### PR DESCRIPTION
Some untested code relating to capabilities for venue and organizer post types snuck into core and caused breakages. This strips those back out.

[C#41329](https://central.tri.be/issues/41329)