### PR TITLE
Removing unneeded hook

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,6 +312,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 = [4.1.2] TBD =
 
 * Security - Only allow the tribe bar to redirect to approved domain names (props to Paul Mynarsky for reporting this issue) [45473]
+* Tweak - Removed unneeded hook that attempted to add a query argument to event tag links that has been present on those links since at least WP 3.9 [45431]
 * Fix - Resolved issue where events marked as "sticky" would not display as such in Month View [44863]
 
 = [4.1.1] 2016-03-30 =

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -514,7 +514,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			add_action( 'load-tribe_events_page_' . Tribe__Settings::$parent_slug, array( 'Tribe__Events__Amalgamator', 'listen_for_migration_button' ), 10, 0 );
 			add_action( 'tribe_settings_after_save', array( $this, 'flushRewriteRules' ) );
-			add_action( 'load-edit-tags.php', array( $this, 'prepare_to_fix_tagcloud_links' ), 10, 0 );
+
 			add_action( 'update_option_' . Tribe__Main::OPTIONNAME, array( $this, 'fix_all_day_events' ), 10, 2 );
 
 			// Check for a page that might conflict with events archive (but we only need to do that
@@ -4334,8 +4334,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * When the edit-tags.php screen loads, setup filters
 		 * to fix the tagcloud links
 		 *
+		 * @deprecated 4.1.2
 		 */
 		public function prepare_to_fix_tagcloud_links() {
+			_deprecated_function( __METHOD__, '4.1.2' );
 			if ( Tribe__Admin__Helpers::instance()->is_post_type_screen( self::POSTTYPE ) ) {
 				add_filter( 'get_edit_term_link', array( $this, 'add_post_type_to_edit_term_link' ), 10, 4 );
 			}
@@ -4347,6 +4349,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * in Events post type context, make sure we add that
 		 * arg to the edit tag link
 		 *
+		 * @deprecated 4.1.2
+		 *
 		 * @param string $link
 		 * @param int    $term_id
 		 * @param string $taxonomy
@@ -4355,6 +4359,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @return string
 		 */
 		public function add_post_type_to_edit_term_link( $link, $term_id, $taxonomy, $context ) {
+			_deprecated_function( __METHOD__, '4.1.2' );
 			if ( $taxonomy == 'post_tag' && empty( $context ) ) {
 				$link = add_query_arg( array( 'post_type' => self::POSTTYPE ), $link );
 			}


### PR DESCRIPTION
While looking into the WP 4.5 breaking changes surrounding admin pages for tags, I discovered that our one hook to `load-edit-tags.php` didn't do anything of note.

The associated functions attempt to add a `post_type` argument to the term cloud links on the `edit-tags.php` page for our Event post type. I commented out the hook and then rolled back my WP through the 4.x versions and all the way back to 3.9 - the earliest that we claim to support - and the `post_type` argument was still present.

As such...let's deprecate the two functions and get rid of the hook rather than keeping useless code around.

See: https://central.tri.be/issues/45431