### PR TITLE
Allow imports to save mappings for each different type

### DIFF
--- a/src/Tribe/Importer/Admin_Page.php
+++ b/src/Tribe/Importer/Admin_Page.php
@@ -317,7 +317,7 @@ class Tribe__Events__Importer__Admin_Page {
 			return false;
 		}
 
-		update_option( 'tribe_events_import_column_mapping', $column_mapping );
+		update_option( 'tribe_events_import_column_mapping_' . $importer->get_type(), $column_mapping );
 		return true;
 	}
 
@@ -361,7 +361,7 @@ class Tribe__Events__Importer__Admin_Page {
 		$type = get_option( 'tribe_events_import_type' );
 		$file_reader = new Tribe__Events__Importer__File_Reader( Tribe__Events__Importer__File_Uploader::get_file_path() );
 		$importer = Tribe__Events__Importer__File_Importer::get_importer( $type, $file_reader );
-		$importer->set_map( get_option( 'tribe_events_import_column_mapping', array() ) );
+		$importer->set_map( get_option( 'tribe_events_import_column_mapping_' . $type, array() ) );
 		$importer->set_type( get_option( 'tribe_events_import_type' ) );
 		$importer->set_limit( absint( apply_filters( 'tribe_events_csv_batch_size', 100 ) ) );
 		$importer->set_offset( get_option( 'tribe_events_importer_has_header', 0 ) );

--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -109,6 +109,10 @@ abstract class Tribe__Events__Importer__File_Importer {
 		return $this->required_fields;
 	}
 
+	public function get_type() {
+		return $this->type;
+	}
+
 	public function import_next_row( $throw = false ) {
 		$record = $this->reader->read_next_row();
 		$row    = $this->reader->get_last_line_number_read() + 1;

--- a/src/io/csv/admin-views/columns.php
+++ b/src/io/csv/admin-views/columns.php
@@ -14,7 +14,6 @@ if ( isset( $_POST['column_map'] ) ) {
 	$mapper->set_defaults( $_POST['column_map'] );
 } else {
 	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping_' . $import_type , array() ) );
-	//$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping', array() ) );
 }
 
 require_once 'header.php';

--- a/src/io/csv/admin-views/columns.php
+++ b/src/io/csv/admin-views/columns.php
@@ -13,7 +13,7 @@ $mapper = new Tribe__Events__Importer__Column_Mapper( $import_type );
 if ( isset( $_POST['column_map'] ) ) {
 	$mapper->set_defaults( $_POST['column_map'] );
 } else {
-	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping_' . $import_type , array() ) );
+	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping_' . $import_type, array() ) );
 }
 
 require_once 'header.php';

--- a/src/io/csv/admin-views/columns.php
+++ b/src/io/csv/admin-views/columns.php
@@ -13,7 +13,8 @@ $mapper = new Tribe__Events__Importer__Column_Mapper( $import_type );
 if ( isset( $_POST['column_map'] ) ) {
 	$mapper->set_defaults( $_POST['column_map'] );
 } else {
-	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping', array() ) );
+	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping_' . $import_type , array() ) );
+	//$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping', array() ) );
 }
 
 require_once 'header.php';


### PR DESCRIPTION
I was testing out some stuff and got tired of resetting these mappings each time I changed an import type.  This changes the option name to include the type, so you can switch between venue, event, and organizer without having to reset field mappings.

Also adds Tribe__Events__Importer__File_Importer::get_type() which might be useful for something.