### PR TITLE
Better handling of internationalized slugs

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -787,10 +787,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->singular_event_label                       = $this->get_event_label_singular();
 			$this->plural_event_label                         = $this->get_event_label_plural();
 
-			$this->postTypeArgs['rewrite']['slug']            = $rewrite->prepare_slug( self::POSTTYPE, $this->rewriteSlugSingular );
-			$this->postVenueTypeArgs['rewrite']['slug']       = $rewrite->prepare_slug( self::VENUE_POST_TYPE, $this->singular_venue_label );
+			$this->postTypeArgs['rewrite']['slug']            = $rewrite->prepare_slug( $this->rewriteSlugSingular, self::POSTTYPE );
+			$this->postVenueTypeArgs['rewrite']['slug']       = $rewrite->prepare_slug( $this->singular_venue_label, self::VENUE_POST_TYPE );
 			$this->postVenueTypeArgs['show_in_nav_menus']     = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
-			$this->postOrganizerTypeArgs['rewrite']['slug']   = $rewrite->prepare_slug( self::ORGANIZER_POST_TYPE, $this->singular_organizer_label );
+			$this->postOrganizerTypeArgs['rewrite']['slug']   = $rewrite->prepare_slug( $this->singular_organizer_label, self::ORGANIZER_POST_TYPE );
 			$this->postOrganizerTypeArgs['show_in_nav_menus'] = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postVenueTypeArgs['public']                = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postOrganizerTypeArgs['public']            = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4702,7 +4702,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// if there isn't a post id, don't change the symbol
-			if ( !$post_id ) {
+			if ( ! $post_id ) {
 				return $reverse_position;
 			}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -764,6 +764,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Run on applied action init
 		 */
 		public function init() {
+			$rewrite = Tribe__Events__Rewrite::instance();
+
 			$this->pluginName = $this->plugin_name            = esc_html__( 'The Events Calendar', 'the-events-calendar' );
 			$this->rewriteSlug                                = $this->getRewriteSlug();
 			$this->rewriteSlugSingular                        = $this->getRewriteSlugSingular();
@@ -785,10 +787,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->singular_event_label                       = $this->get_event_label_singular();
 			$this->plural_event_label                         = $this->get_event_label_plural();
 
-			$this->postTypeArgs['rewrite']['slug']            = $this->prepare_slug( $this->rewriteSlugSingular );
-			$this->postVenueTypeArgs['rewrite']['slug']       = $this->prepare_slug( $this->singular_venue_label );
+			$this->postTypeArgs['rewrite']['slug']            = $rewrite->prepare_slug( self::POSTTYPE, $this->rewriteSlugSingular );
+			$this->postVenueTypeArgs['rewrite']['slug']       = $rewrite->prepare_slug( self::VENUE_POST_TYPE, $this->singular_venue_label );
 			$this->postVenueTypeArgs['show_in_nav_menus']     = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
-			$this->postOrganizerTypeArgs['rewrite']['slug']   = $this->prepare_slug( $this->singular_organizer_label );
+			$this->postOrganizerTypeArgs['rewrite']['slug']   = $rewrite->prepare_slug( self::ORGANIZER_POST_TYPE, $this->singular_organizer_label );
 			$this->postOrganizerTypeArgs['show_in_nav_menus'] = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postVenueTypeArgs['public']                = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postOrganizerTypeArgs['public']            = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
@@ -4700,7 +4702,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// if there isn't a post id, don't change the symbol
-			if ( ! $post_id ) {
+			if ( !$post_id ) {
 				return $reverse_position;
 			}
 
@@ -4714,25 +4716,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$reverse_position = ( 'suffix' === $reverse_position );
 
 			return $reverse_position;
-		}
-
-		/**
-		 * Accepts a string a returns a sanitized version that can be used in
-		 * rewrite rules.
-		 *
-		 * @param  string $possible_slug_name
-		 * @return string
-		 */
-		protected function prepare_slug( $possible_slug_name ) {
-			$sanitized_slug = sanitize_title( $possible_slug_name );
-
-			// Was UTF8 encoding required for the slug?
-			if ( preg_match( '/(%[0-9a-f]{2})+/', $sanitized_slug ) ) {
-				// User agents encode things the same way but in uppercase
-				$sanitized_slug = strtoupper( $sanitized_slug );
-			}
-
-			return preg_quote( $sanitized_slug );
 		}
 	} // end Tribe__Events__Main class
 } // end if !class_exists Tribe__Events__Main

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -785,10 +785,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->singular_event_label                       = $this->get_event_label_singular();
 			$this->plural_event_label                         = $this->get_event_label_plural();
 
-			$this->postTypeArgs['rewrite']['slug']            = sanitize_title( $this->rewriteSlugSingular );
-			$this->postVenueTypeArgs['rewrite']['slug']       = sanitize_title( $this->singular_venue_label );
+			$this->postTypeArgs['rewrite']['slug']            = $this->prepare_slug( $this->rewriteSlugSingular );
+			$this->postVenueTypeArgs['rewrite']['slug']       = $this->prepare_slug( $this->singular_venue_label );
 			$this->postVenueTypeArgs['show_in_nav_menus']     = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
-			$this->postOrganizerTypeArgs['rewrite']['slug']   = sanitize_title( $this->singular_organizer_label );
+			$this->postOrganizerTypeArgs['rewrite']['slug']   = $this->prepare_slug( $this->singular_organizer_label );
 			$this->postOrganizerTypeArgs['show_in_nav_menus'] = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postVenueTypeArgs['public']                = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
 			$this->postOrganizerTypeArgs['public']            = class_exists( 'Tribe__Events__Pro__Main' ) ? true : false;
