### PR TITLE
Fix/37494 filter events only

### DIFF
--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -90,6 +90,11 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 		 * @return  Array                   Modified SQL clauses
 		 */
 		public static function sort_by_event_date( Array $clauses, WP_Query $wp_query ) {
+			// bail if this is not a query for event post type
+			if ( $wp_query->get( 'post_type' ) !== Tribe__Events__Main::POSTTYPE ) {
+				return $clauses;
+			}
+
 			global $wpdb;
 
 			$sort_direction = self::get_sort_direction( $wp_query );

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -706,6 +706,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return string
 		 */
 		public static function posts_join_venue_organizer( $join_sql, $query ) {
+			// bail if this is not a query for event post type
+			if ( $query->get( 'post_type' ) !== Tribe__Events__Main::POSTTYPE ) {
+				return $join_sql;
+			}
+
 			global $wpdb;
 
 			switch ( $query->get( 'orderby' ) ) {

--- a/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
+++ b/tests/phantomjs/Issue_38042_Dropping_CategoryCest.php
@@ -14,7 +14,7 @@ class Issue_38042_Dropping_CategoryCest {
 		$options = $I->getDefaultCoreOptions( [ 'tribeEventsTemplate' => '', 'viewOption' => 'month' ] );
 		$I->haveOptionInDatabase( 'tribe_events_calendar_options', $options );
 
-		// let's resize the window not to incure in mobile breakpoints
+		// let's resize the window not to incurr in mobile breakpoints
 		$I->resizeWindow( 1200, 1000 );
 
 		$I->amOnPage( "/events/category/{$this->an_existing_event_category}" );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/37494#note-20

While working on solving the ticket not above I've noticed many query filters are running taking the fact that the query is on the tribe_events post types for granted; this would block or interfere with accessory queries made on different post types (e.g. the query made for tickets while filtering the events list by tickets).

The alternative solution is to suppress_filters on all accessory queries: it works but it's not flexible and does not solve the problem.