### PR TITLE
Hook to the_content on 9 rather than 10 for better plugin compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -309,6 +309,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [4.0.6] unreleased =
+
+* Tweak - Adjust injection of event data into the_content from priority 10 to 9 for better 3rd-party plugin compatibility
+
 = [4.0.5] 2016-01-15 =
 
 * Security - Security fix with Venues and Organizers (props to grantdayjames for reporting this!)

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -284,7 +284,8 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 				add_action( 'the_post', array( __CLASS__, 'spoof_the_post' ) );
 
 				// on the_content, load our events template
-				add_filter( 'the_content', array( __CLASS__, 'load_ecp_into_page_template' ) );
+				// We're hooking to priority 9 for better compatibility with other non-tribe plugins that hook to the_content
+				add_filter( 'the_content', array( __CLASS__, 'load_ecp_into_page_template' ), 9 );
 
 				// remove the comments template
 				add_filter( 'comments_template', array( __CLASS__, 'load_ecp_comments_page_template' ) );
@@ -451,7 +452,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 		 */
 		public static function load_ecp_into_page_template() {
 			// only run once!!!
-			remove_filter( 'the_content', array( __CLASS__, 'load_ecp_into_page_template' ) );
+			remove_filter( 'the_content', array( __CLASS__, 'load_ecp_into_page_template' ), 9 );
 
 			self::restoreQuery();
 


### PR DESCRIPTION
So, I made this change and activated all of our plugins and loaded our single event page (with tickets) and nothing seemed awry.

Here's [the request](https://wordpress.org/support/topic/the-load_ecp_into_page_template-method-overrides-page-builder-content)

See: https://central.tri.be/issues/37991