### PR TITLE
If we unhook posts_fields() we should also unhook posts_orderby()

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -355,6 +355,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			if ( self::should_remove_date_filters( $query ) ) {
 				remove_filter( 'posts_where', array( __CLASS__, 'posts_where' ), 10, 2 );
 				remove_filter( 'posts_fields', array( __CLASS__, 'posts_fields' ) );
+				remove_filter( 'posts_orderby', array( __CLASS__, 'posts_orderby' ), 10, 2 );
 				$query->set( 'post__not_in', '' );
 
 				// set the default order for posts within admin lists


### PR DESCRIPTION
Within `Tribe__Events__Query` if `self::should_remove_date_filters( $query )` is true we unhook our `posts_fields` filter but not our `posts_orderby` filter (which depends on the aliases set up by the former). This change ensures they are all unhooked together - otherwise we hit things like:

*Unknown column 'EventStartDate' in 'order clause'*

[C#35479](https://central.tri.be/issues/35479)