### PR TITLE
Created the phantomjs suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
   "prefer-stable": true,
   "config": {
     "preferred-install": "dist"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tribe\\Tests\\Modules\\Core\\": "tests/_support/Modules"
+    }
   }
 }

--- a/tests/_support/Helper/Phantomjs.php
+++ b/tests/_support/Helper/Phantomjs.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Phantomjs extends \Codeception\Module
+{
+
+}

--- a/tests/_support/Modules/Acceptance/Options.php
+++ b/tests/_support/Modules/Acceptance/Options.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tribe\Tests\Modules\Core\Acceptance;
+
+
+class Options extends \Codeception\Module {
+
+	/**
+	 * Returns an array of default options overriding the specified ones.
+	 *
+	 * @param array $overrides
+	 *
+	 * @return array
+	 */
+	public function grabDefaultCoreOptions( array $overrides = [ ] ) {
+		$defaults = [
+			'schema-version'                   => '4.0beta2',
+			'recurring_events_are_hidden'      => 'hidden',
+			'previous_ecp_versions'            => [
+				0 => '0',
+			],
+			'latest_ecp_version'               => '4.0beta2',
+			'donate-link'                      => false,
+			'postsPerPage'                     => '10',
+			'liveFiltersUpdate'                => true,
+			'showComments'                     => false,
+			'showEventsInMainLoop'             => false,
+			'eventsSlug'                       => 'events',
+			'singleEventSlug'                  => 'event',
+			'multiDayCutoff'                   => '00:00',
+			'defaultCurrencySymbol'            => '$',
+			'reverseCurrencyPosition'          => false,
+			'embedGoogleMaps'                  => true,
+			'embedGoogleMapsZoom'              => '10',
+			'debugEvents'                      => false,
+			'tribe_events_timezone_mode'       => 'event',
+			'tribe_events_timezones_show_zone' => false,
+			'stylesheetOption'                 => 'tribe',
+			'tribeEventsTemplate'              => 'default',
+			'tribeEnableViews'                 => [
+				0 => 'list',
+				1 => 'month',
+				2 => 'day',
+			],
+			'viewOption'                       => 'month',
+			'tribeDisableTribeBar'             => false,
+			'monthEventAmount'                 => '3',
+			'enable_month_view_cache'          => false,
+			'dateWithYearFormat'               => 'm/d/Y',
+			'dateWithoutYearFormat'            => 'F j',
+			'monthAndYearFormat'               => 'F Y',
+			'dateTimeSeparator'                => ' @ ',
+			'timeRangeSeparator'               => ' - ',
+			'datepickerFormat'                 => '0',
+			'tribeEventsBeforeHTML'            => '',
+			'tribeEventsAfterHTML'             => '',
+		];
+
+		return array_merge( $defaults, $overrides );
+	}
+}

