### PR TITLE
Remove unneeded (and problem-causing) code | 41574

### DIFF
--- a/src/resources/js/tribe-events-ajax-calendar.js
+++ b/src/resources/js/tribe-events-ajax-calendar.js
@@ -155,12 +155,6 @@
 
 			data.has_events = $date.hasClass( 'tribe-events-has-events' );
 
-			// Backwards compatibility
-			// @todo "Check if we can remove this check"
-			if ( data.has_events ) {
-				data.date_name = '';
-			}
-
 			$triggers.removeClass( 'mobile-active' )
 				// If full_date_name is empty then default to highlighting the first day of the current month
 				.filter( _active ).addClass( 'mobile-active' );


### PR DESCRIPTION
Removes a section of code that was wiping the title of the list which displays below month view in mobile mode. Props will be due to Jason on the forum for this one.

[C#41574](https://central.tri.be/issues/41574)