### PR TITLE
Re-structure Query::set_order() to allow better support on WP 4.2

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -627,8 +627,10 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return string
 		 */
 		public static function set_order( $default = null, $query = null ) {
-			// What should $default be?
-			if ( null === $default && isset( $query->query['order'] ) ) {
+			// As of WordPress 4.2 'order' can be set via the 'orderby' as an associative array
+			if ( ! empty( $query->query['orderby'] ) && is_array( $query->query['orderby'] ) && ! empty( $query->query['orderby']['meta_value'] ) ){
+				$default = $query->query['orderby']['meta_value'];
+			} elseif ( ! empty( $query->query['order'] ) ) {
 				$default = $query->query['order'];
 			} elseif ( null === $default ) {
 				$default = 'ASC';

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -628,7 +628,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 */
 		public static function set_order( $default = null, $query = null ) {
 			// As of WordPress 4.2 'order' can be set via the 'orderby' as an associative array
-			if ( ! empty( $query->query['orderby'] ) && is_array( $query->query['orderby'] ) && ! empty( $query->query['orderby']['meta_value'] ) ){
+			if ( ! empty( $query->query['orderby'] ) && is_array( $query->query['orderby'] ) && ! empty( $query->query['orderby']['meta_value'] ) ) {
 				$default = $query->query['orderby']['meta_value'];
 			} elseif ( ! empty( $query->query['order'] ) ) {
 				$default = $query->query['order'];


### PR DESCRIPTION
_Ref:_ [C#38473](https://central.tri.be/issues/38473)