### PR TITLE
Make the time section hookable so that Recurring events can override

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -311,6 +311,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 = [4.0.3] unreleased =
 
+* Tweak - Adjust single-event.php template to allow the "Time" title and content to be filterable
 * Fix - Resolved issue with an overly escaped Event Category edit URL that prevented editing categories
 
 = [4.0.2] 2015-12-16 =

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -22,6 +22,31 @@ $end_date = tribe_get_display_end_date( null, false );
 $end_time = tribe_get_end_date( null, false, $time_format );
 $end_ts = tribe_get_end_date( null, false, Tribe__Date_Utils::DBDATEFORMAT );
 
+$formatted_time = null;
+if ( $start_time == $end_time ) {
+	$formatted_time = esc_html( $start_time );
+} else {
+	$formatted_time = esc_html( $start_time . $time_range_separator . $end_time );
+}
+
+$event_id = Tribe__Main::post_id_helper();
+
+/**
+ * Returns a formatted time for a single event
+ *
+ * @var string Formatted time string
+ * @var int Event post id
+ */
+$formatted_time = apply_filters( 'tribe_events_single_event_formatted_time', $formatted_time, $event_id );
+
+/**
+ * Returns the title of the "Time" section of event details
+ *
+ * @var string Time title
+ * @var int Event post id
+ */
+$time_title = apply_filters( 'tribe_events_single_event_time_title', __( 'Time:', 'the-events-calendar' ), $event_id );
+
 $cost = tribe_get_formatted_cost();
 $website = tribe_get_event_website_link();
 ?>
@@ -82,14 +107,10 @@ $website = tribe_get_event_website_link();
 				<abbr class="tribe-events-abbr updated published dtstart" title="<?php esc_attr_e( $start_ts ) ?>"> <?php esc_html_e( $start_date ) ?> </abbr>
 			</dd>
 
-			<dt> <?php esc_html_e( 'Time:', 'the-events-calendar' ) ?> </dt>
-			<dd><abbr class="tribe-events-abbr updated published dtstart" title="<?php esc_attr_e( $end_ts ) ?>">
-					<?php if ( $start_time == $end_time ) {
-						esc_html_e( $start_time );
-					} else {
-						esc_html_e( $start_time . $time_range_separator . $end_time );
-					} ?>
-				</abbr></dd>
+			<dt> <?php echo esc_html( $time_title ); ?> </dt>
+			<dd><div class="tribe-events-abbr updated published dtstart" title="<?php esc_attr_e( $end_ts ) ?>">
+					<?php echo $formatted_time; ?>
+				</div></dd>
 
 		<?php endif ?>
 

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -22,11 +22,11 @@ $end_date = tribe_get_display_end_date( null, false );
 $end_time = tribe_get_end_date( null, false, $time_format );
 $end_ts = tribe_get_end_date( null, false, Tribe__Date_Utils::DBDATEFORMAT );
 
-$formatted_time = null;
+$time_formatted = null;
 if ( $start_time == $end_time ) {
-	$formatted_time = esc_html( $start_time );
+	$time_formatted = esc_html( $start_time );
 } else {
-	$formatted_time = esc_html( $start_time . $time_range_separator . $end_time );
+	$time_formatted = esc_html( $start_time . $time_range_separator . $end_time );
 }
 
 $event_id = Tribe__Main::post_id_helper();
@@ -37,7 +37,7 @@ $event_id = Tribe__Main::post_id_helper();
  * @var string Formatted time string
  * @var int Event post id
  */
-$formatted_time = apply_filters( 'tribe_events_single_event_formatted_time', $formatted_time, $event_id );
+$time_formatted = apply_filters( 'tribe_events_single_event_time_formatted', $time_formatted, $event_id );
 
 /**
  * Returns the title of the "Time" section of event details
@@ -109,7 +109,7 @@ $website = tribe_get_event_website_link();
 
 			<dt> <?php echo esc_html( $time_title ); ?> </dt>
 			<dd><div class="tribe-events-abbr updated published dtstart" title="<?php esc_attr_e( $end_ts ) ?>">
-					<?php echo $formatted_time; ?>
+					<?php echo $time_formatted; ?>
 				</div></dd>
 
 		<?php endif ?>


### PR DESCRIPTION
Recurring events need to be able to output multiple times on the single-event template. This twiddles the template to allow that by adding a few filters.

Related: https://github.com/moderntribe/events-pro/pull/252

See: https://central.tri.be/issues/39821