### PR TITLE
Avoid accidentally fetching event category #1 

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2661,12 +2661,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				if ( ! is_wp_error( $term_link ) ) {
 					$event_url = trailingslashit( $term_link );
 				}
-			} else {
-				if ( $term ) {
-					$term_link = get_term_link( (int) $term, self::TAXONOMY );
-					if ( ! is_wp_error( $term_link ) ) {
-						$event_url = trailingslashit( $term_link );
-					}
+			} elseif ( $term && is_numeric( $term ) ) {
+				$term_link = get_term_link( (int) $term, self::TAXONOMY );
+				if ( ! is_wp_error( $term_link ) ) {
+					$event_url = trailingslashit( $term_link );
 				}
 			}
 


### PR DESCRIPTION
If $term is a boolean value we shouldn't cast it to an int and try to fetch that term. See also [PRO PR 248](https://github.com/moderntribe/events-pro/pull/248).

[C#42381](https://central.tri.be/issues/42381)