### PR TITLE
Fix/41383 month order sticky

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -45,6 +45,10 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$can_inject = false;
 			}
 
+			if (isset($query->query_vars['eventDoNotInjectDate']) && $query->query_vars['eventDoNotInjectDate']){
+				$can_inject= false;
+			}
+
 			return apply_filters( 'tribe_query_can_inject_date_field', $can_inject );
 		}
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -45,8 +45,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$can_inject = false;
 			}
 
-			if (isset($query->query_vars['eventDoNotInjectDate']) && $query->query_vars['eventDoNotInjectDate']){
-				$can_inject= false;
+			if ( isset( $query->query_vars['do_not_inject_date'] ) && $query->query_vars['do_not_inject_date'] ) {
+				$can_inject = false;
 			}
 
 			return apply_filters( 'tribe_query_can_inject_date_field', $can_inject );

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -619,7 +619,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
-					'eventDoNotInjectDate'   => true,
+					'do_not_inject_date'     => true,
 					'meta_key'               => '_EventStartDate',
 					'orderby'                => array(
 						'menu_order'          => 'ASC',

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -619,8 +619,12 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
+					'eventDoNotInjectDate'   => true,
 					'meta_key'               => '_EventStartDate',
-					'orderby'                => 'meta_value_date',
+					'orderby'                => array(
+						'menu_order'          => 'ASC',
+						'meta_value_datetime' => 'ASC',
+					),
 				), $this->args
 			);
 


### PR DESCRIPTION
This is a re-opening of the Pull Request from @lucatume (#615) against the `develop` branch rather than `release/4.1.1` - which has been deleted.

> I had the default ordering switched from menu_order to date in the Month view but not taking menu_order into account will break sticky events.
This fix will sort events by menu_order and then date in the Month view.
Please keep in mind that the database used in the ticket has events with menu_order values all over the place (see http://glui.me/?i=nnlskdxlexoa8j7/2016-03-16_at_12.21.png/) and this code modification will restore the issue the user has in this particular instance.

> I'm not aware of any of our plugins setting the menu order to anything else but 0 or -1 but I might simply ignore the fact. If it's like that then the issue might be a third party plugin modifying the menu order.

> What should we do?

Ticket: https://central.tri.be/issues/44863