### PR TITLE
Allow plugins to do something once importer options have updated | 41714

### DIFF
--- a/src/Tribe/Importer/Options.php
+++ b/src/Tribe/Importer/Options.php
@@ -35,6 +35,13 @@ class Tribe__Events__Importer__Options {
 				Tribe__Settings_Manager::set_option( $_option, $value );
 			}
 
+			/**
+			 * Fires once import options have been saved/updated.
+			 *
+			 * @var array $options
+			 */
+			do_action( 'tribe_import_options_updated', $options );
+
 			add_action( 'tribe_import_under_heading', array( __CLASS__, 'settings_saved_message' ) );
 		}
 	}


### PR DESCRIPTION
Fire an action once importer options have been updated.

[C#41714](https://central.tri.be/issues/41714)