### PR TITLE
Update JSON-LD Address Output

### DIFF
--- a/src/Tribe/Google_Data_Markup/Event.php
+++ b/src/Tribe/Google_Data_Markup/Event.php
@@ -20,29 +20,29 @@ class Tribe__Events__Google_Data_Markup__Event extends Tribe__Events__Google_Dat
 		$event_data[ $id ]->startDate = get_gmt_from_date( tribe_get_start_date( $post, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), 'c' );
 		$event_data[ $id ]->endDate   = get_gmt_from_date( tribe_get_end_date( $post, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), 'c' );
 		if ( tribe_has_venue( $id ) ) {
-			$event_data[ $id ]->location          = new stdClass();
+			$event_data[ $id ]->location            = new stdClass();
 			$event_data[ $id ]->location->{'@type'} = 'Place';
-			$event_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
-			$event_data[ $id ]->location->address = new stdClass();
+			$event_data[ $id ]->location->name      = tribe_get_venue( $post->ID );
+			$event_data[ $id ]->location->address   = new stdClass();
 
 			if ( tribe_get_address( $post->ID ) ) {
-				$event_data[ $id ]->location->address->streetAddress    = tribe_get_address();
+				$event_data[ $id ]->location->address->streetAddress = tribe_get_address();
 			}
 
 			if ( tribe_get_city( $post->ID ) ) {
-				$event_data[ $id ]->location->address->addressLocality    = tribe_get_city();
+				$event_data[ $id ]->location->address->addressLocality = tribe_get_city();
 			}
 
 			if ( tribe_get_region( $post->ID ) ) {
-				$event_data[ $id ]->location->address->addressRegion    = tribe_get_region();
+				$event_data[ $id ]->location->address->addressRegion = tribe_get_region();
 			}
 
 			if ( tribe_get_zip( $post->ID ) ) {
-				$event_data[ $id ]->location->address->postalCode    = tribe_get_zip();
+				$event_data[ $id ]->location->address->postalCode = tribe_get_zip();
 			}
 
 			if ( tribe_get_country( $post->ID ) ) {
-				$event_data[ $id ]->location->address->addressCountry    = tribe_get_country();
+				$event_data[ $id ]->location->address->addressCountry = tribe_get_country();
 			}
 
 		}

--- a/src/Tribe/Google_Data_Markup/Event.php
+++ b/src/Tribe/Google_Data_Markup/Event.php
@@ -23,7 +23,27 @@ class Tribe__Events__Google_Data_Markup__Event extends Tribe__Events__Google_Dat
 			$event_data[ $id ]->location          = new stdClass();
 			$event_data[ $id ]->location->{'@type'} = 'Place';
 			$event_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
-			$event_data[ $id ]->location->address = strip_tags( str_replace( "\n", '', tribe_get_full_address( $post->ID ) ) );
+			
+			if ( tribe_get_address( $post->ID ) ) {
+				$event_data[ $id ]->location->address->streetAddress    = tribe_get_address();
+			}
+			
+			if ( tribe_get_city( $post->ID ) ) {
+				$event_data[ $id ]->location->address->addressLocality    = tribe_get_city();
+			}
+			
+			if ( tribe_get_region( $post->ID ) ) {
+				$event_data[ $id ]->location->address->addressRegion    = tribe_get_region();
+			}
+			
+			if ( tribe_get_zip( $post->ID ) ) {
+				$event_data[ $id ]->location->address->postalCode    = tribe_get_zip();
+			}
+			
+			if ( tribe_get_country( $post->ID ) ) {
+				$event_data[ $id ]->location->address->addressCountry    = tribe_get_country();
+			}
+			
 		}
 
 		return $event_data;

--- a/src/Tribe/Google_Data_Markup/Event.php
+++ b/src/Tribe/Google_Data_Markup/Event.php
@@ -23,27 +23,27 @@ class Tribe__Events__Google_Data_Markup__Event extends Tribe__Events__Google_Dat
 			$event_data[ $id ]->location          = new stdClass();
 			$event_data[ $id ]->location->{'@type'} = 'Place';
 			$event_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
-			
+
 			if ( tribe_get_address( $post->ID ) ) {
 				$event_data[ $id ]->location->address->streetAddress    = tribe_get_address();
 			}
-			
+
 			if ( tribe_get_city( $post->ID ) ) {
 				$event_data[ $id ]->location->address->addressLocality    = tribe_get_city();
 			}
-			
+
 			if ( tribe_get_region( $post->ID ) ) {
 				$event_data[ $id ]->location->address->addressRegion    = tribe_get_region();
 			}
-			
+
 			if ( tribe_get_zip( $post->ID ) ) {
 				$event_data[ $id ]->location->address->postalCode    = tribe_get_zip();
 			}
-			
+
 			if ( tribe_get_country( $post->ID ) ) {
 				$event_data[ $id ]->location->address->addressCountry    = tribe_get_country();
 			}
-			
+
 		}
 
 		return $event_data;

--- a/src/Tribe/Google_Data_Markup/Event.php
+++ b/src/Tribe/Google_Data_Markup/Event.php
@@ -23,6 +23,7 @@ class Tribe__Events__Google_Data_Markup__Event extends Tribe__Events__Google_Dat
 			$event_data[ $id ]->location          = new stdClass();
 			$event_data[ $id ]->location->{'@type'} = 'Place';
 			$event_data[ $id ]->location->name    = tribe_get_venue( $post->ID );
+			$event_data[ $id ]->location->address = new stdClass();
 
 			if ( tribe_get_address( $post->ID ) ) {
 				$event_data[ $id ]->location->address->streetAddress    = tribe_get_address();


### PR DESCRIPTION
tribe_get_full_address provides inconsistent data for the markup, especially if the output have been modified by themes. (Since the `tribe_get_full_address` tag is built using the `modules/address` template.) This change guarantees consistent JSON-LD location output.

[C#44700](https://central.tri.be/issues/44700)