### PR TITLE
Avoid hardcoded table prefixes | 42021

### DIFF
--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -148,17 +148,17 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 			// collect the terms in the desired taxonomy for the given post into a single string
 			$smashed_terms_sql = "
 				SELECT
-					GROUP_CONCAT( wp_terms.name ORDER BY name ASC ) smashed_terms
+					GROUP_CONCAT( $wpdb->terms.name ORDER BY name ASC ) smashed_terms
 				FROM
-					wp_term_relationships
-					LEFT JOIN wp_term_taxonomy ON (
-						wp_term_relationships.term_taxonomy_id = wp_term_taxonomy.term_taxonomy_id
+					$wpdb->term_relationships
+					LEFT JOIN $wpdb->term_taxonomy ON (
+						$wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id
 						AND taxonomy = '%s'
 					)
-					LEFT JOIN wp_terms ON (
-						wp_term_taxonomy.term_id = wp_terms.term_id
+					LEFT JOIN $wpdb->terms ON (
+						$wpdb->term_taxonomy.term_id = $wpdb->terms.term_id
 					)
-				WHERE wp_term_relationships.object_id = wp_posts.ID
+				WHERE $wpdb->term_relationships.object_id = $wpdb->posts.ID
 			";
 
 			$smashed_terms_sql = $wpdb->prepare( $smashed_terms_sql, $taxonomy );


### PR DESCRIPTION
A query with hardcoded `wp_` table prefixes had snuck in, breaking the admin events list when ordered by tag or category. This change should fix (for any sites that don't use `wp_` as their prefix).

[C#42021](https://central.tri.be/issues/42021)