### PR TITLE
Restore safety check introduced in PR 520 | #42940

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -217,11 +217,13 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 							// if the eventDisplay is 'custom', all we're gonna do is make sure the start and end dates are formatted
 							$start_date = $query->get( 'start_date' );
 							if ( $start_date ) {
-								$query->set( 'start_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $start_date ) ) );
+								$start_date_string = $start_date instanceof DateTime ? $start_date->date : $start_date;
+								$query->set( 'start_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $start_date_string ) ) );
 							}
 							$end_date = $query->get( 'end_date' );
 							if ( $end_date ) {
-								$query->set( 'end_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $end_date ) ) );
+								$end_date_string = $end_date instanceof DateTime ? $end_date->date : $end_date;
+								$query->set( 'end_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $end_date_string ) ) );
 							}
 							break;
 						case 'month':


### PR DESCRIPTION
Restores a change that seems to have been accidentally dropped due to merging issues. Basically a repeat of [PR 520](https://github.com/moderntribe/the-events-calendar/pull/520/).

[C#42940](https://central.tri.be/issues/42940)