### PR TITLE
Make organizer fields sticky

### DIFF
--- a/src/Tribe/Admin/Organizer_Chooser_Meta_Box.php
+++ b/src/Tribe/Admin/Organizer_Chooser_Meta_Box.php
@@ -19,6 +19,7 @@ class Tribe__Events__Admin__Organizer_Chooser_Meta_Box {
 	public function __construct( $event = null ) {
 		$this->tribe = Tribe__Events__Main::instance();
 		$this->get_event( $event );
+		add_action( 'wp', array( $this, 'sticky_form_data' ), 50 ); // Later than events-admin.js itself is enqueued
 	}
 
 	/**
@@ -191,4 +192,34 @@ class Tribe__Events__Admin__Organizer_Chooser_Meta_Box {
 		echo '<a class="dashicons dashicons-trash delete-organizer-group" href="#"></a>';
 	}
 
+	/**
+	 * Supply previously submitted organizer field values to the events-admin.js
+	 * script in order to provide them with sticky qualities.
+	 *
+	 * This *must* run later than the action:priority used to enqueue
+	 * events-admin.js.
+	 */
+	public function sticky_form_data() {
+		$submitted_data = array();
+
+		if ( empty( $_POST['organizer'] ) || ! is_array( $_POST['organizer'] ) ) {
+			return;
+		}
+
+		foreach ( $_POST['organizer'] as $field => $set_of_values ) {
+			if ( ! is_array( $set_of_values ) ) {
+				continue;
+			}
+
+			foreach ( $set_of_values as $index => $value ) {
+				if ( ! isset( $submitted_data[ $index ] ) ) {
+					$submitted_data[ $index ] = array();
+				}
+
+				$submitted_data[ $index ][ $field ] = esc_attr( $value );
+			}
+		}
+
+		wp_localize_script( 'tribe-events-admin', 'tribe_sticky_organizer_fields', $submitted_data );
+	}
 }

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -231,7 +231,7 @@ jQuery( document ).ready( function( $ ) {
 		 */
 		function add_sticky_organizer_data( fields ) {
 			// Bail if expected global array tribe_sticky_organizer_fields is not set
-			if ( ! $.isArray( tribe_sticky_organizer_fields ) ) {
+			if ( 'undefined' === typeof tribe_sticky_organizer_fields || ! $.isArray( tribe_sticky_organizer_fields ) ) {
 				return;
 			}
 

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -222,11 +222,48 @@ jQuery( document ).ready( function( $ ) {
 		});
 
 		organizer_section.on('change', '.organizer-dropdown', toggle_organizer_fields);
+
+		/**
+		 * Populates the organizer fields with previously submitted data to
+		 * give them sticky form qualities.
+		 *
+		 * @param fields
+		 */
+		function add_sticky_organizer_data( fields ) {
+			// Bail if expected global array tribe_sticky_organizer_fields is not set
+			if ( ! $.isArray( tribe_sticky_organizer_fields ) ) {
+				return;
+			}
+
+			// The organizer fields also need sticky field behaviour: populate
+			// them if we've been provided with the necessary data to do so
+			var sticky_data = tribe_sticky_organizer_fields.shift();
+
+			if ( 'object' === typeof sticky_data ) {
+				for ( var key in sticky_data ) {
+					// Check to see if we have a field of this name
+					var $field = $( fields ).find( 'input[name="organizer[' + key + '][]"]' );
+
+					if ( ! $field.length ) {
+						continue;
+					}
+
+					// Set the value accordingly
+					$field.val( sticky_data[ key ] );
+				}
+			}
+		}
+
+		/**
+		 * Add the expected fields (organizer name, phone etc as per the
+		 * 'tribe-create-organizer' template to each row.
+		 */
 		organizer_rows.each( function () {
 			var row = $( this );
 			var group = row.closest( 'tbody' );
 			var fields = $( create_organizer_template( {} ) ).find( '.organizer' ); // we already have our tbody
 			var dropdown = row.find( '.organizer-dropdown' );
+
 			if ( dropdown.length ) {
 				var value = dropdown.val();
 				if ( value != '0' ) {
@@ -237,6 +274,9 @@ jQuery( document ).ready( function( $ ) {
 				label.text( label.data( 'l10n-create-organizer' ) );
 				row.find( '.nosaved' ).remove();
 			}
+
+			// Populate the fields with any sticky data then add them to the page
+			add_sticky_organizer_data( fields );
 			group.append( fields );
 		} );
 


### PR DESCRIPTION
Makes the organizer fields 'sticky', to avoid data loss during frontend event submission (such as if the submission is initially rejected due to missing required fields, etc).

[C#44457](https://central.tri.be/issues/44457)