### PR TITLE
Restore tribe_get_venue_website_url()  | 26901

### DIFF
--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -398,8 +398,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return string Formatted link to the venue website
 	 */
 	function tribe_get_venue_website_link( $post_id = null, $label = null ) {
-		$post_id = tribe_get_venue_id( $post_id );
-		$url     = tribe_get_event_meta( $post_id, '_VenueURL', true );
+		$url = tribe_get_venue_website_url( $post_id );
+
 		if ( ! empty( $url ) ) {
 			$label = is_null( $label ) ? $url : $label;
 			if ( ! empty( $url ) ) {
@@ -419,6 +419,22 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		return apply_filters( 'tribe_get_venue_website_link', $html );
+	}
+
+	/**
+	 * Returns the venue website URL related to the current post or for the optionally
+	 * specified post.
+	 *
+	 * @param int|null $post_id
+	 *
+	 * @return string
+	 */
+	function tribe_get_venue_website_url( $post_id = null ) {
+		return (string) tribe_get_event_meta(
+			tribe_get_venue_id( $post_id ),
+			'_VenueURL',
+			true
+		);
 	}
 
 	/**

--- a/tests/functional/functions/template-tags/Venue_Template_Tags_Test.php
+++ b/tests/functional/functions/template-tags/Venue_Template_Tags_Test.php
@@ -1,0 +1,121 @@
+<?php
+namespace Tribe\Events;
+
+use Tribe__Events__WP_UnitTestCase;
+
+class Venue_Template_Tags_Test extends Tribe__Events__WP_UnitTestCase {
+	protected $posts = [];
+	protected $venue_url = 'http://power.of.greyskull/by-the';
+
+	/**
+	 * Create a set of test events and venues.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$settings = $this->post_example_settings;
+		unset( $settings['EventHideFromUpcoming'] );
+
+		// Create a test venue with a URL
+		$this->posts['venue_with_url'] = tribe_create_venue( [
+			'Venue' => 'Castle Greyskull',
+			'URL'   => $this->venue_url
+		] );
+
+		// Create a test venue without a URL
+		$this->posts['venue_without_url'] = tribe_create_venue( [
+			'Venue' => 'Deathstar Loading Dock'
+		] );
+
+		// Create a venueless event
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$this->posts['no_venue'] = tribe_create_event( $settings );
+
+		// Create an event with a venue
+		$settings['EventVenueID'] = $this->posts['venue_with_url'];
+		$this->posts['has_venue'] = tribe_create_event( $settings );
+	}
+
+	/**
+	 * Remove our test events and venues.
+	 */
+	public function tearDown() {
+		foreach ( $this->posts as $test_post_id ) {
+			wp_delete_post( $test_post_id, true );
+		}
+	}
+
+	/**
+	 * Confirm that tribe_get_venue_website_url() retrieves the expected
+	 * results for events with and without venues and for venues with and
+	 * without URLs.
+	 */
+	public function test_get_venue_website_url() {
+		$venue_website_url = tribe_get_venue_website_url( $this->posts['no_venue'] );
+		$this->assertEmpty( $venue_website_url,
+			'Events without a venue should return an empty string'
+		);
+
+		$venue_website_url = tribe_get_venue_website_url( $this->posts['venue_without_url'] );
+		$this->assertEmpty( $venue_website_url,
+			'Venue without a URL should return an empty string'
+		);
+
+		$venue_website_url = tribe_get_venue_website_url( $this->posts['has_venue'] );
+		$this->assertEquals( $this->venue_url, $venue_website_url,
+			'An event with a venue (that has a URL) should return the venue URL'
+		);
+
+		$venue_website_url = tribe_get_venue_website_url( $this->posts['venue_with_url'] );
+		$this->assertEquals( $this->venue_url, $venue_website_url,
+			'Venue (that has a URL) should return that URL'
+		);
+	}
+
+	/**
+	 * Confirm that tribe_get_venue_website_link() retrieves the expected
+	 * results for events with and without venues and for venues with and
+	 * without URLs.
+	 */
+	public function test_get_venue_website_link() {
+		$venue_website_link = tribe_get_venue_website_link( $this->posts['no_venue'] );
+		$this->assertEmpty( $venue_website_link,
+			'Events without a venue should return an empty string'
+		);
+
+		$venue_website_link = tribe_get_venue_website_link( $this->posts['venue_without_url'] );
+		$this->assertEmpty( $venue_website_link,
+			'Venue without a URL should return an empty string'
+		);
+
+		$venue_website_link = tribe_get_venue_website_link( $this->posts['has_venue'] );
+		$this->assertTrue( $this->is_link_containing( $venue_website_link, $this->venue_url ),
+			'An event with a venue (that has a URL) should return the venue URL as an HTML link'
+		);
+
+		$venue_website_link = tribe_get_venue_website_link( $this->posts['venue_with_url'] );
+		$this->assertTrue( $this->is_link_containing( $venue_website_link, $this->venue_url ),
+			'Venue (that has a URL) should return that URL as an HTML link'
+		);
+	}
+
+	/**
+	 * Helper that tries to determine if the provided HTML fragment is an HTML
+	 * link containing the specified URL.
+	 *
+	 * @param string $html_fragment
+	 * @param string $url
+	 *
+	 * @return bool
+	 */
+	protected function is_link_containing( $html_fragment, $url ) {
+		$html_fragment = trim( $html_fragment );
+
+		// Check it opens and closes as expected and contains the URL
+		return (
+			0 === strpos( $html_fragment, '<a ' )
+			&& strpos( $html_fragment, '</a>' ) === strlen( $html_fragment ) - 4
+			&& 2 <= strpos( $html_fragment, $url )
+		);
+	}
+}


### PR DESCRIPTION
Restore work [done here](https://github.com/moderntribe/the-events-calendar/pull/517) (looks like it was overwritten when the last MR was merged in).

[C#26901](https://central.tri.be/issues/26901)