### PR TITLE
added postmeta_table default value

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -937,7 +937,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		private static function postmeta_table( $query ) {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
-			$postmeta_table =  $wpdb->postmeta;
+			$postmeta_table = $wpdb->postmeta;
 
 			if ( ! $query->tribe_is_multi_posttype ) {
 				return $postmeta_table;

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -935,13 +935,13 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return string
 		 **/
 		private static function postmeta_table( $query ) {
-
+			/** @var \wpdb $wpdb */
 			global $wpdb;
+			$postmeta_table =  $wpdb->postmeta;
 
 			if ( ! $query->tribe_is_multi_posttype ) {
-				return $wpdb->postmeta;
+				return $postmeta_table;
 			}
-
 
 			$qv = $query->query_vars;
 
@@ -962,7 +962,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			return $postmeta_table;
-
 		}
 
 		/**


### PR DESCRIPTION
Ticket https://central.tri.be/issues/42331

We came across this in a service project.

Set up is multisite, WPML used on subdomain site and languages are English and Chinese simplified.
A notice is thrown as the `postmeta_table` var is not defined in the `Tribe__Events__Query` class on some queries in the simplified Chinese version.
The simple fix is to default the `postmeta_table` variable to `$wpdb->postmeta`.

