### PR TITLE
Bring back the default country array

### DIFF
--- a/src/Tribe/Default_Values.php
+++ b/src/Tribe/Default_Values.php
@@ -47,7 +47,7 @@ class Tribe__Events__Default_Values {
 	}
 
 	public function country() {
-		return '';
+		return array( '', '' );
 	}
 
 	public function phone() {

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -120,7 +120,14 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 */
 	function tribe_get_country( $postId = null ) {
 		$postId = tribe_get_venue_id( $postId );
-		$output = esc_html( tribe_get_event_meta( $postId, '_VenueCountry', true ) );
+		$venue_country = tribe_get_event_meta( $postId, '_VenueCountry', true );
+
+		// _VenueCountry should hold an array of [ 'country_id', 'country_name' ]. Let's get the country
+		// name from that array and output that
+		if ( is_array( $venue_country ) ) {
+			$venue_country = array_pop( $venue_country );
+		}
+		$output = esc_html( $venue_country );
 
 		return apply_filters( 'tribe_get_country', $output );
 	}


### PR DESCRIPTION
This was removed in #609, however, it is relied on by Pro. The exected data stored for countries is the country id (i.e. US) and the country name (i.e. United States). When the default country is blank, let's provide the expected array.

Then, in `tribe_get_event_country()`, make sure we handle the array and return the country _name_.

See: https://central.tri.be/issues/44929