### PR TITLE
If cost holds non-numeric text, use 0 for the cost range

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -289,6 +289,9 @@ class Tribe__Events__Cost_Utils {
 			// Get the required parts
 			if ( preg_match_all( '/' . $price_regex . '/', $cost, $matches ) ) {
 				$cost = reset( $matches );
+			} else {
+				$matches = array();
+				$cost = array( 0 );
 			}
 
 			// Get the max number of decimals for the range

--- a/tests/functional/Tribe__Events__Cost_Utils_Test.php
+++ b/tests/functional/Tribe__Events__Cost_Utils_Test.php
@@ -98,4 +98,35 @@ class Tribe__Events__Cost_Utils_Test extends Tribe__Events__WP_UnitTestCase {
 			unset( $this->test_events[ $event_id ] );
 		}
 	}
+
+	/**
+	 * Test that cost ranges return appropriate data
+	 */
+	public function test_parse_cost_range() {
+		$costs = array(
+			5,
+			10,
+			1.5,
+			'1 - 15',
+			'$6',
+		);
+
+		$cost_utils = Tribe__Events__Cost_Utils::instance();
+		$range = $cost_utils->parse_cost_range( $costs );
+
+		$this->assertEquals( array(
+			10 => '1',
+			15 => '1.5',
+			50 => '5',
+			60 => '6',
+			100 => '10',
+			150 => '15',
+		), $range );
+
+		$range = $cost_utils->parse_cost_range( array( 10 ) );
+		$this->assertEquals( array( 10 => '10' ), $range );
+
+		$range = $cost_utils->parse_cost_range( array( 'Free' ) );
+		$this->assertEquals( array( 0 ), $range );
+	}
 }


### PR DESCRIPTION
When the cost meta holds something other than a numeric string (parseable by our regex), there are a few array operations that throw notices. This changeset sets some defaults in the event that the regex fails.

See: https://central.tri.be/issues/42174