### PR TITLE
Allow 0-cost (free) events. Don't consider non-numeric as '0'

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -273,11 +273,11 @@ class Tribe__Events__Cost_Utils {
 			return array();
 		}
 
-		// remove any empty prices
-		$costs = array_filter( (array) $costs );
+		// make sure costs is an array
+		$costs = (array) $costs;
 
-		// If it's empty returns 0
-		if ( empty( $costs ) ) {
+		// If there aren't any costs, return a blank array
+		if ( 0 === count( $costs ) ) {
 			return array();
 		}
 
@@ -290,8 +290,8 @@ class Tribe__Events__Cost_Utils {
 			if ( preg_match_all( '/' . $price_regex . '/', $cost, $matches ) ) {
 				$cost = reset( $matches );
 			} else {
-				$matches = array();
-				$cost = array( 0 );
+				$cost = array();
+				continue;
 			}
 
 			// Get the max number of decimals for the range
@@ -311,7 +311,7 @@ class Tribe__Events__Cost_Utils {
 
 		foreach ( $costs as $cost ) {
 			// Creates a Well Balanced Index that will perform good on a Key Sorting method
-			$index = str_replace( '.', '', number_format( str_replace( $this->get_separators(), '.', $cost ), $max ) );
+			$index = str_replace( array( '.', ',' ), '', number_format( str_replace( $this->get_separators(), '.', $cost ), $max ) );
 
 			// Keep the Costs in a organizeable array by keys with the "numeric" value
 			$ocost[ $index ] = $cost;

--- a/tests/functional/Tribe__Events__Cost_Utils_Test.php
+++ b/tests/functional/Tribe__Events__Cost_Utils_Test.php
@@ -127,6 +127,6 @@ class Tribe__Events__Cost_Utils_Test extends Tribe__Events__WP_UnitTestCase {
 		$this->assertEquals( array( 10 => '10' ), $range );
 
 		$range = $cost_utils->parse_cost_range( array( 'Free' ) );
-		$this->assertEquals( array( 0 ), $range );
+		$this->assertEquals( array(), $range );
 	}
 }


### PR DESCRIPTION
During 4.0, we started tossing out explicit 0-cost events when, in fact, we want them (and need them) identified separately so we can throw the `Free` label on events.

See: https://central.tri.be/issues/42173