### PR TITLE
Support costs that begin with a decimal

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -72,8 +72,9 @@ class Tribe__Events__Cost_Utils {
 	}
 
 	public function get_cost_regex() {
+		$separators = '[\\' . implode( '\\', $this->get_separators() ) . ']?';
 		return apply_filters( 'tribe_events_cost_regex',
-			'(([\d]+)[\\' . implode( '\\', $this->get_separators() ) . ']?([\d]*))' );
+			'(' . $separators . '([\d]+)' . $separators . '([\d]*))' );
 	}
 
 	/**


### PR DESCRIPTION
This modifies the regex to allow for the cost separators to _begin_ the cost regex in addition to appearing in the middle. This _may_ cause issues with costs entered as `0.0.0`, but I'm willing to deal with that problem later if a user raises it in the interest of keeping the regex simpler.

_Note: This passes our functional tests for cost ranges_

See: https://central.tri.be/issues/44711