### PR TITLE
Strip leading/trailing whitespace from prospective image URLs (spotfix)

### DIFF
--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -206,6 +206,14 @@ abstract class Tribe__Events__Importer__File_Importer {
 	 * @return Tribe__Events__Importer__Featured_Image_Uploader
 	 */
 	protected function featured_image_uploader( $featured_image ) {
-		return empty( $this->featured_image_uploader ) ? new Tribe__Events__Importer__Featured_Image_Uploader( $featured_image ) : $this->featured_image_uploader;
+		// Remove any leading/trailing whitespace (if the string is a URL, extra whitespace
+		// could result in URL validation fail)
+		if ( is_string( $featured_image ) ) {
+			$featured_image = trim( $featured_image );
+		}
+
+		return empty( $this->featured_image_uploader )
+			? new Tribe__Events__Importer__Featured_Image_Uploader( $featured_image )
+			: $this->featured_image_uploader;
 	}
 }


### PR DESCRIPTION
Helps to avoid image URLs being rejected where they contain leading or trailing whitespace - [example in team chat](https://tribe.slack.com/archives/products-dev/p1458925376001083).