### PR TITLE
Observe the end-of-day cutoff when building the date range for multi-day

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -913,7 +913,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				$inner .= tribe_get_start_date( $event, true, $format );
 				$inner .= '</span>' . $time_range_separator;
 				$inner .= '<span class="tribe-event-date-end">';
-				$inner .= tribe_get_end_date( $event, true, $format2ndday );
+
+				$end_date_full_timestamp = tribe_get_end_date( $event, true, 'U' );
+
+				// if the end date is <= the beginning of the day, consider it the previous day
+				if ( $end_date_full_timestamp <= strtotime( tribe_beginning_of_day( $end_date_full_timestamp ) ) ) {
+					$end_date = tribe_format_date( $end_date_full_timestamp - DAY_IN_SECONDS, false, $format2ndday );
+				} else {
+					$end_date = tribe_get_end_date( $event, false, $format2ndday );
+				}
+
+				$inner .= $end_date;
 			} else {
 				$inner .= tribe_get_start_date( $event, false, $format ) . ( $time ? $datetime_separator . tribe_get_start_date( $event, false, $time_format ) : '' );
 				$inner .= '</span>' . $time_range_separator;


### PR DESCRIPTION
When running multi-day all-day events, we were not looking at the end of day cutoff when building the date range. Instead, we blindly took the end date/time and displayed that. Example:

End of day cut-off: 3am
Event: All-day, December 8 to December 10

*With the bug:*

* Event dates would be stored as 2015-12-08 03:00:00 to 2015-12-11 02:59:59
* Event would be rendered as December 8 - December 11

*With the fix:*

* Event dates would be stored as 2015-12-08 03:00:00 to 2015-12-11 02:59:59
* Event would be rendered as December 8 - December 10

See: https://central.tri.be/issues/40555