### PR TITLE
Only append the original orderby if it is an orderby post_date

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,6 +312,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 = [4.0.3] unreleased =
 
 * Fix - Resolved issue with an overly escaped Event Category edit URL that prevented editing categories
+* Fix - Fixed issue where clicking on columns on the Events listed in the Admin Dashboard were ALWAYS sorted by Event start/end date before sorting by the column selected
 
 = [4.0.2] 2015-12-16 =
 


### PR DESCRIPTION
This partial reversion/hybrid is a best-of-both-worlds of a few previous renditions of this code. This allows any non-post_date field to take precedence over the start/end date of the event _*except*_ the post_date, which largely doesn't matter for Events.

See: https://central.tri.be/issues/38331