@@ -4714,6 +4714,25 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$reverse_position = ( 'suffix' === $reverse_position );
 
 			return $reverse_position;
+		}
+
+		/**
+		 * Accepts a string a returns a sanitized version that can be used in
+		 * rewrite rules.
+		 *
+		 * @param  string $possible_slug_name
+		 * @return string
+		 */
+		protected function prepare_slug( $possible_slug_name ) {
+			$sanitized_slug = sanitize_title( $possible_slug_name );
+
+			// Was UTF8 encoding required for the slug?
+			if ( preg_match( '/(%[0-9a-f]{2})+/', $sanitized_slug ) ) {
+				// User agents encode things the same way but in uppercase
+				$sanitized_slug = strtoupper( $sanitized_slug );
+			}
+
+			return preg_quote( $sanitized_slug );
 		}
 	} // end Tribe__Events__Main class
 } // end if !class_exists Tribe__Events__Main

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -413,8 +413,7 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 		}
 
 		/**
-		 * Accepts a string a returns a sanitized version that can be used in
-		 * rewrite rules.
+		 * Returns a sanitized version of $slug that can be used in rewrite rules.
 		 *
 		 * This is ideal for those times where we wish to support internationalized
 		 * URLs (ie, where "venue" in "venue/some-slug" may be rendered in non-ascii
@@ -423,11 +422,11 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 		 * In the case of registering new post types, $permastruct_name should
 		 * generally match the CPT name itself.
 		 *
-		 * @param  string $permastruct_name
 		 * @param  string $slug
+		 * @param  string $permastruct_name
 		 * @return string
 		 */
-		public function prepare_slug( $permastruct_name, $slug ) {
+		public function prepare_slug( $slug, $permastruct_name ) {
 			$needs_handling = false;
 			$sanitized_slug = sanitize_title( $slug );
 

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -14,6 +14,11 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 	 * Permalinks magic Happens over here!
 	 */
 	class Tribe__Events__Rewrite {
+		/**
+		 * If we wish to setup a rewrite rule that uses percent symbols, we'll need
+		 * to make use of this placeholder.
+		 */
+		const PERCENT_PLACEHOLDER = '~~TRIBE~PC~~';
 
 		/**
 		 * Static singleton variable
@@ -407,6 +412,87 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 			return $this->add( $regex, $args );
 		}
 
+		/**
+		 * Accepts a string a returns a sanitized version that can be used in
+		 * rewrite rules.
+		 *
+		 * This is ideal for those times where we wish to support internationalized
+		 * URLs (ie, where "venue" in "venue/some-slug" may be rendered in non-ascii
+		 * characters).
+		 *
+		 * In the case of registering new post types, $permastruct_name should
+		 * generally match the CPT name itself.
+		 *
+		 * @param  string $permastruct_name
+		 * @param  string $slug
+		 * @return string
+		 */
+		public function prepare_slug( $permastruct_name, $slug ) {
+			$needs_handling = false;
+			$sanitized_slug = sanitize_title( $slug );
+
+			// Was UTF8 encoding required for the slug? %a0 type entities are a tell-tale of this
+			if ( preg_match( '/(%[0-9a-f]{2})+/', $sanitized_slug ) ) {
+				/**
+				 * Controls whether special UTF8 URL handling is setup for the set of
+				 * rules described by $permastruct_name.
+				 *
+				 * This only fires if Tribe__Events__Rewrite::prepare_slug() believes
+				 * handling is required.
+				 *
+				 * @var string $permastruct_name
+				 * @var string $possible_slug_name
+				 */
+				$needs_handling = apply_filters( 'tribe_events_rewrite_utf8_handling',
+					true,
+					$permastruct_name,
+					$possible_slug_name
+				);
+			}
+
+			if ( $needs_handling ) {
+				// User agents encode things the same way but in uppercase
+				$sanitized_slug = strtoupper( $sanitized_slug );
+
+				// UTF8 encoding results in lots of "%" chars in our string which play havoc
+				// with WP_Rewrite::generate_rewrite_rules(), so we swap them out temporarily
+				$sanitized_slug = str_replace( '%', self::PERCENT_PLACEHOLDER, $sanitized_slug );
+
+				// Restore the % chars later on
+				add_filter( $permastruct_name . '_rewrite_rules', array( $this, 'remove_percent_placeholders' ) );
+			}
+
+			/**
+			 * Provides an opportunity to modify the sanitized slug which will be used
+			 * in rewrite rules relating to $permastruct_name.
+			 *
+			 * @var string $prepared_slug
+			 * @var string $permastruct_name
+			 * @var string $original_slug
+			 */
+			return apply_filters( 'tribe_events_rewrite_prepared_slug',
+				preg_quote( $sanitized_slug ),
+				$permastruct_name,
+				$slug
+			);
+		}
+
+		/**
+		 * Converts any percentage placeholders in the array keys back to % symbols.
+		 *
+		 * @param  array $rules
+		 * @return array
+		 */
+		public function remove_percent_placeholders( array $rules ) {
+			$new_rules = array();
+
+			foreach ( $rules as $key => $value ) {
+				$key = str_replace( self::PERCENT_PLACEHOLDER, '%', $key );
+				$new_rules[$key] = $value;
+			}
+
+			return $new_rules;
+		}
 	} // end Tribe__Events__Rewrite class
 
 } // end if !class_exists Tribe__Events__Rewrite


### PR DESCRIPTION
The venue and organizer CPT slugs can already be localized - but the end result with non-Roman alphabets like Greek is not always a happy one. This change corrects that, potentially paving the way for us to finally offer more complete support for Shavian.

[C#40385](https://central.tri.be/issues/40385)