### PR TITLE
Fix handling of datetime objects passed in custom event queries | #44736

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -216,13 +216,22 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 						case 'custom':
 							// if the eventDisplay is 'custom', all we're gonna do is make sure the start and end dates are formatted
 							$start_date = $query->get( 'start_date' );
+
 							if ( $start_date ) {
-								$start_date_string = $start_date instanceof DateTime ? $start_date->date : $start_date;
+								$start_date_string = $start_date instanceof DateTime
+									? $start_date->format( Tribe__Date_Utils::DBDATETIMEFORMAT )
+									: $start_date;
+
 								$query->set( 'start_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $start_date_string ) ) );
 							}
+
 							$end_date = $query->get( 'end_date' );
+
 							if ( $end_date ) {
-								$end_date_string = $end_date instanceof DateTime ? $end_date->date : $end_date;
+								$end_date_string = $end_date instanceof DateTime
+									? $end_date->format( Tribe__Date_Utils::DBDATETIMEFORMAT )
+									: $end_date;
+
 								$query->set( 'end_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, strtotime( $end_date_string ) ) );
 							}
 							break;


### PR DESCRIPTION
Resolves a problem introduced in [PR 520](https://github.com/moderntribe/the-events-calendar/pull/520) which saw us trying to access the `date` property of `DateTime` objects, which isn't actually a real thing.

[C#44736](https://central.tri.be/issues/44736)