### PR TITLE
Make constructor public (class isn't using the singleton pattern) | spotfix

### DIFF
--- a/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
+++ b/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
@@ -31,7 +31,7 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 	 */
 	protected $singular_name;
 
-	protected function __construct( $event = null, $post_type = null ) {
+	public function __construct( $event = null, $post_type = null ) {
 		$this->tribe        = Tribe__Events__Main::instance();
 		$this->linked_posts = Tribe__Events__Linked_Posts::instance();
 		$this->post_type = $post_type;


### PR DESCRIPTION
Looks like the constructor was set to protected - but this class isn't using the singleton pattern so we need to undo that.

(Spotfix)