### PR TITLE
Ignore drafts, revisions when looking at event costs | #46403

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -282,6 +282,7 @@ class Tribe__Events__Cost_Utils {
 			return (bool) $have_uncosted;
 		}
 
+		// @todo consider expanding our logic for improved handling of private posts etc
 		$uncosted = $wpdb->get_var( $wpdb->prepare( "
 			SELECT ID
 			FROM   {$wpdb->posts}
@@ -294,6 +295,7 @@ class Tribe__Events__Cost_Utils {
 			          LENGTH( meta_value ) = 0
 			          OR meta_value IS NULL
 			      )
+			      AND post_status NOT IN ( 'auto-draft', 'revision' )
 			      
 			LIMIT 1
 		", Tribe__Events__Main::POSTTYPE ) );


### PR DESCRIPTION
Stops our uncosted events query from looking at auto-drafts and revisions.

Ultimately, we probably want to be smarter in a number of places like this and match the same set of post statuses that the main query is interested in, but that's out of scope for this issue.

[C#46403](https://central.tri.be/issues/46403)