### PR TITLE
Prevent fatal if import/continue screen is refreshed | 37186

### DIFF
--- a/src/Tribe/Importer/Admin_Page.php
+++ b/src/Tribe/Importer/Admin_Page.php
@@ -232,7 +232,11 @@ class Tribe__Events__Importer__Admin_Page {
 				break;
 
 			case 'continue':
-				$this->continue_import();
+				// This test guards against a fatal error that can occur if the action=continue
+				// screen is refreshed after the import completes
+				if ( Tribe__Events__Importer__File_Uploader::has_valid_csv_file() ) {
+					$this->continue_import();
+				}
 				break;
 
 			default:

--- a/src/Tribe/Importer/File_Uploader.php
+++ b/src/Tribe/Importer/File_Uploader.php
@@ -54,6 +54,17 @@ class Tribe__Events__Importer__File_Uploader {
 		return $path;
 	}
 
+	/**
+	 * Indicates if the file returned by self::get_file_path() (still) exists
+	 * and is readable.
+	 *
+	 * @return bool
+	 */
+	public static function has_valid_csv_file() {
+		$csv_file = self::get_file_path();
+		return file_exists( $csv_file ) && is_readable( $csv_file );
+	}
+
 	private static function get_upload_directory() {
 		$upload_dir_array = wp_upload_dir();
 		$path             = $upload_dir_array['basedir'];


### PR DESCRIPTION
[C#37186](https://central.tri.be/issues/37186) - prevent a fatal/WSOD that can occur in some edge case-like scenarios.