### PR TITLE
Make it possible to order the admin events list by organizer/venue

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -375,7 +375,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		}
 
 		/**
-		 * Returns whether or not the event date & upcoming filters should be removed from the query
+		 * Returns whether or not the event date & upcoming filters should be removed from the query.
+		 *
+		 * This can be useful for admin screens (ie, importer related) that "share" the
+		 * edit.php?post_type=tribe_events screen, though we do not wish this to be applied to the
+		 * main admin events list itself.
 		 *
 		 * @since 4.0
 		 * @param WP_Query $query WP_Query object
@@ -388,10 +392,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			// otherwise, let's remove the date filters if we're in the admin dashboard and the query is
-			// and event query on the tribe_events edit page
+			// an event query on a tribe_events edit page *other* than the main events list
 			return is_admin()
 				&& $query->tribe_is_event_query
-				&& Tribe__Admin__Helpers::instance()->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
+				&& Tribe__Admin__Helpers::instance()->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE )
+				&& ! empty( $_GET['page'] );
 		}
 
 		/**

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -734,8 +734,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		}
 
 		/**
-		 * Appends the necessary conditions to the order clause in order to order by
-		 * either venue or organizer.
+		 * Appends the necessary conditions to the order clause to sort by either venue or
+		 * organizer.
 		 *
 		 * @param  array    $clauses
 		 * @param  WP_Query $query

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -375,11 +375,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		}
 
 		/**
-		 * Returns whether or not the event date & upcoming filters should be removed from the query.
-		 *
-		 * This can be useful for admin screens (ie, importer related) that "share" the
-		 * edit.php?post_type=tribe_events screen, though we do not wish this to be applied to the
-		 * main admin events list itself.
+		 * Returns whether or not the event date & upcoming filters should be removed from the query
 		 *
 		 * @since 4.0
 		 * @param WP_Query $query WP_Query object
@@ -392,11 +388,10 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			// otherwise, let's remove the date filters if we're in the admin dashboard and the query is
-			// an event query on a tribe_events edit page *other* than the main events list
+			// and event query on the tribe_events edit page
 			return is_admin()
 				&& $query->tribe_is_event_query
-				&& Tribe__Admin__Helpers::instance()->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE )
-				&& ! empty( $_GET['page'] );
+				&& Tribe__Admin__Helpers::instance()->is_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
 		}
 
 		/**

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -719,10 +719,24 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			 */
 			add_filter( 'posts_clauses', array( __CLASS__, 'posts_orderby_venue_organizer' ), 100, 2 );
 
-			/**
-			 * @deprecated since 4.0.2
-			 */
-			$join_sql = apply_filters( 'tribe_events_query_posts_join_orderby', $join_sql );
+			if ( has_filter( 'tribe_events_query_posts_join_orderby' ) ) {
+				/**
+				 * Historically this filter has only been useful to modify the joins setup
+				 * in relation to organizers and venues. In future it may have a more general
+				 * application or may be removed.
+				 *
+				 * @deprecated since 4.0.2
+				 *
+				 * @var string $join_sql
+				 */
+				$join_sql = apply_filters( 'tribe_events_query_posts_join_orderby', $join_sql );
+
+				_doing_it_wrong(
+					'tribe_events_query_posts_join_orderby (filter)',
+					'To modify joins in relation to venues and organizers specifically you are encouraged to use the tribe_events_query_posts_join_venue_organizer hook.',
+					'4.0.2'
+				);
+			}
 
 			/**
 			 * Provides an opportunity to modify the join condition added to the query when


### PR DESCRIPTION
This change better isolates the logic for ordering by venue/organizer from the logic used to order by date (which doesn't always run, depending on the context) - letting users successfully order the admin events list by organizer/venue (such as if APM is enabled and has made those particular columns sortable).

[C#37286](https://central.tri.be/issues/37286)