### PR TITLE
Don't use the default country for new venues within the event editor | 42170

### DIFF
--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -49,14 +49,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<td>
 		<?php
 		$countries = Tribe__View_Helpers::constructCountries( $event->ID );
-		$defaultCountry = tribe_get_default_value( 'country' );
+
 		if ( isset( $_VenueCountry ) && $_VenueCountry ) {
 			$current = $_VenueCountry;
-		} elseif ( isset( $defaultCountry[1] ) ) {
-			$current = $defaultCountry[1];
 		} else {
 			$current = null;
 		}
+
 		if ( is_array( $current ) && isset( $current[1] ) ) {
 			$current = $current[1];
 		}


### PR DESCRIPTION
The venue meta box (within the event meta box) was attempting to use the default country value, making it the odd man out amongst its fellow fields.

https://central.tri.be/issues/42170 but see also https://central.tri.be/issues/29366