### PR TITLE
Fixed PHP Notice: "Undefined index: SERVER_NAME" upon every WP-CLI command

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -397,7 +397,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 
 				// For multisite, return the network-level siteurl ... in
 				// all other cases return the actual URL being serviced
-				$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : (defined('WP_SITEURL') ? parse_url(WP_SITEURL)['host'] : $_SERVER['SERVER_NAME']);
+				$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : ( defined( 'WP_SITEURL' ) ? parse_url( WP_SITEURL )['host'] : $_SERVER['SERVER_NAME'] );
 
 				if ( is_multisite() ) {
 					$queryArgs['multisite']         = 1;
@@ -514,7 +514,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 			$queryArgs['wp_version'] = $wp_version;
 
 			//include domain and multisite stats
-			$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : (defined('WP_SITEURL') ? parse_url(WP_SITEURL)['host'] : $_SERVER['SERVER_NAME']);
+			$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : ( defined( 'WP_SITEURL' ) ? parse_url( WP_SITEURL )['host'] : $_SERVER['SERVER_NAME'] );
 
 			if ( is_multisite() ) {
 				$queryArgs['multisite']         = 1;

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -397,7 +397,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 
 				// For multisite, return the network-level siteurl ... in
 				// all other cases return the actual URL being serviced
-				$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : $_SERVER['SERVER_NAME'];
+				$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : (defined('WP_SITEURL') ? parse_url(WP_SITEURL)['host'] : $_SERVER['SERVER_NAME']);
 
 				if ( is_multisite() ) {
 					$queryArgs['multisite']         = 1;
@@ -514,7 +514,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 			$queryArgs['wp_version'] = $wp_version;
 
 			//include domain and multisite stats
-			$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : $_SERVER['SERVER_NAME'];
+			$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : (defined('WP_SITEURL') ? parse_url(WP_SITEURL)['host'] : $_SERVER['SERVER_NAME']);
 
 			if ( is_multisite() ) {
 				$queryArgs['multisite']         = 1;

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -133,6 +133,25 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 		}
 
 		/**
+		 * Returns the domain name of this site.
+		 *
+		 * @return string
+		 */
+		private function get_domain() {
+			if ( is_multisite() ) {
+				$url = get_site_option( 'siteurl' );
+			} else {
+				$url = get_site_url();
+			}
+			$parts = parse_url( $url );
+			if ( isset( $parts['host'] ) ) {
+				return $parts['host'];
+			} elseif ( isset( $_SERVER['SERVER_NAME'] ) ) {
+				return $_SERVER['SERVER_NAME'];
+			}
+		}
+
+		/**
 		 * Get the plugin file path
 		 *
 		 * @return string
@@ -395,9 +414,8 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 				global $wp_version;
 				$queryArgs['wp_version'] = $wp_version;
 
-				// For multisite, return the network-level siteurl ... in
-				// all other cases return the actual URL being serviced
-				$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : ( defined( 'WP_SITEURL' ) ? parse_url( WP_SITEURL )['host'] : $_SERVER['SERVER_NAME'] );
+				//include domain and multisite stats
+				$queryArgs['domain'] = $this->get_domain();
 
 				if ( is_multisite() ) {
 					$queryArgs['multisite']         = 1;
@@ -514,7 +532,7 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 			$queryArgs['wp_version'] = $wp_version;
 
 			//include domain and multisite stats
-			$queryArgs['domain'] = is_multisite() ? $this->get_network_domain() : ( defined( 'WP_SITEURL' ) ? parse_url( WP_SITEURL )['host'] : $_SERVER['SERVER_NAME'] );
+			$queryArgs['domain'] = $this->get_domain();
 
 			if ( is_multisite() ) {
 				$queryArgs['multisite']         = 1;
@@ -566,20 +584,6 @@ if ( ! class_exists( 'Tribe__Events__PUE__Checker' ) ) {
 			$plugin_info_cache[ $key ] = $pluginInfo;
 
 			return $pluginInfo;
-		}
-
-		/**
-		 * Returns the domain contained in the network's siteurl option (not the full URL).
-		 *
-		 * @return string
-		 */
-		public function get_network_domain() {
-			$site_url = parse_url( get_site_option( 'siteurl' ) );
-			if ( ! $site_url || ! isset( $site_url['host'] ) ) {
-				return '';
-			} else {
-				return strtolower( $site_url['host'] );
-			}
 		}
 
 		/**


### PR DESCRIPTION
Problem

* The following PHP Notices are triggered when WordPress is bootstrapped via WP-CLI on the command line:

```sh
$ wp plugin list
PHP Notice:  Undefined index: SERVER_NAME in wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php on line 517
PHP Stack trace:
PHP   1. {main}() bin\wp:0
PHP   2. include() bin\wp:4
PHP   3. include() phar://bin/wp/php/boot-phar.php:5
PHP   4. WP_CLI\Runner->start() phar://bin/wp/php/wp-cli.php:21
PHP   5. WP_CLI\Runner->_run_command() phar://bin/wp/php/WP_CLI/Runner.php:723
PHP   6. WP_CLI\Runner->run_command() phar://bin/wp/php/WP_CLI/Runner.php:320
PHP   7. WP_CLI\Dispatcher\Subcommand->invoke() phar://bin/wp/php/WP_CLI/Runner.php:313
PHP   8. call_user_func:{phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294}() phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294
PHP   9. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}() phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294
PHP  10. call_user_func:{phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52}() phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52
PHP  11. Plugin_Command->list_() phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52
PHP  12. WP_CLI\CommandWithUpgrade->_list() phar://bin/wp/php/commands/plugin.php:623
PHP  13. call_user_func:{phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295}() phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295
PHP  14. wp_update_plugins() phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295
PHP  15. set_site_transient() wp-includes\update.php:262
PHP  16. apply_filters() wp-includes\option.php:1621
PHP  17. call_user_func_array:{wp-includes\plugin.php:235}() wp-includes\plugin.php:235
PHP  18. Tribe__Events__PUE__Checker->check_for_updates() wp-includes\plugin.php:235
PHP  19. Tribe__Events__PUE__Checker->request_update() wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php:723
PHP  20. Tribe__Events__PUE__Checker->request_info() wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php:595

PHP Notice:  Undefined index: SERVER_NAME in wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php on line 517
PHP Stack trace:
PHP   1. {main}() bin\wp:0
PHP   2. include() bin\wp:4
PHP   3. include() phar://bin/wp/php/boot-phar.php:5
PHP   4. WP_CLI\Runner->start() phar://bin/wp/php/wp-cli.php:21
PHP   5. WP_CLI\Runner->_run_command() phar://bin/wp/php/WP_CLI/Runner.php:723
PHP   6. WP_CLI\Runner->run_command() phar://bin/wp/php/WP_CLI/Runner.php:320
PHP   7. WP_CLI\Dispatcher\Subcommand->invoke() phar://bin/wp/php/WP_CLI/Runner.php:313
PHP   8. call_user_func:{phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294}() phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294
PHP   9. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}() phar://bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:294
PHP  10. call_user_func:{phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52}() phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52
PHP  11. Plugin_Command->list_() phar://bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:52
PHP  12. WP_CLI\CommandWithUpgrade->_list() phar://bin/wp/php/commands/plugin.php:623
PHP  13. call_user_func:{phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295}() phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295
PHP  14. wp_update_plugins() phar://bin/wp/php/WP_CLI/CommandWithUpgrade.php:295
PHP  15. set_site_transient() wp-includes\update.php:332
PHP  16. apply_filters() wp-includes\option.php:1621
PHP  17. call_user_func_array:{wp-includes\plugin.php:235}() wp-includes\plugin.php:235
PHP  18. Tribe__Events__PUE__Checker->check_for_updates() wp-includes\plugin.php:235
PHP  19. Tribe__Events__PUE__Checker->request_update() wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php:723
PHP  20. Tribe__Events__PUE__Checker->request_info() wp-content\plugins\the-events-calendar\src\Tribe\PUE\Checker.php:595

+------------------------------+----------+-----------+---------+
| name                         | status   | update    | version |
+------------------------------+----------+-----------+---------+
...
| the-events-calendar          | active   | available | 4.x.x   |
+------------------------------+----------+-----------+---------+
```

Details

* That's not unusual, but all other usages of `$_SERVER['SERVER_NAME']` in WordPress Core & plugins can be muted/satisfied by setting the `WP_SITEURL` constant in `wp-config.php`.

Proposed solution

1. Check for a possibly set `WP_SITEURL` constant (URL) before trying to use `$_SERVER['SERVER_NAME']`.
