### PR TITLE
Replace "ical" and "events" (from the suggested filename for .ics downloads) | 38124

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -330,8 +330,9 @@ class Tribe__Events__iCal {
 		}
 
 		header( 'Content-type: text/calendar; charset=UTF-8' );
+		$site = sanitize_title( get_bloginfo( 'name' ) );
 		$hash = substr( md5( implode( $event_ids ) ), 0, 11 );
-		header( 'Content-Disposition: attachment; filename="ical-event-' . $hash . '.ics"' );
+		header( 'Content-Disposition: attachment; filename="' . $site . '-' . $hash . '.ics"' );
 		$content = "BEGIN:VCALENDAR\r\n";
 		$content .= "VERSION:2.0\r\n";
 		$content .= 'PRODID:-//' . $blogName . ' - ECPv' . Tribe__Events__Main::VERSION . "//NONSGML v1.0//EN\r\n";


### PR DESCRIPTION
Per [C#38124](https://central.tri.be/issues/38124) `{sitename}-{hash}.ics` is probably better than `ical-events-{hash}.ics` since even if we ignore the .ics extension the user is probably well aware that it is iCal format and that it contains events ;-)