### PR TITLE
Remove date filters on import pages

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -382,11 +382,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return boolean
 		 */
 		public static function should_remove_date_filters( $query ) {
-			// if we are on an import page, let's keep the date filters
-			if ( isset( $_GET['page'] ) && 'events-importer' == $_GET['page'] ) {
-				return false;
-			}
-
 			// if we're doing ajax, let's keep the date filters
 			if ( Tribe__Main::instance()->doing_ajax() ) {
 				return false;

--- a/tests/functional/Query/Date_Filter_Test.php
+++ b/tests/functional/Query/Date_Filter_Test.php
@@ -56,7 +56,7 @@ class Tribe_Query_Date_Filter_Test extends Tribe__Events__WP_UnitTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_not_remove_date_filters_on_event_import_page() {
+	public function it_should_remove_date_filters_on_event_import_page() {
 		set_current_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
 
 		$_GET['page'] = 'events-importer';
@@ -67,7 +67,7 @@ class Tribe_Query_Date_Filter_Test extends Tribe__Events__WP_UnitTestCase {
 			'post_type' => Tribe__Events__Main::POSTTYPE,
 		] );
 
-		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed when on the event import page' );
+		$this->assertTrue( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event import page' );
 	}
 
 	/**


### PR DESCRIPTION
With [this fix](https://github.com/moderntribe/the-events-calendar/pull/445), we don't really need filters on the import pages. In fact, excluding them is necessary. Previous tests returned false positives that were caused by the date of the event and the injected date aligning just so...through crazy random happenstance. When looking for importable events, we won't need to have a date-beefed-up query.

See: https://central.tri.be/issues/41385