### PR TITLE
Add a filter for customizing the Organizer import fields | #46476

### DIFF
--- a/src/Tribe/Importer/File_Importer_Organizers.php
+++ b/src/Tribe/Importer/File_Importer_Organizers.php
@@ -38,6 +38,6 @@ class Tribe__Events__Importer__File_Importer_Organizers extends Tribe__Events__I
 			'FeaturedImage' => $featured_image,
 		);
 
-		return $organizer;
+		return apply_filters( 'tribe_events_csv_import_organizer_fields', $organizer );
 	}
 }


### PR DESCRIPTION
This is a suggestion that arose from a user named Geir [in the forums](). This new filter, `tribe_events_csv_import_organizer_fields()`, should help simplify the process of importing custom data for Organizers.

[C#46476](https://central.tri.be/issues/46476)