### PR TITLE
Fixing some textdomain issues that were introduced in late changes

### DIFF
--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -63,16 +63,16 @@ $display_tab_fields = Tribe__Main::array_insert_after_key(
 	array(
 		'dateWithoutYearFormat'              => array(
 			'type'            => 'text',
-			'label'           => esc_html__( 'Date without year', 'tribe-common' ),
-			'tooltip'         => esc_html__( 'Enter the format to use for displaying dates without a year. Used when showing an event from the current year.', 'tribe-common' ),
+			'label'           => esc_html__( 'Date without year', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'Enter the format to use for displaying dates without a year. Used when showing an event from the current year.', 'the-events-calendar' ),
 			'default'         => 'F j',
 			'size'            => 'medium',
 			'validation_type' => 'html',
 		),
 		'monthAndYearFormat'                 => array(
 			'type'            => 'text',
-			'label'           => esc_html__( 'Month and year format', 'tribe-common' ),
-			'tooltip'         => esc_html__( 'Enter the format to use for dates that show a month and year only. Used on month view.', 'tribe-common' ),
+			'label'           => esc_html__( 'Month and year format', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'Enter the format to use for dates that show a month and year only. Used on month view.', 'the-events-calendar' ),
 			'default'         => 'F Y',
 			'size'            => 'medium',
 			'validation_type' => 'html',
@@ -86,8 +86,8 @@ $display_tab_fields = Tribe__Main::array_insert_after_key(
 	array(
 		'timeRangeSeparator'                 => array(
 			'type'            => 'text',
-			'label'           => esc_html__( 'Time range separator', 'tribe-common' ),
-			'tooltip'         => esc_html__( 'Enter the separator that will be used between the start and end time of an event.', 'tribe-common' ),
+			'label'           => esc_html__( 'Time range separator', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'Enter the separator that will be used between the start and end time of an event.', 'the-events-calendar' ),
 			'default'         => ' - ',
 			'size'            => 'small',
 			'validation_type' => 'html',
@@ -179,18 +179,18 @@ $display_tab_fields = Tribe__Main::array_insert_after_key(
 	array(
 		'tribeEventsAdvancedSettingsTitle'   => array(
 			'type' => 'html',
-			'html' => '<h3>' . esc_html__( 'Advanced Template Settings', 'tribe-common' ) . '</h3>',
+			'html' => '<h3>' . esc_html__( 'Advanced Template Settings', 'the-events-calendar' ) . '</h3>',
 		),
 		'tribeEventsBeforeHTML'              => array(
 			'type'            => 'wysiwyg',
-			'label'           => esc_html__( 'Add HTML before event content', 'tribe-common' ),
-			'tooltip'         => esc_html__( 'If you are familiar with HTML, you can add additional code before the event template. Some themes may require this to help with styling or layout.', 'tribe-common' ),
+			'label'           => esc_html__( 'Add HTML before event content', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'If you are familiar with HTML, you can add additional code before the event template. Some themes may require this to help with styling or layout.', 'the-events-calendar' ),
 			'validation_type' => 'html',
 		),
 		'tribeEventsAfterHTML'               => array(
 			'type'            => 'wysiwyg',
-			'label'           => esc_html__( 'Add HTML after event content', 'tribe-common' ),
-			'tooltip'         => esc_html__( 'If you are familiar with HTML, you can add additional code after the event template. Some themes may require this to help with styling or layout.', 'tribe-common' ),
+			'label'           => esc_html__( 'Add HTML after event content', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'If you are familiar with HTML, you can add additional code after the event template. Some themes may require this to help with styling or layout.', 'the-events-calendar' ),
 			'validation_type' => 'html',
 		),
 	)

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -95,7 +95,7 @@ $general_tab_fields = Tribe__Main::array_insert_before_key(
 		),
 		'multiDayCutoff'                => array(
 			'type'            => 'dropdown',
-			'label'           => esc_html__( 'End of day cutoff', 'tribe-common' ),
+			'label'           => esc_html__( 'End of day cutoff', 'the-events-calendar' ),
 			'validation_type' => 'options',
 			'size'            => 'small',
 			'default'         => '12:00',
@@ -116,7 +116,7 @@ $general_tab_fields = Tribe__Main::array_insert_before_key(
 		),
 		'multiDayCutoffHelper'          => array(
 			'type'        => 'html',
-			'html'        => '<p class="tribe-field-indent tribe-field-description description">' . sprintf( esc_html__( "Have an event that runs past midnight? Select a time after that event's end to avoid showing the event on the next day's calendar.", 'tribe-common' ) ) . '</p>',
+			'html'        => '<p class="tribe-field-indent tribe-field-description description">' . sprintf( esc_html__( "Have an event that runs past midnight? Select a time after that event's end to avoid showing the event on the next day's calendar.", 'the-events-calendar' ) ) . '</p>',
 			'conditional' => ( '' != get_option( 'permalink_structure' ) ),
 		),
 	)
@@ -168,11 +168,11 @@ $general_tab_fields = Tribe__Main::array_insert_after_key(
 	array(
 		'viewWelcomePage'          => array(
 			'type'        => 'html',
-			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'View Welcome Page', 'tribe-common' ) . '</legend><div class="tribe-field-wrap"><a href="' . Tribe__Settings::instance()->get_url( array( 'tec-welcome-message' => true ) ) . '" class="button">' . esc_html__( 'View Welcome Page', 'tribe-common' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you initially installed the plugin.', 'tribe-common' ) . '</p></div></fieldset><div class="clear"></div>',
+			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'View Welcome Page', 'the-events-calendar' ) . '</legend><div class="tribe-field-wrap"><a href="' . Tribe__Settings::instance()->get_url( array( 'tec-welcome-message' => true ) ) . '" class="button">' . esc_html__( 'View Welcome Page', 'the-events-calendar' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you initially installed the plugin.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
 		),
 		'viewUpdatePage'          => array(
 			'type'        => 'html',
-			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'View Update Page', 'tribe-common' ) . '</legend><div class="tribe-field-wrap"><a href="' . Tribe__Settings::instance()->get_url( array( 'tec-update-message' => true ) ) . '" class="button">' . esc_html__( 'View Update Page', 'tribe-common' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you updated the plugin.', 'tribe-common' ) . '</p></div></fieldset><div class="clear"></div>',
+			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'View Update Page', 'the-events-calendar' ) . '</legend><div class="tribe-field-wrap"><a href="' . Tribe__Settings::instance()->get_url( array( 'tec-update-message' => true ) ) . '" class="button">' . esc_html__( 'View Update Page', 'the-events-calendar' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you updated the plugin.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
 		),
 	)
 );


### PR DESCRIPTION
I did some changes yesterday to move settings fields from common to TEC.  In doing so, the textdomain was not updated from tribe-common to the-events-calendar. This was noticed while testing translations for tribe-common.