### PR TITLE
Don't try to validate empty strings as organizer names | 41497

### DIFF
--- a/src/admin-views/new-organizer-meta-section.php
+++ b/src/admin-views/new-organizer-meta-section.php
@@ -56,6 +56,12 @@ $organizer_pto = get_post_type_object( Tribe__Events__Main::ORGANIZER_POST_TYPE 
 		$('#event_organizer').on('blur', '.organizer-name', function () {
 			var input = $(this);
 			var group = input.parents('tbody');
+
+			// Not actually populated with anything? Don't bother validating
+			if ( ! input.val().length ) {
+				return;
+			}
+
 			$.post(ajaxurl,
 				{
 					action: 'tribe_event_validation',


### PR DESCRIPTION
https://central.tri.be/issues/41497