### PR TITLE
modified month event ordering to by start time

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -619,7 +619,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
-					'orderby'                => 'menu_order',
+					'meta_key'               => '_EventStartDate',
+					'orderby'                => 'meta_value_datetime',
 				), $this->args
 			);
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/41383
The events, on the Month view, were being sorted by menu order causing some mispositioning.