### PR TITLE
Display Organizer Name if Pro is not active

### DIFF
--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -188,6 +188,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				return apply_filters( 'tribe_get_organizer_link', $link, $postId, $full_link, $url );
 			}
 		}
+		//Return Organizer Name if Pro is not Active
+		return tribe_get_organizer( $org_id );
 	}
 
 	/**


### PR DESCRIPTION
_Ref:_ [C#44285](https://central.tri.be/issues/44285)

If there is no pro then we should call the original function and return the Organizer Name only 

I believe this will enable us to keep the changes made for this ticket:

https://central.tri.be/issues/29941