### PR TITLE
Restore short default filenames for iCal downloads | #39455

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -329,8 +329,19 @@ class Tribe__Events__iCal {
 			$events .= "BEGIN:VEVENT\r\n" . implode( "\r\n", $item ) . "\r\nEND:VEVENT\r\n";
 		}
 
+		$site = sanitize_title( get_bloginfo( 'name' ) );
+		$hash = substr( md5( implode( $event_ids ) ), 0, 11 );
+
+		/**
+		 * Modifies the filename provided in the Content-Disposition header for iCal feeds.
+		 *
+		 * @var string       $ical_feed_filename
+		 * @var WP_Post|null $post
+		 */
+		$filename = apply_filters( 'tribe_events_ical_feed_filename', $site . '-' . $hash . '.ics', $post );
+
 		header( 'Content-type: text/calendar; charset=UTF-8' );
-		header( 'Content-Disposition: attachment; filename="ical-event-' . implode( $event_ids ) . '.ics"' );
+		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 		$content = "BEGIN:VCALENDAR\r\n";
 		$content .= "VERSION:2.0\r\n";
 		$content .= 'PRODID:-//' . $blogName . ' - ECPv' . Tribe__Events__Main::VERSION . "//NONSGML v1.0//EN\r\n";


### PR DESCRIPTION
Changes for [C#39455](https://central.tri.be/issues/39455) | [C#38124](https://central.tri.be/issues/38124) (both relate to the default filename for ical feeds) were dropped during bad merges. This PR restores them.