### PR TITLE
Don't include string-based costs when fetching max/min costs in range

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -193,6 +193,15 @@ class Tribe__Events__Cost_Utils {
 
 		$costs = $this->parse_cost_range( $costs );
 
+		// if there's only one item, we're looking at a single event. If the cost is non-numeric, let's
+		// return the non-numeric cost so that value is preserved
+		if ( 1 === count( $costs ) && ! is_numeric( current( $costs ) ) ) {
+			return current( $costs );
+		}
+
+		// make sure we are only trying to get numeric min/max values
+		$costs = array_filter( $costs, 'is_numeric' );
+
 		if ( empty( $costs ) ) {
 			return 0;
 		}

--- a/tests/functional/Tribe__Events__Cost_Utils_Test.php
+++ b/tests/functional/Tribe__Events__Cost_Utils_Test.php
@@ -127,6 +127,6 @@ class Tribe__Events__Cost_Utils_Test extends Tribe__Events__WP_UnitTestCase {
 		$this->assertEquals( array( 10 => '10' ), $range );
 
 		$range = $cost_utils->parse_cost_range( array( 'Free' ) );
-		$this->assertEquals( array(), $range );
+		$this->assertEquals( array( 'free' => 'Free' ), $range );
 	}
 }


### PR DESCRIPTION
This fix ensures that the min/max cost ranges only include numeric values while allowing single events to preserve their string-based cost formatting.

Cost range tests pass.

Related: https://github.com/moderntribe/events-filterbar/pull/54

See: https://central.tri.be/issues/39041