### PR TITLE
Change superclass for metaTest (spotfix)

### DIFF
--- a/tests/functional/functions/template-tags/metaTest.php
+++ b/tests/functional/functions/template-tags/metaTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace TEC\Tests\functions\template_tags;
 
-class metaTest extends \WP_UnitTestCase {
+class metaTest extends \Tribe__Events__WP_UnitTestCase {
 
 	protected $backupGlobals = false;
 


### PR DESCRIPTION
Run the `template-tags/metaTest.php` test without a class not found error.