### PR TITLE
Add Filter to Month Day Query

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -624,6 +624,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				), $this->args
 			);
 
+			$args = apply_filters( 'tribe_events_month_daily_events_query_args', $args );
+
 			// we don't need this join since we already checked it
 			unset ( $args[ Tribe__Events__Main::TAXONOMY ] );
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -623,7 +623,12 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'orderby'                => 'meta_value_datetime',
 				), $this->args
 			);
-
+			/**
+			 * Filter Daily Events Query Arguments.
+			 *
+			 * @param array $args an array of daily events query.
+			 *
+			 */
 			$args = apply_filters( 'tribe_events_month_daily_events_query_args', $args );
 
 			// we don't need this join since we already checked it


### PR DESCRIPTION
_Ref:_ [C#38137](https://central.tri.be/issues/38137)

Added a filter to change query for the month daily events use this filter to change the order:

```
add_filter('tribe_events_month_daily_events_query_args', 'tribe_change_single_day_order' );
function tribe_change_single_day_order( $args ) {

	$args['order'] = 'DESC';
	
	return $args;
	
}
```	