### PR TITLE
add slash to past/upcoming redirect URL to prevent redirect loop

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2568,10 +2568,17 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public function redirect_past_upcoming_view_urls() {
 
 			if ( strpos( $_SERVER['REQUEST_URI'], $this->getRewriteSlug() . '/' . $this->pastSlug ) !== false ) {
-				wp_redirect( esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), str_replace( '/' . $this->pastSlug . '/', '/' . $this->listSlug . '/', $_SERVER['REQUEST_URI'] ) ) ) );
+				$search = '#/' . $this->pastSlug . '/?#';
+				$replace = '/' . $this->listSlug . '/';
+				$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+				$redirect_url = esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), $redirect_url ) );
+				wp_redirect( $redirect_url );
 				die;
 			} elseif ( strpos( $_SERVER['REQUEST_URI'], $this->getRewriteSlug() . '/' . $this->upcomingSlug ) !== false ) {
-				wp_redirect( str_replace( '/' . $this->upcomingSlug . '/', '/' . $this->listSlug . '/', $_SERVER['REQUEST_URI'] ) );
+				$search = '#/' . $this->upcomingSlug . '/?#';
+				$replace = '/' . $this->listSlug . '/';
+				$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+				wp_redirect( $redirect_url );
 				die;
 			}
 


### PR DESCRIPTION
With the existing redirect, http://example.com/events/upcoming would redirect to http://example.com/events/upcoming, since it lacks the trailing slash to match the `str_replace()`. We can be more accommodating with a `preg_replace()`.

https://central.tri.be/issues/41869
https://central.tri.be/issues/41937