### PR TITLE
Don't change the visibility of these methods. Make new methods

### DIFF
--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -59,9 +59,24 @@ class Tribe__Events__Updater {
 	 * and lower than $this->current_version will have its
 	 * callback called.
 	 *
+	 * This method has been deprecated in favor of a more testable public function
+	 *
+	 * @return array
+	 * @deprecated 4.0
+	 */
+	protected function get_updates() {
+		return $this->get_update_callbacks();
+	}
+
+	/**
+	 * Returns an array of callbacks with version strings as keys.
+	 * Any key higher than the version recorded in the DB
+	 * and lower than $this->current_version will have its
+	 * callback called.
+	 *
 	 * @return array
 	 */
-	public function get_updates() {
+	public function get_update_callbacks() {
 		return array(
 			'2.0.1'  => array( $this, 'migrate_from_sp_events' ),
 			'2.0.6'  => array( $this, 'migrate_from_sp_options' ),
@@ -74,9 +89,22 @@ class Tribe__Events__Updater {
 	 * Returns an array of callbacks that should be called
 	 * every time the version is updated
 	 *
+	 * This method has been deprecated in favor of a more testable public function
+	 *
+	 * @return array
+	 * @deprecated 4.0
+	 */
+	protected function constant_updates() {
+		return $this->get_constant_update_callbacks();
+	}
+
+	/**
+	 * Returns an array of callbacks that should be called
+	 * every time the version is updated
+	 *
 	 * @return array
 	 */
-	public function constant_updates() {
+	public function get_constant_update_callbacks() {
 		return array(
 			array( $this, 'flush_rewrites' ),
 			array( $this, 'set_capabilities' ),

--- a/tests/functional/Updater_Test.php
+++ b/tests/functional/Updater_Test.php
@@ -63,21 +63,21 @@ class Tribe__Events__Updater_Test extends Tribe__Events__WP_UnitTestCase {
 		$this->assertEquals( $version_in_db, 3.9, 'checking that the version in the database was set to 3.9' );
 	}
 
-	public function test_get_updates() {
+	public function test_get_update_callbacks() {
 		$current_version = Tribe__Events__Main::VERSION;
 		$updater = Tribe__Events__Main::instance()->updater();
 
-		$updates = $updater->get_updates();
+		$updates = $updater->get_update_callbacks();
 		foreach ( $updates as $version => $update_callable ) {
 			$this->assertTrue( is_callable( $update_callable ), "checking defined update function is callable ($version)" );
 		}
 	}
 
-	public function test_constant_updates() {
+	public function test_get_constant_update_callbacks() {
 		$current_version = Tribe__Events__Main::VERSION;
 		$updater = Tribe__Events__Main::instance()->updater();
 
-		$contant_updates = $updater->constant_updates();
+		$contant_updates = $updater->get_constant_update_callbacks();
 		foreach ( $contant_updates as $contant_update_callable ) {
 			$this->assertTrue( is_callable( $contant_update_callable ), 'checking constant update function is callable' );
 		}


### PR DESCRIPTION
To more easily test `get_updates()` and `constant_updates()`, those methods were converted to public. This causes fatals when Pro 3.12.x is active because Pro has a class that extends `Tribe__Events__Updater` and overrides the `protected` methods.

The fix is to retain those methods as protected and make new ones that are public.

See: https://central.tri.be/issues/40281