### PR TITLE
Do not output a prev month link if the earliest event date is unknown | #33449

### DIFF
--- a/src/functions/template-tags/month.php
+++ b/src/functions/template-tags/month.php
@@ -247,8 +247,10 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$html = '';
 		$url  = tribe_get_previous_month_link();
 		$date = Tribe__Events__Main::instance()->previousMonth( tribe_get_month_view_date() );
+		$earliest_event_date = tribe_events_earliest_date( Tribe__Date_Utils::DBYEARMONTHTIMEFORMAT );
 
-		if ( $date >= tribe_events_earliest_date( Tribe__Date_Utils::DBYEARMONTHTIMEFORMAT ) ) {
+		// Only form the link if a) we have a known earliest event date and b) the previous month date is the same or later
+		if ( $earliest_event_date && $date >= $earliest_event_date ) {
 			$text = tribe_get_previous_month_text();
 			$html = '<a data-month="' . $date . '" href="' . esc_url( $url ) . '" rel="prev"><span>&laquo;</span> ' . $text . ' </a>';
 		}


### PR DESCRIPTION
On a brand spankers install / if no events have yet been added to the db, then we don't have such a thing as a date for the earliest event and we shouldn't display a link to the previous month.

[C#33449](https://central.tri.be/issues/33449)