### PR TITLE
If $_VenueVenue holds the default value of 0, don't fill the input value

### DIFF
--- a/src/Tribe/Default_Values.php
+++ b/src/Tribe/Default_Values.php
@@ -15,7 +15,7 @@ class Tribe__Events__Default_Values {
 	}
 
 	public function venue_id() {
-		return 0;
+		return null;
 	}
 
 	public function organizer() {

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tr class="venue">
 		<td class='tribe-table-field-label'><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), tribe_get_venue_label_singular() ); ?></td>
 		<td>
-			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='venue[Venue]' size='25' value='<?php if ( isset( $_VenueVenue ) ) {
+			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='venue[Venue]' size='25' value='<?php if ( ! empty( $_VenueVenue ) ) {
 				echo esc_attr( $_VenueVenue );
 			} ?>' />
 		</td>


### PR DESCRIPTION
The `Tribe__Events__Default_Values` class returned a default ID of 0 if there was no default venue specified. Let's do two things:

1. Let's avoid placing non-truthy values in the field.
1. Let's not return 0 as a default venue ID - null is more appropriate if there isn't a venue

See: https://central.tri.be/issues/44826