### PR TITLE
Add new filter to tribe_events_get_the_excerpt | #46477

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1388,7 +1388,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		// Remove "all" HTML based on what is allowed
 		$excerpt = wp_kses( $excerpt, $allowed_html );
 
-		return wpautop( $excerpt );
+		return apply_filters( 'tribe_events_get_the_excerpt', wpautop( $excerpt ) );
 	}
 
 	/**


### PR DESCRIPTION
The `tribe_events_get_the_excerpt()` function does a lot, and it's not rare that we get folks on the forums to alter the excerpt output in some way. It's unfortunately not always as easy a process as it might seem, because if they want the excerpt to do something that a code-stripping or word-trimming function *within* the function will override, then the only option is to make a template override _just_ so that they can use a different excerpt-getting function.

The introduction of this filter should hopefully help to simplify this process.

[C#46477](https://central.tri.be/issues/46477)