### PR TITLE
modified ical file name to use 11 digit hash

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -330,7 +330,8 @@ class Tribe__Events__iCal {
 		}
 
 		header( 'Content-type: text/calendar; charset=UTF-8' );
-		header( 'Content-Disposition: attachment; filename="ical-event-' . implode( $event_ids ) . '.ics"' );
+		$hash = substr( md5( implode( $event_ids ) ), 0, 11 );
+		header( 'Content-Disposition: attachment; filename="ical-event-' . $hash . '.ics"' );
 		$content = "BEGIN:VCALENDAR\r\n";
 		$content .= "VERSION:2.0\r\n";
 		$content .= 'PRODID:-//' . $blogName . ' - ECPv' . Tribe__Events__Main::VERSION . "//NONSGML v1.0//EN\r\n";


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/39455

I've set the length of the has to 11 for the aestethic reason that the generated filename will not be cut with ellipsis in many browsers download windows.
I'm not that concerned about uniqueness as any system, being it a file, will attach a `(1)` or something to it to distinguish.