### PR TITLE
Allow imports to save mappings for each different type

### DIFF
--- a/src/Tribe/Importer/Admin_Page.php
+++ b/src/Tribe/Importer/Admin_Page.php
@@ -317,7 +317,7 @@ class Tribe__Events__Importer__Admin_Page {
 			return false;
 		}
 
-		update_option( 'tribe_events_import_column_mapping', $column_mapping );
+		update_option( 'tribe_events_import_column_mapping_' . $importer->get_type(), $column_mapping );
 		return true;
 	}
 
@@ -361,7 +361,7 @@ class Tribe__Events__Importer__Admin_Page {
 		$type = get_option( 'tribe_events_import_type' );
 		$file_reader = new Tribe__Events__Importer__File_Reader( Tribe__Events__Importer__File_Uploader::get_file_path() );
 		$importer = Tribe__Events__Importer__File_Importer::get_importer( $type, $file_reader );
-		$importer->set_map( get_option( 'tribe_events_import_column_mapping', array() ) );
+		$importer->set_map( get_option( 'tribe_events_import_column_mapping_' . $type, array() ) );
 		$importer->set_type( get_option( 'tribe_events_import_type' ) );
 		$importer->set_limit( absint( apply_filters( 'tribe_events_csv_batch_size', 100 ) ) );
 		$importer->set_offset( get_option( 'tribe_events_importer_has_header', 0 ) );

--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -109,6 +109,10 @@ abstract class Tribe__Events__Importer__File_Importer {
 		return $this->required_fields;
 	}
 
+	public function get_type() {
+		return $this->type;
+	}
+
 	public function import_next_row( $throw = false ) {
 		$record = $this->reader->read_next_row();
 		$row    = $this->reader->get_last_line_number_read() + 1;

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -82,6 +82,7 @@ class Tribe__Events__Updater {
 			'2.0.6'  => array( $this, 'migrate_from_sp_options' ),
 			'3.10a4' => array( $this, 'set_enabled_views' ),
 			'3.10a5' => array( $this, 'remove_30_min_eod_cutoffs' ),
+			'4.1.1'  => array( $this, 'migrate_import_option' ),
 		);
 	}
 
@@ -247,5 +248,20 @@ class Tribe__Events__Updater {
 			$eod_cutoff->modify( '+30 minutes' );
 			tribe_update_option( 'multiDayCutoff', $eod_cutoff->format( 'h:i' ) );
 		}
+	}
+
+	/**
+	 * Migrate the previous import mapping to the new naming and cleanup
+	 * the old.
+	 */
+	public function migrate_import_option() {
+		$legacy_option = get_option( 'tribe_events_import_column_mapping' );
+		$type = get_option( 'tribe_events_import_type' );
+		if ( empty( $legacy_option ) || empty( $type ) ) {
+			return;
+		}
+
+		update_option( 'tribe_events_import_column_mapping_' . $type, $legacy_option );
+		delete_option( 'tribe_events_import_column_mapping' );
 	}
 }

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -82,7 +82,7 @@ class Tribe__Events__Updater {
 			'2.0.6'  => array( $this, 'migrate_from_sp_options' ),
 			'3.10a4' => array( $this, 'set_enabled_views' ),
 			'3.10a5' => array( $this, 'remove_30_min_eod_cutoffs' ),
-			'4.1.1'  => array( $this, 'migrate_import_option' ),
+			'4.2'  => array( $this, 'migrate_import_option' ),
 		);
 	}
 

--- a/src/io/csv/admin-views/columns.php
+++ b/src/io/csv/admin-views/columns.php
@@ -13,7 +13,7 @@ $mapper = new Tribe__Events__Importer__Column_Mapper( $import_type );
 if ( isset( $_POST['column_map'] ) ) {
 	$mapper->set_defaults( $_POST['column_map'] );
 } else {
-	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping', array() ) );
+	$mapper->set_defaults( get_option( 'tribe_events_import_column_mapping_' . $import_type, array() ) );
 }
 
 require_once 'header.php';


### PR DESCRIPTION
I was testing out some stuff and got tired of resetting these mappings each time I changed an import type. This changes the option name to include the type, so you can switch between venue, event, and
organizer without having to reset field mappings.

Also adds Tribe__Events__Importer__File_Importer::get_type() which might be useful for something.

Related to #634