### PR TITLE
rebuild known range when event goes over boundaries

### DIFF
--- a/src/Tribe/Dates/Known_Range.php
+++ b/src/Tribe/Dates/Known_Range.php
@@ -104,7 +104,6 @@ class Tribe__Events__Dates__Known_Range {
 
 			return;
 		}
-
 		$current_min = tribe_events_earliest_date();
 		$current_max = tribe_events_latest_date();
 
@@ -113,9 +112,11 @@ class Tribe__Events__Dates__Known_Range {
 
 
 		if ( $current_min > $event_start ) {
+			$this->rebuild_known_range();
 			tribe_update_option( 'earliest_date', $event_start );
 		}
 		if ( $current_max < $event_end ) {
+			$this->rebuild_known_range();
 			tribe_update_option( 'latest_date', $event_end );
 		}
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/33205

Rebuild the known date range anytime an event goes over boundaries