### PR TITLE
Fix the order in Month View

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,8 +310,8 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 == Changelog ==
 
 = [4.1.3] 2016-04-27 =
-* Fix - Month View single days are now ordered as follows, sticky events, all day events, then events by start time [46113]
-* Fix - Fix compatiblitiy of CSV importer with WordPress 4.5 due to a change in the post_status filter [46286]
+* Fix - Month view single days are now ordered as follows, sticky events, ongoing multi day events, all day events, then by start time [46113]
+* Fix - Fix compatibility of CSV importer with WordPress 4.5 due to a change in the post_status filter [46286]
 * Tweak - Add new event names for AJAX success to the List, Month, and Day views to help compatibility with our premium plugins [45081]
 
 = [4.1.2] 2016-04-11 =

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 == Changelog ==
 
 = [4.1.3] 2016-04-27 =
+* Fix - Month View single days are now ordered as follows, sticky events, all day events, then events by start time [46113]
 * Fix - Fix compatiblitiy of CSV importer with WordPress 4.5 due to a change in the post_status filter [46286]
 * Tweak - Add new event names for AJAX success to the List, Month, and Day views to help compatibility with our premium plugins [45081]
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -609,7 +609,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			// this  will skip updating term and meta caches - those were already
 			// updated in $this->set_events_in_month()
-			//Order of Events Sticky Events, All Day Events, then Events by start time
+			// expected order of events: sticky events, ongoing multi day events, all day events, then by start time
 			$args   = wp_parse_args(
 				array(
 					'eventDisplay'           => 'month',

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -609,6 +609,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			// this  will skip updating term and meta caches - those were already
 			// updated in $this->set_events_in_month()
+			//Order of Events Sticky Events, All Day Events, then Events by start time
 			$args   = wp_parse_args(
 				array(
 					'eventDisplay'           => 'month',
@@ -622,8 +623,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'do_not_inject_date'     => true,
 					'meta_key'               => '_EventStartDate',
 					'orderby'                => array(
-						'menu_order'          => 'ASC',
-						'meta_value_datetime' => 'ASC',
+						'menu_order' => 'ASC',
+						'meta_value' => 'ASC',
 					),
 				), $this->args
 			);


### PR DESCRIPTION
_Ref:_ [C#46113](https://central.tri.be/issues/46113)

Change so Month View single days events are in this order Sticky Events, then All Day Events, then Events by Start Time.

meta_value_datetime was not ordering the dates correctly, not sure why, but the meta_value worked in my tests