### PR TITLE
Admin events list: ensure date ordering is applied | 42022

### DIFF
--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 			}
 
 			if ( ! empty( $clauses['orderby'] ) ) {
-				$clauses['orderby'] .= ',';
+				$original_orderby = $clauses['orderby'];
 			}
 
 			$start_orderby = "tribe_event_start_date.meta_value {$sort_direction}";
@@ -111,7 +111,12 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 				$date_orderby = "{$end_orderby}, {$start_orderby}";
 			}
 
-			$clauses['orderby'] .= $date_orderby;
+			// Add the date orderby rules *before* any pre-existing orderby rules (to stop them being "trumped")
+			$revised_orderby = empty( $original_orderby )
+				? $date_orderby
+				: "$date_orderby, $original_orderby";
+
+			$clauses['orderby'] = $revised_orderby;
 
 			return $clauses;
 		}


### PR DESCRIPTION
Previously, ordering the admin event list by date failed because we were *appending* the extra rules. This change prepends the rules instead, restoring proper ordering by start/end date.

Example, instead of:

`ORDER BY wp_posts.post_date DESC, tribe_event_start_date.meta_value DESC, tribe_event_end_date.meta_value DESC`

We now get:

`ORDER BY tribe_event_start_date.meta_value DESC, tribe_event_end_date.meta_value DESC,  wp_posts.post_date DESC`

[C#42022](https://central.tri.be/issues/42022)