### PR TITLE
modified GMaps API requests to always run on SSL

### DIFF
--- a/src/Tribe/Embedded_Maps.php
+++ b/src/Tribe/Embedded_Maps.php
@@ -159,8 +159,7 @@ class Tribe__Events__Embedded_Maps {
 
 	protected function enqueue_map_scripts() {
 		// Setup Google Maps API
-		$http = is_ssl() ? 'https' : 'http';
-		$url  = apply_filters( 'tribe_events_google_maps_api', $http . '://maps.google.com/maps/api/js' );
+		$url  = apply_filters( 'tribe_events_google_maps_api', 'https://maps.google.com/maps/api/js' );
 		wp_enqueue_script( 'tribe_events_google_maps_api', $url, array(), false, true );
 
 		// Setup our own script used to initialize each map


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/44827#note-16

Small tweak: all Google Maps API requests should hit the `https` site.