### PR TITLE
Default the enabled views to "month"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -356,6 +356,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Fix - Fixed a problem where iCal data was generated with incorrect dates in the case of some all days events (thanks to Matt for highlighting this)
 * Fix - Resolved a problem causing the previous month view to appear when it should not
 * Fix - Fixed issue in mobile month view where date was missing from heading
+* Fix - Resolved issue that caused /events/ to 404 if it was visited on a new install before hitting "Save" on the Events > Settings > Display page
 * Deprecated - The Tribe__Events__Main::defaultValueReplaceEnabled() method is being deprecated in favor of tribe_get_option('defaultValueReplace'). Schedules for removal in v4.5
 * Deprecated - The tribe_event_link() has been deprecated in favor of tribe_get_event_link(). Scheduled for removal in 5.0
 * Deprecated - The third parameter of tribe_get_organizer_link() (the $echo parameter) has been deprecated and is scheduled for removal in 5.0

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1111,7 +1111,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		if ( isset( $deprecated ) ) {
 			_deprecated_argument( __FUNCTION__, '3.10' );
 		}
-		return tribe_get_option( 'tribeEnableViews', array() );
+		return tribe_get_option( 'tribeEnableViews', array( 'month' ) );
 	}
 
 	/**


### PR DESCRIPTION
We set the default view to `month`, however, our default list of enabled views was empty. On a new install, this caused a 404 until the user set the views they wanted to enable via Events > Settings > Display.

This change sets `month` as an enabled view by default so that `/events/` can render before the user hits _Save_ on Events > Settings > Display

See: https://central.tri.be/issues/41981