### PR TITLE
Fixed the offset so it would take the difference of just one hour

### DIFF
--- a/src/Tribe/Utils/DST.php
+++ b/src/Tribe/Utils/DST.php
@@ -66,7 +66,8 @@ class Tribe__Events__Utils__DST {
 	 */
 	public function get_time_aligned_with( Tribe__Events__Utils__DST $dst ) {
 		$dst_aligned = $this->is_in_dst() == $dst->is_in_dst();
-		$offset      = $dst->is_in_dst() - $this->is_in_dst();
+		// The offset is now taking the time it is comparing to and taking the difference of just one instead of 2 hours
+		$offset      = $this->is_in_dst() - $dst->is_in_dst();
 
 		return $dst_aligned ? $this->time : $this->time + $offset * 3600;
 	}


### PR DESCRIPTION
Before the offset would be given and instead of giving the hour difference it was making it a 2 hour difference. What you were suppose to be taking away an hour from was adding an extra hour.

I found this error when trying to run the DST test.