### PR TITLE
Explicitly set order for past event queries (ajax) | 42371

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -115,10 +115,13 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				? true // this is an event query of some type
 				: false; // move along, this is not the query you are looking for
 
-			// is the query pulling posts from the past
-			if ( $query->is_main_query() && ! empty( $_REQUEST['tribe_event_display'] ) && $_REQUEST['tribe_event_display'] == 'past' ) {
+			// is the query pulling posts from the past?
+			$past_requested = ! empty( $_REQUEST['tribe_event_display'] ) && 'past' === $_REQUEST['tribe_event_display'];
+			$display_past   = 'past' === $query->get( 'eventDisplay' );
+
+			if ( $query->is_main_query() && $past_requested ) {
 				$query->tribe_is_past = true;
-			} elseif ( tribe_is_ajax_view_request() && $query->get( 'eventDisplay' ) == 'past' ) {
+			} elseif ( tribe_is_ajax_view_request() && ( $display_past || $past_requested ) ) {
 				$query->tribe_is_past = true;
 			} elseif ( $query->get( 'tribe_is_past' ) ) {
 				$query->tribe_is_past = true;

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -73,6 +73,7 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 			if ( isset( $_POST['tribe_event_display'] ) ) {
 				if ( $_POST['tribe_event_display'] == 'past' ) {
 					$args['eventDisplay'] = 'past';
+					$args['order'] = 'DESC';
 				} elseif ( 'all' == $_POST['tribe_event_display'] ) {
 					$args['eventDisplay'] = 'all';
 				}


### PR DESCRIPTION
This change ensures that a) the `$query->tribe_is_past` flag is set during past event requests made by ajax and b) the order is set to `DESC` (a recent-ish change to the default args used in `tribe_get_events()` requires this).

[C#42371](https://central.tri.be/issues/42371)