### PR TITLE
Register core views/overrides (with the template update checker)

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -81,6 +81,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			}
 
 			add_filter( 'get_post_time', array( __CLASS__, 'event_date_to_pubDate' ), 10, 3 );
+			add_filter( 'tribe_support_registered_template_systems', array( __CLASS__, 'register_template_updates' ) );
 		}
 
 		/**
@@ -800,6 +801,23 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 
 			// Don't do this again
 			unset( $wp_query->spoofed );
+		}
+
+		/**
+		 * Registers The Events Calendar with the views/overrides update checker.
+		 *
+		 * @param array $plugins
+		 *
+		 * @return array
+		 */
+		public static function register_template_updates( $plugins ) {
+			$plugins[ __( 'The Events Calendar', 'the-events-calendar' ) ] = array(
+				Tribe__Events__Main::VERSION,
+				Tribe__Events__Main::instance()->plugin_path . 'src/views',
+				trailingslashit( get_stylesheet_directory() ) . 'tribe-events'
+			);
+
+			return $plugins;
 		}
 	}
 }

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -814,7 +814,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			$plugins[ __( 'The Events Calendar', 'the-events-calendar' ) ] = array(
 				Tribe__Events__Main::VERSION,
 				Tribe__Events__Main::instance()->plugin_path . 'src/views',
-				trailingslashit( get_stylesheet_directory() ) . 'tribe-events'
+				trailingslashit( get_stylesheet_directory() ) . 'tribe-events',
 			);
 
 			return $plugins;


### PR DESCRIPTION
Register TEC's view path and override path with the template updates checker.

[C#28582](https://central.tri.be/issues/28582)