--- a/tests/_support/Modules/Acceptance/Options.php
+++ b/tests/_support/Modules/Acceptance/Options.php
@@ -12,7 +12,7 @@ class Options extends \Codeception\Module {
 	 *
 	 * @return array
 	 */
-	public function grabDefaultCoreOptions( array $overrides = [ ] ) {
+	public function getDefaultCoreOptions( array $overrides = [ ] ) {
 		$defaults = [
 			'schema-version'                   => '4.0beta2',
 			'recurring_events_are_hidden'      => 'hidden',

--- a/tests/_support/PhantomjsTester.php
+++ b/tests/_support/PhantomjsTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class PhantomjsTester extends \Codeception\Actor
+{
+    use _generated\PhantomjsTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/phantomjs.suite.dist.yml
+++ b/tests/phantomjs.suite.dist.yml
@@ -1,0 +1,22 @@
+class_name: PhantomjsTester
+modules:
+modules:
+    enabled:
+        - WPWebDriver
+        - \Helper\Phantomjs
+        - Asserts
+        - WPDb
+        - \Tribe\Tests\Modules\Core\Acceptance\Options
+    config:
+        WPDb:
+            populate: false
+            cleanup: false
+        WPWebDriver:
+            url: 'http://tec.tri.be'
+            browser: phantomjs
+            port: 4444
+            restart: true
+            wait: 0
+            adminUsername: admin
+            adminPassword: password
+            adminUrl: /wp-admin

--- a/tests/phantomjs.suite.dist.yml
+++ b/tests/phantomjs.suite.dist.yml
@@ -12,11 +12,7 @@ modules:
             populate: false
             cleanup: false
         WPWebDriver:
-            url: 'http://tec.tri.be'
             browser: phantomjs
             port: 4444
             restart: true
             wait: 0
-            adminUsername: admin
-            adminPassword: password
-            adminUrl: /wp-admin

--- a/tests/phantomjs.suite.yml
+++ b/tests/phantomjs.suite.yml
@@ -12,11 +12,7 @@ modules:
             populate: false
             cleanup: false
         WPWebDriver:
-            url: 'http://tribe-pro.dev'
             browser: phantomjs
             port: 4444
             restart: true
             wait: 0
-            adminUsername: admin
-            adminPassword: iguana
-            adminUrl: /wp-admin

--- a/tests/phantomjs.suite.yml
+++ b/tests/phantomjs.suite.yml
@@ -1,0 +1,22 @@
+class_name: PhantomjsTester
+modules:
+modules:
+    enabled:
+        - WPWebDriver
+        - \Helper\Phantomjs
+        - Asserts
+        - WPDb
+        - \Tribe\Tests\Modules\Core\Acceptance\Options
+    config:
+        WPDb:
+            populate: false
+            cleanup: false
+        WPWebDriver:
+            url: 'http://tribe-pro.dev'
+            browser: phantomjs
+            port: 4444
+            restart: true
+            wait: 0
+            adminUsername: admin
+            adminPassword: iguana
+            adminUrl: /wp-admin

--- a/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
+++ b/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
@@ -8,7 +8,7 @@ class Issue_38042_Dropping_CategoryCest {
 
 	public function _before( PhantomjsTester $I ) {
 		$this->settings_backup = $I->grabOptionFromDatabase( 'tribe_events_calendar_options' );
-		codecept_debug( "Settings backup: " . print_r( json_encode( $this->settings_backup, true ), true ) );
+		codecept_debug( "Settings backup: " . json_encode( $this->settings_backup ) );
 
 		// use the default events template and set the view to month
 		$options = $I->getDefaultCoreOptions( [ 'tribeEventsTemplate' => '', 'viewOption' => 'month' ] );

--- a/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
+++ b/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
@@ -11,7 +11,7 @@ class Issue_38042_Dropping_CategoryCest {
 		codecept_debug( "Settings backup: " . print_r( json_encode( $this->settings_backup, true ), true ) );
 
 		// use the default events template and set the view to month
-		$options = $I->grabDefaultCoreOptions( [ 'tribeEventsTemplate' => '', 'viewOption' => 'month' ] );
+		$options = $I->getDefaultCoreOptions( [ 'tribeEventsTemplate' => '', 'viewOption' => 'month' ] );
 		$I->haveOptionInDatabase( 'tribe_events_calendar_options', $options );
 
 		// let's resize the window not to incure in mobile breakpoints

--- a/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
+++ b/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
@@ -6,26 +6,31 @@ class Issue_38042_Dropping_CategoryCest {
 	protected $an_existing_event_category = 'barbecue';
 	protected $settings_backup;
 
-	public function _before( AcceptanceTester $I ) {
-		// Make sure the WPDb module is not pointing to the test database but to the one currently serving the domain the acceptance test is hitting!
+	public function _before( PhantomjsTester $I ) {
 		$this->settings_backup = $I->grabOptionFromDatabase( 'tribe_events_calendar_options' );
-		codecept_debug( "Settings backup: " . json_encode( $this->settings_backup ) );
-		$option_initial_state = "a:27:{s:14:\"schema-version\";s:8:\"4.0beta2\";s:27:\"recurring_events_are_hidden\";s:7:\"exposed\";s:21:\"previous_ecp_versions\";a:1:{i:0;s:1:\"0\";}s:18:\"latest_ecp_version\";s:8:\"4.0beta2\";s:29:\"disable_metabox_custom_fields\";s:4:\"show\";s:18:\"pro-schema-version\";s:8:\"4.0beta2\";s:16:\"stylesheetOption\";s:5:\"tribe\";s:19:\"tribeEventsTemplate\";s:0:\"\";s:16:\"tribeEnableViews\";a:6:{i:0;s:4:\"list\";i:1;s:5:\"month\";i:2;s:4:\"week\";i:3;s:3:\"day\";i:4;s:3:\"map\";i:5;s:5:\"photo\";}s:10:\"viewOption\";s:5:\"month\";s:20:\"tribeDisableTribeBar\";b:0;s:18:\"hideLocationSearch\";b:0;s:17:\"hideRelatedEvents\";b:0;s:23:\"week_view_hide_weekends\";b:0;s:16:\"monthEventAmount\";s:1:\"3\";s:23:\"enable_month_view_cache\";b:0;s:18:\"dateWithYearFormat\";s:6:\"F j, Y\";s:21:\"dateWithoutYearFormat\";s:3:\"F j\";s:18:\"monthAndYearFormat\";s:3:\"F Y\";s:13:\"weekDayFormat\";s:4:\"D jS\";s:17:\"dateTimeSeparator\";s:3:\" @ \";s:18:\"timeRangeSeparator\";s:3:\" - \";s:16:\"datepickerFormat\";s:1:\"0\";s:21:\"tribeEventsBeforeHTML\";s:0:\"\";s:20:\"tribeEventsAfterHTML\";s:0:\"\";s:13:\"earliest_date\";s:19:\"2015-09-03 00:00:00\";s:11:\"latest_date\";s:19:\"2016-04-21 23:59:59\";}";
-		$I->haveOptionInDatabase( 'tribe_events_calendar_options', $option_initial_state );
+		codecept_debug( "Settings backup: " . print_r( json_encode( $this->settings_backup, true ), true ) );
+
+		// use the default events template and set the view to month
+		$options = $I->grabDefaultCoreOptions( [ 'tribeEventsTemplate' => '', 'viewOption' => 'month' ] );
+		$I->haveOptionInDatabase( 'tribe_events_calendar_options', $options );
+
+		// let's resize the window not to incure in mobile breakpoints
+		$I->resizeWindow( 1200, 1000 );
+
 		$I->amOnPage( "/events/category/{$this->an_existing_event_category}" );
 
 		// Why not inserting some posts and categories too?
 		//This issue *should* be independent of posts and categories in the database.
 	}
 
-	public function _after( AcceptanceTester $I ) {
+	public function _after( PhantomjsTester $I ) {
 	}
 
 	/**
 	 * @test
 	 * it should not drop the category when using the Tribe search bar
 	 */
-	public function it_should_not_drop_the_category_when_using_the_tribe_search_bar( AcceptanceTester $I ) {
+	public function it_should_not_drop_the_category_when_using_the_tribe_search_bar( PhantomjsTester $I ) {
 		$I->fillField( 'input[name="tribe-bar-search"]', 'foo' );
 		$I->click( 'input[name="submit-bar"]' );
 		$I->waitForJqueryAjax( 10 );
@@ -38,7 +43,7 @@ class Issue_38042_Dropping_CategoryCest {
 	 * @test
 	 * it should it should not drop the category when unsing the month selector
 	 */
-	public function it_should_it_should_not_drop_the_category_when_unsing_the_month_selector( AcceptanceTester $I ) {
+	public function it_should_it_should_not_drop_the_category_when_unsing_the_month_selector( PhantomjsTester $I ) {
 		$I->click( [ 'css' => 'input#tribe-bar-date' ] );
 		// I click the 5th month in the datepicker
 		$I->click( [ 'css' => 'body > .datepicker > div.datepicker-months span:nth-child(5)' ] );
@@ -52,7 +57,7 @@ class Issue_38042_Dropping_CategoryCest {
 	 * @test
 	 * it should not drop the category when using the month selector then the search
 	 */
-	public function it_should_not_drop_the_category_when_using_the_month_selector_and_the_search( AcceptanceTester $I ) {
+	public function it_should_not_drop_the_category_when_using_the_month_selector_and_the_search( PhantomjsTester $I ) {
 		$I->click( [ 'css' => 'input#tribe-bar-date' ] );
 		// I click the 5th month in the datepicker, this will submit
 		$I->click( [ 'css' => 'body > .datepicker > div.datepicker-months span:nth-child(11)' ] );
@@ -74,7 +79,7 @@ class Issue_38042_Dropping_CategoryCest {
 	 * @test
 	 * it should not drop category when using the search then the month selector
 	 */
-	public function it_should_not_drop_category_when_using_the_search_then_the_month_selector( AcceptanceTester $I ) {
+	public function it_should_not_drop_category_when_using_the_search_then_the_month_selector( PhantomjsTester $I ) {
 
 		$I->fillField( 'input[name="tribe-bar-search"]', 'foo' );
 		$I->click( 'input[name="submit-bar"]' );

--- a/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
+++ b/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
@@ -33,7 +33,9 @@ class Issue_38042_Dropping_CategoryCest {
 	public function it_should_not_drop_the_category_when_using_the_tribe_search_bar( PhantomjsTester $I ) {
 		$I->fillField( 'input[name="tribe-bar-search"]', 'foo' );
 		$I->click( 'input[name="submit-bar"]' );
+
 		$I->waitForJqueryAjax( 10 );
+
 		$href = $I->grabFullUrl();
 		$I->assertContains( 'tribe-bar-search=foo', $href );
 		$I->assertContains( 'tribe_events_cat=', $href );
@@ -47,7 +49,9 @@ class Issue_38042_Dropping_CategoryCest {
 		$I->click( [ 'css' => 'input#tribe-bar-date' ] );
 		// I click the 5th month in the datepicker
 		$I->click( [ 'css' => 'body > .datepicker > div.datepicker-months span:nth-child(5)' ] );
+
 		$I->waitForJqueryAjax( 10 );
+
 		$href = $I->grabFullUrl();
 		$I->assertContains( 'tribe_events_cat=', $href );
 		$I->assertContains( 'tribe-bar-date', $href );

--- a/tests/phantomjs/_bootstrap.php
+++ b/tests/phantomjs/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/40423
I've moved the only acceptance test we have in the new `phantomjs` suite and solved the problem (window size) that would prevent it from running.  
Along with it I've added a Tribe module to handle options in acceptance tests.
I've PRed on core as the issue under test (https://central.tri.be/issues/38042) was really a core issue. We currently have the same exact test on Pro and filters and I can easily replicate the test, the module and the suite set up there too should that be the case.