### PR TITLE
Mod the WHERE clause when fetching next/prev events to avoid exclusions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -316,6 +316,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Tweak - Improve messaging in the same-slug warning message
 * Fix - Ensure the past events list displays the correct events when accessed via ajax
 * Fix - Support ordering by venue/organizer within event queries
+* Fix - Fix issue where events with the same date/time would sometimes be excluded from single-event navigation
 
 = [4.0.1] 2015-12-10 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3931,7 +3931,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * return string
 		 */
-		public function get_closest_event_where( $where_sql, $query ) {
+		public function get_closest_event_where( $where_sql ) {
 			// if we are in this method, we KNOW there is a section of the SQL that looks like this:
 			//     ( table.meta_key = '_EventStartDate' AND CAST( table.meta_value AS DATETIME ) [<|>] '2015-01-01 00:00:00' )
 			// What we want to do is to extract all the portions of the WHERE BEFORE that section, all the
@@ -4064,9 +4064,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 * @var WP_Post $post
 			 */
 			$args = (array) apply_filters( "tribe_events_get_{$mode}_event_link", $args, $post );
-			add_filter( 'posts_where', array( $this, 'get_closest_event_where' ), 10, 2 );
+			add_filter( 'posts_where', array( $this, 'get_closest_event_where' ) );
 			$results = tribe_get_events( $args );
-			remove_filter( 'posts_where', array( $this, 'get_closest_event_where' ), 10, 2 );
+			remove_filter( 'posts_where', array( $this, 'get_closest_event_where' ) );
 
 			$event = null;
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3919,17 +3919,113 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Get a "previous/next post" link for events. Ordered by start date instead of ID.
+		 * Modify the WHERE clause of query when fetching next/prev posts so events with identical times are not excluded
+		 *
+		 * This method ensures that when viewing single events that occur at a given time, other events
+		 * that occur at the exact same time are are not excluded from the prev/next links
+		 *
+		 * @since 4.0.2
+		 *
+		 * @param string $where_sql WHERE SQL statement
+		 * @param WP_Query $query WP_Query object
+		 *
+		 * return string
+		 */
+		public function get_closest_event_where( $where_sql, $query ) {
+			// if we are in this method, we KNOW there is a section of the SQL that looks like this:
+			//     ( table.meta_key = '_EventStartDate' AND CAST( table.meta_value AS DATETIME ) [<|>] '2015-01-01 00:00:00' )
+			// What we want to do is to extract all the portions of the WHERE BEFORE that section, all the
+			// portions AFTER that section, and then rebuild that section to be flexible enough to include
+			// events that have the SAME datetime as the event we're comparing against.  Sadly, this requires
+			// some regex-fu.
+			//
+			// The end-game is to change the known SQL line (from above) into the following:
+			//
+			//  (
+			//    ( table.meta_key = '_EventStartDate' AND CAST( table.meta_value AS DATETIME ) [<|>] '2015-01-01 00:00:00' )
+			//    OR (
+			//      ( table.meta_key = '_EventStartDate' AND CAST( table.meta_value AS DATETIME ) = '2015-01-01 00:00:00' )
+			//      AND
+			//      table.post_id [<|>] POST_ID
+			//    )
+			//  )
+			//
+
+			// Here's the regex portion that matches the part that we know. From that line, we want to
+			// have a few capture groups.
+			//     1) We need the whole thing
+			//     2) We need the meta table alias
+			//     3) We need the < or > sign
+
+			// Here's the regex for getting the meta table alias
+			$meta_table_regex = '([^\.]+)\.meta_key\s*=\s*';
+
+			// Here's the regex for the middle section of the know line
+			$middle_regex = '[\'"]_EventStartDate[\'"]\s+AND\s+CAST[^\)]+AS DATETIME\s*\)\s*';
+
+			// Here's the regex for the < and > sign
+			$gt_lt_regex = '(\<|\>)';
+
+			// Let's put that line together, making sure we are including the wrapping parens and the
+			// characters that make up the rest of the line - spacing in front, non paren characters at
+			// the end
+			$known_sql_regex = "\(\s*{$meta_table_regex}{$middle_regex}{$gt_lt_regex}[^\)]+\)";
+
+			// The known SQL line will undoubtedly be included amongst other WHERE statements. We need
+			// to generically grab the SQL before and after the known line so we can rebuild our nice new
+			// where statement. Here's the regex that brings it all together.
+			//   Note: We are using the 'm' modifier so that the regex looks over multiple lines as well
+			//         as the 's' modifier so that '.' includes linebreaks
+			$full_regex = "/(.*)($known_sql_regex)(.*)/ms";
+
+			// here's a regex to grab the post ID from a portion of the WHERE statement
+			$post_id_regex = '/NOT IN\s*\(([0-9]+)\)/';
+
+			if ( preg_match( $full_regex, $where_sql, $matches ) ) {
+				// place capture groups into vars that are easier to read
+				$before = $matches[1];
+				$known = $matches[2];
+				$alias = $matches[3];
+				$gt_lt = $matches[4];
+				$after = $matches[5];
+
+				// copy the known line but replace the < or > symbol with an =
+				$equal = preg_replace( '/(\<|\>)/', '=', $known );
+
+				// extract the post ID from the extra "before" or "after" WHERE
+				if (
+					preg_match( $post_id_regex, $before, $post_id )
+					|| preg_match( $post_id_regex, $after, $post_id )
+				) {
+					$post_id = absint( $post_id[1] );
+				} else {
+					// if we can't find the post ID, then let's bail
+					return $where_sql;
+				}
+
+				// rebuild the WHERE clause
+				$where_sql = "{$before} (
+					{$known}
+					OR (
+						{$equal}
+						AND {$alias}.post_id {$gt_lt} {$post_id}
+					)
+				) {$after} ";
+			}
+
+			return $where_sql;
+		}
+
+		/**
+		 * Get the prev/next post for a given event. Ordered by start date instead of ID.
 		 *
 		 * @param WP_Post $post The post/event.
 		 * @param string  $mode Either 'next' or 'previous'.
-		 * @param mixed   $anchor
 		 *
-		 * @return string The link (with <a> tags).
+		 * @return null|WP_Post
 		 */
-		public function get_event_link( $post, $mode = 'next', $anchor = false ) {
+		public function get_closest_event( $post, $mode = 'next' ) {
 			global $wpdb;
-			$link = '';
 
 			if ( 'previous' === $mode ) {
 				$order      = 'DESC';
@@ -3966,15 +4062,44 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 *
 			 * @var array   $args
 			 * @var WP_Post $post
-			 * @var boolean $anchor
 			 */
-			$args = (array) apply_filters( "tribe_events_get_{$mode}_event_link", $args, $post, $anchor );
+			$args = (array) apply_filters( "tribe_events_get_{$mode}_event_link", $args, $post );
+			add_filter( 'posts_where', array( $this, 'get_closest_event_where' ), 10, 2 );
 			$results = tribe_get_events( $args );
+			remove_filter( 'posts_where', array( $this, 'get_closest_event_where' ), 10, 2 );
+
+			$event = null;
 
 			// If we successfully located the next/prev event, we should have precisely one element in $results
 			if ( 1 === count( $results ) ) {
 				$event = current( $results );
+			}
 
+			/**
+			 * Affords an opportunity to modify the event used to generate the event link (typically for
+			 * the next or previous event in relation to $post).
+			 *
+			 * @var WP_Post $post
+			 * @var string  $mode (typically "previous" or "next")
+			 */
+			return apply_filters( 'tribe_events_get_closest_event', $event, $post, $mode );
+		}
+
+		/**
+		 * Get a "previous/next post" link for events. Ordered by start date instead of ID.
+		 *
+		 * @param WP_Post $post The post/event.
+		 * @param string  $mode Either 'next' or 'previous'.
+		 * @param mixed   $anchor
+		 *
+		 * @return string The link (with <a> tags).
+		 */
+		public function get_event_link( $post, $mode = 'next', $anchor = false ) {
+			$link = null;
+			$event = $this->get_closest_event( $post, $mode );
+
+			// If we successfully located the next/prev event, we should have precisely one element in $results
+			if ( $event ) {
 				if ( ! $anchor ) {
 					$anchor = apply_filters( 'the_title', $event->post_title );
 				} elseif ( strpos( $anchor, '%title%' ) !== false ) {

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -650,11 +650,16 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			global $wpdb;
 
 			if ( $query->tribe_is_event || $query->tribe_is_event_category ) {
-				$order   = ( isset( $query->order ) && ! empty( $query->order ) ) ? $query->order : $query->get( 'order' );
-				$orderby = ( isset( $query->orderby ) && ! empty( $query->orderby ) ) ? $query->orderby : $query->get( 'orderby' );
+				$order   = ( isset( $query->query_vars['order'] ) && ! empty( $query->query_vars['order'] ) ) ? $query->query_vars['order'] : $query->get( 'order' );
+				$orderby = ( isset( $query->query_vars['orderby'] ) && ! empty( $query->query_vars['orderby'] ) ) ? $query->query_vars['orderby'] : $query->get( 'orderby' );
 
 				if ( self::can_inject_date_field( $query ) ) {
+					$old_orderby = $order_sql;
 					$order_sql = "EventStartDate {$order}";
+
+					if ( $old_orderby ) {
+						$order_sql .= ", {$old_orderby}";
+					}
 				}
 
 				do_action( 'log', 'orderby', 'default', $orderby );

--- a/tests/functional/Tribe/Events/Navigation_Test.php
+++ b/tests/functional/Tribe/Events/Navigation_Test.php
@@ -14,7 +14,18 @@ class Navigation_Test extends \Tribe__Events__WP_UnitTestCase {
 		parent::tearDown();
 	}
 
-	public function test_closest_event() {
+	/**
+	 * Test a linear closest event list
+	 *
+	 * The order should be:
+	 *
+	 *   ID  EventStartDate
+	 *   1   2015-12-01 15:00:00
+	 *   2   2015-12-02 15:00:00
+	 *   3   2015-12-02 15:00:00
+	 *   4   2015-12-03 15:00:00
+	 */
+	public function test_closest_event_linear() {
 		$main = \Tribe__Events__Main::instance();
 		$settings = $this->post_example_settings;
 		unset( $settings['EventHideFromUpcoming'] );
@@ -55,5 +66,82 @@ class Navigation_Test extends \Tribe__Events__WP_UnitTestCase {
 
 		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_4, 'previous' )->ID, "Post 4's previous post should be Post 3" );
 		$this->assertEquals( null, $main->get_closest_event( $post_4, 'next' ), "Post 4's next post should be null" );
+	}
+
+	/**
+	 * Test a non-linear closest event list
+	 *
+	 * The order should be:
+	 *
+	 *   ID  EventStartDate
+	 *   2   2015-12-01 12:00:00
+	 *   1   2015-12-02 15:00:00
+	 *   3   2015-12-02 15:00:00
+	 *   4   2015-12-02 15:00:00
+	 *   5   2015-12-03 16:00:00
+	 */
+	public function test_closest_event_non_linear() {
+		$main = \Tribe__Events__Main::instance();
+		$settings = $this->post_example_settings;
+		unset( $settings['EventHideFromUpcoming'] );
+
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+		$settings['EventStartHour'] = '3';
+		$settings['EventStartMinute'] = '00';
+		$settings['EventStartMeridian'] = 'pm';
+		$settings['EventEndHour'] = '4';
+		$settings['EventEndMinute'] = '00';
+		$settings['EventEndMeridian'] = 'pm';
+
+		$post_id = tribe_create_event( $settings );
+		$post_1 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 2';
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$settings['EventStartHour'] = '12';
+		$settings['EventEndHour'] = '1';
+
+		$post_id = tribe_create_event( $settings );
+		$post_2 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 3';
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+		$settings['EventStartHour'] = '3';
+		$settings['EventEndHour'] = '4';
+
+		$post_id = tribe_create_event( $settings );
+		$post_3 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 4';
+
+		$post_id = tribe_create_event( $settings );
+		$post_4 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 5';
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
+		$settings['EventStartHour'] = '4';
+		$settings['EventEndHour'] = '5';
+
+		$post_id = tribe_create_event( $settings );
+		$post_5 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$this->assertEquals( $post_2->ID, $main->get_closest_event( $post_1, 'previous' )->ID, "Post 1's previous post should be Post 2" );
+		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_1, 'next' )->ID, "Post 1's next post should be Post 3" );
+
+		$this->assertEquals( null, $main->get_closest_event( $post_2, 'previous' ), "Post 2's previous post should be null" );
+		$this->assertEquals( $post_1->ID, $main->get_closest_event( $post_2, 'next' )->ID, "Post 2's next post should be Post 1" );
+
+		$this->assertEquals( $post_1->ID, $main->get_closest_event( $post_3, 'previous' )->ID, "Post 3's previous post should be Post 1" );
+		$this->assertEquals( $post_4->ID, $main->get_closest_event( $post_3, 'next' )->ID, "Post 3's next post should be Post 4" );
+
+		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_4, 'previous' )->ID, "Post 4's previous post should be Post 3" );
+		$this->assertEquals( $post_5->ID, $main->get_closest_event( $post_4, 'next' )->ID, "Post 4's next post should be Post 5" );
+
+		$this->assertEquals( $post_4->ID, $main->get_closest_event( $post_5, 'previous' )->ID, "Post 5's previous post should be Post 4" );
+		$this->assertEquals( null, $main->get_closest_event( $post_5, 'next' ), "Post 5's next post should be null" );
 	}
 }

--- a/tests/functional/Tribe/Events/Navigation_Test.php
+++ b/tests/functional/Tribe/Events/Navigation_Test.php
@@ -1,0 +1,59 @@
+<?php
+namespace Tribe\Events;
+
+class Navigation_Test extends \Tribe__Events__WP_UnitTestCase {
+	public function setUp() {
+		// before
+		parent::setUp();
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+		// then
+		parent::tearDown();
+	}
+
+	public function test_closest_event() {
+		$main = \Tribe__Events__Main::instance();
+		$settings = $this->post_example_settings;
+		unset( $settings['EventHideFromUpcoming'] );
+
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+
+		$post_id = tribe_create_event( $settings );
+		$post_1 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 2';
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
+
+		$post_id = tribe_create_event( $settings );
+		$post_2 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 3';
+
+		$post_id = tribe_create_event( $settings );
+		$post_3 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$settings['post_title'] = 'Test event 4';
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
+
+		$post_id = tribe_create_event( $settings );
+		$post_4 = tribe_get_events( array( 'p' => $post_id ) )[0];
+
+		$this->assertEquals( null, $main->get_closest_event( $post_1, 'previous' ), "Post 1's previous post should be null" );
+		$this->assertEquals( $post_2->ID, $main->get_closest_event( $post_1, 'next' )->ID, "Post 1's next post should be Post 2" );
+
+		$this->assertEquals( $post_1->ID, $main->get_closest_event( $post_2, 'previous' )->ID, "Post 2's previous post should be Post 1" );
+		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_2, 'next' )->ID, "Post 2's next post should be Post 3" );
+
+		$this->assertEquals( $post_2->ID, $main->get_closest_event( $post_3, 'previous' )->ID, "Post 3's previous post should be Post 2" );
+		$this->assertEquals( $post_4->ID, $main->get_closest_event( $post_3, 'next' )->ID, "Post 3's next post should be Post 4" );
+
+		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_4, 'previous' )->ID, "Post 4's previous post should be Post 3" );
+		$this->assertEquals( null, $main->get_closest_event( $post_4, 'next' ), "Post 4's next post should be null" );
+	}
+}


### PR DESCRIPTION
I've commented the code heavily, but the gist is - when we were fetching next/previous events, the query that was being generated excluded events that had identical times to the event being viewed. Additionally, sometimes events with duplicate times wouldn't show up in the single-event navigation at all.

This fix reworks the WHERE clause meta query for the date selection to add additional meta/post_id statements that aren't possible with the standard WP_Query parameters. It includes a heavily commented regex that I tried to make _very_ targeted to avoid accidental butchery.

This code includes tests.

See: https://central.tri.be/issues/41290