### PR TITLE
Fix Importer due to change in WordPress 4.5

### DIFF
--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -178,14 +178,15 @@ abstract class Tribe__Events__Importer__File_Importer {
 			return 0;
 		}
 		$query_args = array(
-			'post_type'   => $post_type,
-			'post_status' => 'publish',
-			'post_title'  => $name,
-			'fields'      => 'ids',
+			'post_type'        => $post_type,
+			'post_status'      => 'publish',
+			'post_title'       => $name,
+			'fields'           => 'ids',
+			'suppress_filters' => false,
 		);
 		add_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10, 2 );
 		$ids = get_posts( $query_args );
-		remove_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10, 2 );
+		remove_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10 );
 
 		return empty( $ids ) ? 0 : reset( $ids );
 	}

--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -14,10 +14,11 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 		// Base query - only the meta query will be different
 		$query_args = array(
-			'post_type'      => Tribe__Events__Main::POSTTYPE,
-			'post_title'     => $this->get_value_by_key( $record, 'event_name' ),
-			'fields'         => 'ids',
-			'posts_per_page' => 1,
+			'post_type'        => Tribe__Events__Main::POSTTYPE,
+			'post_title'       => $this->get_value_by_key( $record, 'event_name' ),
+			'fields'           => 'ids',
+			'posts_per_page'   => 1,
+			'suppress_filters' => false,
 		);
 
 		// When trying to find matches for all day events, the comparison should only be against the date
@@ -57,7 +58,7 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 		add_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10, 2 );
 		$matches = get_posts( $query_args );
-		remove_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10, 2 );
+		remove_filter( 'posts_search', array( $this, 'filter_query_for_title_search' ), 10 );
 
 		if ( empty( $matches ) ) {
 			return 0;


### PR DESCRIPTION
_Ref:_ [C#46286](https://central.tri.be/issues/46286)

In WordPress 4.5 they wrapped the post_search filter in a conditional for not having a suppress_filters aregument:

https://github.com/WordPress/WordPress/commit/e6d2b6cab0702a480efc7de0c63467a858f32f8b#diff-8e20e94124dba46643814ef699330737

I believe the change I made by adding suppress_filters=false to the query should not cause earlier versions of WordPress to not have problems. 

I did this in both places we use the post_search filter