### PR TITLE
If there is no default country, return an empty string | #44829

### DIFF
--- a/src/Tribe/Default_Values.php
+++ b/src/Tribe/Default_Values.php
@@ -47,7 +47,7 @@ class Tribe__Events__Default_Values {
 	}
 
 	public function country() {
-		return array( '', '' );
+		return '';
 	}
 
 	public function phone() {


### PR DESCRIPTION
In the absence of a default country, let's return an empty string.

[C#44829](https://central.tri.be/issues/44829)