### PR TITLE
Ensure availability of styles for the event details shortcode | 37918

### DIFF
--- a/src/Tribe/Shortcode/Event_Details.php
+++ b/src/Tribe/Shortcode/Event_Details.php
@@ -193,6 +193,10 @@ class Tribe__Events__Shortcode__Event_Details {
 		 */
 		$classes = apply_filters( 'tribe_events_shortcode_' . $slug . '_container_classes', $classes, $args, $tag );
 
+		// Ensure the expected CSS is available to style the shortcode output (this will
+		// happen automatically in event views, but not elsewhere)
+		Tribe__Events__Template_Factory::asset_package( 'events-css' );
+
 		// Start to record the Output
 		ob_start();
 


### PR DESCRIPTION
Support expected formatting of `[tribe:event-details]` shortcode even outside of event views.

[C#37918](https://central.tri.be/issues/37918)