### PR TITLE
Don't quote TZID in DTSTART/END

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Fix - Resolved issue where the Month View in mobile sizes retained the long day-of-week names when the abbreviations should have been used
 * Fix - Fixed bug where a "0" was added to the default Venue name when creating a new event
 * Fix - Fixed notice that caused Ajax requests to fail (props to cgrymala on WP.org for reporting this!)
+* Fix - Removed quotes from around TZID-specified timezones in iCal feeds which causes problems with some parsers
 * Fix - Resolved various capitalization issues with German translations
 
 = [4.1.0.1] 2016-03-17 =

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -264,8 +264,8 @@ class Tribe__Events__iCal {
 					? Tribe__Events__Timezones::get_event_timezone_string( $event_post->ID )
 					: Tribe__Events__Timezones::wp_timezone_string();
 
-				$item[] = 'DTSTART;TZID="'.$tz.'":' . $tzoned->start;
-				$item[] = 'DTEND;TZID="'.$tz.'":' . $tzoned->end;
+				$item[] = 'DTSTART;TZID=' . $tz . ':' . $tzoned->start;
+				$item[] = 'DTEND;TZID=' . $tz . ':' . $tzoned->end;
 			}
 
 			$item[] = 'DTSTAMP:' . date( $full_format, time() );


### PR DESCRIPTION
The iCal spec doesn't call for it and it breaks some parsers (including the one we use in our iCal importer)

See: https://central.tri.be/issues/42795