### PR TITLE
In WP 4.4, the $post_type is no longer an array but an object

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, borkweb, zbtirrell, barry.hughes, bordoni, brianjesse
 Tags: events, calendar, event, venue, organizer, dates, date, google maps, conference, workshop, concert, meeting, seminar, summit, class, modern tribe, tribe, widget
 Donate link: http://m.tri.be/29
 Requires at least: 3.9
-Tested up to: 4.3.1
+Tested up to: 4.4
 Stable tag: 4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -314,6 +314,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Tweak - Add a warning message for major updates
 * Tweak - For SEO reasons, use an <h1> for the title rather than an <h2> (props to wpexplorer for this fix)
 * Tweak - Target the calendar view grid in JS using a simpler selector
+* Fix - Resolved WP 4.4 related fatal on the Nav Menu page that prevented the admin footer from rendering/enqueuing JS
 * Fix - Resolved bug where visiting /events/upcoming could sometimes result in an infinite redirect loop
 * Fix - Removed `wp_trim_excerpt` and use only it's powers, fixing the excerpt problem
 * Fix - Fixed bug where the mobile calendar view did not display the date for the date being viewed

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1139,13 +1139,22 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$_nav_menu_placeholder = ( 0 > $_nav_menu_placeholder ) ? intval( $_nav_menu_placeholder ) - 1 : - 1;
 			$archive_slug          = $this->getLink();
 
+			// In WP 4.4, $post_type is an object rather than an array
+			if ( is_array( $post_type ) ) {
+				// support pre WP 4.4
+				$all_items = $post_type['args']->labels->all_items;
+			} else {
+				// support WP 4.4+
+				$all_items = $post_type->labels->all_items;
+			}
+
 			array_unshift(
 				$posts, (object) array(
 					'ID'           => 0,
 					'object_id'    => $_nav_menu_placeholder,
 					'post_content' => '',
 					'post_excerpt' => '',
-					'post_title'   => $post_type['args']->labels->all_items,
+					'post_title'   => $all_items,
 					'post_type'    => 'nav_menu_item',
 					'type'         => 'custom',
 					'url'          => $archive_slug,


### PR DESCRIPTION
Tested against WP 4.4, the `$post_type` variable is passed in as an object whereas in WP 4.3 it is passed in as an array where the `args` index holds the object we care about. This changeset supports both structures to prevent the fatal that was being thrown.

See: https://central.tri.be/issues/42220