### PR TITLE
Revert "Reference the class of the relocated method"

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1371,7 +1371,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		// If not, try to determine now
-		Tribe__Events__Dates__Known_Range::instance()->rebuild_known_range();
+		Tribe__Events__Main::instance()->rebuild_known_range();
 		$latest = tribe_get_option( 'latest_date', false );
 		if ( false !== $latest ) {
 			return Tribe__Date_Utils::reformat( $latest, $format );


### PR DESCRIPTION
This was another change that didn't need to happen in 4.0.6 but was done because of the funky merge commit. Let's revert it.

Reverts moderntribe/the-events-calendar#559