### PR TITLE
added missing array cast

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -400,7 +400,7 @@ class Tribe__Events__Cost_Utils {
 		$all_numeric_costs = array_filter( array_merge( $numeric_merging_cost_costs, $numeric_orignal_costs ) );
 		$cost_min          = $cost_max = false;
 
-		$merging_mins     = array_intersect( $sorted_mins, $merging_cost );
+		$merging_mins = array_intersect( $sorted_mins, (array) $merging_cost );
 		$merging_has_min  = array_search( reset( $merging_mins ), $sorted_mins );
 		$original_has_min = array_search( $original_string_cost, $sorted_mins );
 		$merging_has_min  = false === $merging_has_min ? 999 : $merging_has_min;
@@ -412,7 +412,7 @@ class Tribe__Events__Cost_Utils {
 			$cost_min = empty( $all_numeric_costs ) ? '' : min( $all_numeric_costs );
 		}
 
-		$merging_maxs     = array_intersect( $sorted_maxs, $merging_cost );
+		$merging_maxs = array_intersect( $sorted_maxs, (array) $merging_cost );
 		$merging_has_max  = array_search( end( $merging_maxs ), $sorted_maxs );
 		$original_has_max = array_search( $original_string_cost, $sorted_maxs );
 		$merging_has_max  = false === $merging_has_max ? - 1 : $merging_has_max;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/33491#note-15

This PR adds two missing array castings that would prevent the price merging from correctly happening