### PR TITLE
Multi-day All-day events may require an adjusted date by eod cutoff

### DIFF
--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -281,7 +281,7 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 				break;
 
 				case 'end-date':
-					echo tribe_get_end_date( $post_id, false );
+					echo tribe_get_display_end_date( $post_id, false );
 				break;
 			}
 		}

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -103,14 +103,14 @@ if ( ! function_exists( 'tribe_get_display_end_date' ) ) {
 	 * Returns the event end date that observes the end of day cutoff
 	 *
 	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param bool   $displayTime If true shows date and time, if false only shows date
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
+	 * @param int    $event        (optional)
+	 * @param bool   $display_time If true shows date and time, if false only shows date
+	 * @param string $date_format  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
+	 * @param string $timezone     Timezone in which to present the date/time (or default behaviour if not set)
 	 *
 	 * @return string|null Date
 	 */
-	function tribe_get_display_end_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
+	function tribe_get_display_end_date( $event = null, $display_time = true, $date_format = '', $timezone = null ) {
 		$end_date = tribe_get_end_date( $event, true, 'U', $timezone );
 		$beginning_of_day = tribe_beginning_of_day( date( Tribe__Date_Utils::DBDATETIMEFORMAT, $end_date ) );
 
@@ -118,7 +118,7 @@ if ( ! function_exists( 'tribe_get_display_end_date' ) ) {
 			$end_date -= DAY_IN_SECONDS;
 		}
 
-		return tribe_format_date( $end_date, $displayTime, $dateFormat );
+		return tribe_format_date( $end_date, $display_time, $date_format );
 	}
 }
 

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -96,47 +96,11 @@ if ( ! function_exists( 'tribe_get_end_time' ) ) {
 	}
 }
 
-if ( ! function_exists( 'tribe_get_start_date' ) ) {
+if ( ! function_exists( 'tribe_get_display_end_date' ) ) {
 	/**
-	 * Start Date
+	 * End Date formatted for display
 	 *
-	 * Returns the event start date and time
-	 *
-	 * @category Events
-	 * @param int    $event       (optional)
-	 * @param bool   $displayTime If true shows date and time, if false only shows date
-	 * @param string $dateFormat  Allows date and time formating using standard php syntax (http://php.net/manual/en/function.date.php)
-	 * @param string $timezone    Timezone in which to present the date/time (or default behaviour if not set)
-	 * @return string|null Date
-	 */
-	function tribe_get_start_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
-		}
-
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return '';
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			$displayTime = false;
-		}
-
-		$start_date = Tribe__Events__Timezones::event_start_timestamp( $event->ID, $timezone );
-		return tribe_format_date( $start_date, $displayTime, $dateFormat );
-	}
-}
-
-if ( ! function_exists( 'tribe_get_end_date' ) ) {
-	/**
-	 * End Date
-	 *
-	 * Returns the event end date
+	 * Returns the event end date that observes the end of day cutoff
 	 *
 	 * @category Events
 	 * @param int    $event       (optional)
@@ -146,25 +110,14 @@ if ( ! function_exists( 'tribe_get_end_date' ) ) {
 	 *
 	 * @return string|null Date
 	 */
-	function tribe_get_end_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
-		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
+	function tribe_get_display_end_date( $event = null, $displayTime = true, $dateFormat = '', $timezone = null ) {
+		$end_date = tribe_get_end_date( $event, true, 'U', $timezone );
+		$beginning_of_day = tribe_beginning_of_day( date( Tribe__Date_Utils::DBDATETIMEFORMAT, $end_date ) );
+
+		if ( tribe_event_is_multiday( $event ) && $end_date < strtotime( $beginning_of_day ) ) {
+			$end_date -= DAY_IN_SECONDS;
 		}
 
-		if ( is_numeric( $event ) ) {
-			$event = get_post( $event );
-		}
-
-		if ( ! is_object( $event ) ) {
-			return '';
-		}
-
-		if ( tribe_event_is_all_day( $event ) ) {
-			$displayTime = false;
-		}
-
-		$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
 		return tribe_format_date( $end_date, $displayTime, $dateFormat );
 	}
 }

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -69,7 +69,7 @@ $website = tribe_get_event_website_link();
 
 			<dt> <?php esc_html_e( 'End:', 'the-events-calendar' ) ?> </dt>
 			<dd>
-				<abbr class="tribe-events-abbr dtend" title="<?php esc_attr_e( $end_ts ) ?>"> <?php esc_html_e( $end_date ) ?> </abbr>
+				<abbr class="tribe-events-abbr dtend" title="<?php esc_attr_e( $end_ts ) ?>"> <?php esc_html_e( $end_datetime ) ?> </abbr>
 			</dd>
 
 		<?php

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -18,7 +18,7 @@ $start_time = tribe_get_start_date( null, false, $time_format );
 $start_ts = tribe_get_start_date( null, false, Tribe__Date_Utils::DBDATEFORMAT );
 
 $end_datetime = tribe_get_end_date();
-$end_date = tribe_get_end_date( null, false );
+$end_date = tribe_get_display_end_date( null, false );
 $end_time = tribe_get_end_date( null, false, $time_format );
 $end_ts = tribe_get_end_date( null, false, Tribe__Date_Utils::DBDATEFORMAT );
 
@@ -69,7 +69,7 @@ $website = tribe_get_event_website_link();
 
 			<dt> <?php esc_html_e( 'End:', 'the-events-calendar' ) ?> </dt>
 			<dd>
-				<abbr class="tribe-events-abbr dtend" title="<?php esc_attr_e( $end_ts ) ?>"> <?php esc_html_e( $end_datetime ) ?> </abbr>
+				<abbr class="tribe-events-abbr dtend" title="<?php esc_attr_e( $end_ts ) ?>"> <?php esc_html_e( $end_date ) ?> </abbr>
 			</dd>
 
 		<?php


### PR DESCRIPTION
All-day Multi-day events have their end dates displayed individually in a few locations - when viewing a single event and viewing the event in the admin dashboard. In those instances, the true end date is not what is desired, but, rather an end date that observes the end of day cutoff.

This changeset adds a new method ( `tribe_get_display_end_date()` ) that calls `tribe_get_end_date()` and adusts the output based on the multi-day/eod status of the event whose end date is being fetched.

**Note:** I'm also removing `tribe_get_start_date()` and `tribe_get_end_date()` from TEC because those are duplicated in tribe-common now. Which meant that the ones in TEC were never declared because the functions already existed. That was a fun frustration as I worked on stuff.

See: https://central.tri.be/issues/40555#note-16