### PR TITLE
Fix description wrap in month mobile and tooltip

### DIFF
--- a/src/views/month/mobile.php
+++ b/src/views/month/mobile.php
@@ -32,7 +32,7 @@
 			</div>
 			[[ } ]]
 			[[ if(excerpt.length) { ]]
-			<p class="tribe-event-description">[[=raw excerpt]]</p>
+			<div class="tribe-event-description"> [[=raw excerpt]] </div>
 			[[ } ]]
 			<a href="[[=permalink]]" class="tribe-events-read-more" rel="bookmark">[[=i18n.find_out_more]]</a>
 		</div>

--- a/src/views/month/tooltip.php
+++ b/src/views/month/tooltip.php
@@ -22,7 +22,7 @@
 			</div>
 			[[ } ]]
 			[[ if(excerpt.length) { ]]
-			<p class="tribe-event-description">[[=raw excerpt]]</p>
+			<div class="tribe-event-description">[[=raw excerpt]]</div>
 			[[ } ]]
 			<span class="tribe-events-arrow"></span>
 		</div>


### PR DESCRIPTION
_Ref:_ [C#42701](https://central.tri.be/issues/42701)

The excerpt comes with p tags and our wrap was p tags so it would close our wrap , changed to a div to prevent this. 