### PR TITLE
Ensure that EventStartDate isn't stripped from importer page queries

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -352,24 +352,17 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			// if is in the admin remove the event date & upcoming filters, unless is an ajax call
-			if (
-				is_admin()
-				&& $query->tribe_is_event_query
-				&& $admin_helpers->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE )
-			) {
-				if ( ( ! defined( 'DOING_AJAX' ) ) || ( defined( 'DOING_AJAX' ) && ! ( DOING_AJAX ) ) ) {
+			if ( self::should_remove_date_filters( $query ) ) {
+				remove_filter( 'posts_where', array( __CLASS__, 'posts_where' ), 10, 2 );
+				remove_filter( 'posts_fields', array( __CLASS__, 'posts_fields' ) );
+				$query->set( 'post__not_in', '' );
 
-					remove_filter( 'posts_where', array( __CLASS__, 'posts_where' ), 10, 2 );
-					remove_filter( 'posts_fields', array( __CLASS__, 'posts_fields' ) );
-					$query->set( 'post__not_in', '' );
-
-					// set the default order for posts within admin lists
-					if ( ! isset( $query->query['order'] ) ) {
-						$query->set( 'order', 'DESC' );
-					} else {
-						// making sure we preserve the order supplied by the query string even if it is overwritten above
-						$query->set( 'order', $query->query['order'] );
-					}
+				// set the default order for posts within admin lists
+				if ( ! isset( $query->query['order'] ) ) {
+					$query->set( 'order', 'DESC' );
+				} else {
+					// making sure we preserve the order supplied by the query string even if it is overwritten above
+					$query->set( 'order', $query->query['order'] );
 				}
 			}
 
@@ -378,6 +371,27 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			return $query;
+		}
+
+		/**
+		 * Returns whether or not the event date & upcoming filters should be removed from the query
+		 */
+		public static function should_remove_date_filters( $query ) {
+			// if we are on an import page, let's keep the date filters
+			if ( isset( $_GET['page'] ) && 'events-importer' == $_GET['page'] ) {
+				return false;
+			}
+
+			// if we're doing ajax, let's keep the date filters
+			if ( Tribe__Main::instance()->doing_ajax() ) {
+				return false;
+			}
+
+			// otherwise, let's remove the date filters if we're in the admin dashboard and the query is
+			// and event query on the tribe_events edit page
+			return is_admin()
+				&& $query->tribe_is_event_query
+				&& Tribe__Admin__Helpers::instance()->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
 		}
 
 		/**

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -375,6 +375,10 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 
 		/**
 		 * Returns whether or not the event date & upcoming filters should be removed from the query
+		 *
+		 * @since 4.0
+		 * @param WP_Query $query WP_Query object
+		 * @return boolean
 		 */
 		public static function should_remove_date_filters( $query ) {
 			// if we are on an import page, let's keep the date filters

--- a/tests/functional/Query/Date_Filter_Test.php
+++ b/tests/functional/Query/Date_Filter_Test.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Test that the Event Queries behave as expected
+ *
+ * @group   core
+ *
+ * @package Tribe__Events__Main
+ */
+class Tribe_Query_Date_Filter_Test extends Tribe__Events__WP_UnitTestCase {
+	/**
+	 * Event date & upcoming filters should not be removed from non-admin pages
+	 *
+	 * @test
+	 */
+	public function it_should_not_remove_date_filters_on_front_end() {
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => Tribe__Events__Main::POSTTYPE,
+		] );
+
+		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on the front end' );
+	}
+
+	/**
+	 * Event date & upcoming filters should not be removed from queries for non event post types
+	 *
+	 * @test
+	 */
+	public function it_should_not_remove_date_filters_on_non_event_query() {
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => 'post',
+		] );
+
+		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event queries' );
+	}
+
+	/**
+	 * Event date & upcoming filters should not be removed from admin pages that aren't event edit pages
+	 *
+	 * @test
+	 */
+	public function it_should_not_remove_date_filters_on_non_event_edit_pages() {
+		set_current_screen( 'edit-post' );
+
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => Tribe__Events__Main::POSTTYPE,
+		] );
+
+		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event edit pages' );
+	}
+
+	/**
+	 * Event date & upcoming filters should not be removed from the event import page
+	 *
+	 * @test
+	 */
+	public function it_should_not_remove_date_filters_on_event_import_page() {
+		set_current_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
+
+		$_GET['page'] = 'events-importer';
+		$_GET['tab'] = 'general';
+
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => Tribe__Events__Main::POSTTYPE,
+		] );
+
+		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed when on the event import page' );
+	}
+
+	/**
+	 * Event date & upcoming filters should not be removed when the query is being done via AJAX
+	 *
+	 * We have to segregate the AJAX tests because we're going to twiddle the DOING_AJAX constant
+	 *
+	 * @test
+	 */
+	public function it_should_not_remove_date_filters_when_doing_ajax() {
+		Tribe__Main::instance()->doing_ajax( true );
+
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => Tribe__Events__Main::POSTTYPE,
+		] );
+
+		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed when doing AJAX stuff' );
+
+		Tribe__Main::instance()->doing_ajax( false );
+	}
+
+	/**
+	 * Event date & upcoming filters SHOULD be removed from event list pages (they do their own date filtering)
+	 *
+	 * @test
+	 */
+	public function it_should_remove_date_filters_on_event_list() {
+		set_current_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
+
+		$query = new WP_Query;
+		$query->parse_query( [
+			'post_type' => Tribe__Events__Main::POSTTYPE,
+		] );
+
+		if ( isset( $_GET['page'] ) ) {
+			unset( $_GET['page'] );
+		}
+
+		if ( isset( $_GET['tab'] ) ) {
+			unset( $_GET['tab'] );
+		}
+
+		$this->assertTrue( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event list page' );
+	}
+}


### PR DESCRIPTION
The Facebook importer lives on the "same" current screen as the event list in the dashboard, however, it _should not_ have the date filters removed like the event list requires. This fixes that so that duplicate Facebook imports can be identified.

This changeset includes tests.

~~This change set _requires_ [this PR](https://github.com/moderntribe/tribe-common/pull/28) to be merged into tribe-common (and the hash will need an update)~~ The hash for the `common/`directory has been updated.

Best reviewed with `?w=1`

See: https://central.tri.be/issues/41385