### PR TITLE
added comma sep. org. ID list support

### DIFF
--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -188,6 +188,7 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 	private function find_matching_organizer_id( $record ) {
 		$name = $this->get_value_by_key( $record, 'event_organizer_name' );
+		
 		// organizer name is a list of IDs either space or comma separated
 		if ( preg_match( '/[\\s,]+/', $name ) && is_numeric( preg_replace( '/[\\s,]+/', '', $name ) ) ) {
 			$split = preg_split( '/[\\s,]+/', $name );

--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -188,10 +188,10 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 	private function find_matching_organizer_id( $record ) {
 		$name = $this->get_value_by_key( $record, 'event_organizer_name' );
-
-		// if the organizers have a space and the items that are separated by spaces are numbers
-		if ( strpos( $name, ' ' ) && is_numeric( str_replace( ' ', '', $name ) ) ) {
-			$split = explode( ' ', $name );
+		
+		// organizer name is a list of IDs either space or comma separated
+		if ( preg_match( '/[\\s,]+/', $name ) && is_numeric( preg_replace( '/[\\s,]+/', '', $name ) ) ) {
+			$split = preg_split( '/[\\s,]+/', $name );
 			$match = array();
 			foreach ( $split as $possible_id_match ) {
 				$match[] = $this->find_matching_post_id( $possible_id_match, Tribe__Events__Organizer::POSTTYPE );

--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -188,7 +188,6 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 	private function find_matching_organizer_id( $record ) {
 		$name = $this->get_value_by_key( $record, 'event_organizer_name' );
-		
 		// organizer name is a list of IDs either space or comma separated
 		if ( preg_match( '/[\\s,]+/', $name ) && is_numeric( preg_replace( '/[\\s,]+/', '', $name ) ) ) {
 			$split = preg_split( '/[\\s,]+/', $name );

--- a/tests/functional/Tribe/Events/Importer/File_Importer_Events_MultipleOrganizersTest.php
+++ b/tests/functional/Tribe/Events/Importer/File_Importer_Events_MultipleOrganizersTest.php
@@ -136,4 +136,23 @@ class File_Importer_Events_MultipleOrganizersTest extends File_Importer_EventsTe
 		$this->assertCount( 1, get_post_meta( $post_id, '_EventOrganizerID', false ) );
 		$this->assertEquals( $organizer_id, get_post_meta( $post_id, '_EventOrganizerID', true ) );
 	}
+
+	/**
+	 * @test
+	 * it should import a comma separated list of organizer IDs
+	 */
+	public function it_should_import_a_comma_separated_list_of_organizer_i_ds() {
+		$organizer_ids = $this->factory()->post->create_many( 3, [ 'post_type' => Main::ORGANIZER_POST_TYPE ] );
+		$this->data    = [
+			'organizer_1' => '"' . implode( ', ', $organizer_ids ) . '"',
+		];
+
+		$sut = $this->make_instance( 'multiple-organizers' );
+
+		$post_id = $sut->import_next_row();
+
+		$stored_organizer_ids = get_post_meta( $post_id, '_EventOrganizerID', false );
+		$this->assertCount( 3, $stored_organizer_ids );
+		$this->assertEqualSets( $organizer_ids, $stored_organizer_ids );
+	}
 }

--- a/tests/functional/Tribe/Events/Importer/File_Importer_Events_MultipleOrganizersTest.php
+++ b/tests/functional/Tribe/Events/Importer/File_Importer_Events_MultipleOrganizersTest.php
@@ -155,4 +155,23 @@ class File_Importer_Events_MultipleOrganizersTest extends File_Importer_EventsTe
 		$this->assertCount( 3, $stored_organizer_ids );
 		$this->assertEqualSets( $organizer_ids, $stored_organizer_ids );
 	}
+
+	/**
+	 * @test
+	 * it should import a tight comma separated list for organizer ids
+	 */
+	public function it_should_import_a_tight_comma_separated_list_for_organizer_ids() {
+		$organizer_ids = $this->factory()->post->create_many( 3, [ 'post_type' => Main::ORGANIZER_POST_TYPE ] );
+		$this->data    = [
+			'organizer_1' => '"' . implode( ',', $organizer_ids ) . '"',
+		];
+
+		$sut = $this->make_instance( 'multiple-organizers' );
+
+		$post_id = $sut->import_next_row();
+
+		$stored_organizer_ids = get_post_meta( $post_id, '_EventOrganizerID', false );
+		$this->assertCount( 3, $stored_organizer_ids );
+		$this->assertEqualSets( $organizer_ids, $stored_organizer_ids );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/39038#note-44

This PR adds support in the importer for multiple organisers specified as a comma separated list.

e.g. `"12, 3434, 434"` or `"34,343,345"`