### PR TITLE
Fix infinite loop caused by Maybe iCal Method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -323,6 +323,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Tweak - Language files in the `wp-content/languages/plugins` path will be loaded before attempting to load internal language files [36246]
 * Tweak - Switch to HTTPS for the "Powered by The Events Calendar" link [46542]
 * Deprecated - Tribe__Events__PUE__Checker, Tribe__Events__PUE__Plugin_Info, and Tribe__Events__PUE__Utility classes are deprecated and are replaced by Tribe__PUE__Checker, Tribe__PUE__Plugin_Info, and Tribe__PUE__Utility classes [46188]
+* Fixed - Changed the use of have_posts() in the maybe iCal links for the main views that could cause an infinite loop [46320]
 * Accessibility - Focus styles added for search fields [32936]
 * Accessibility - Add ARIA labels for Month/Day/List sub nav [32937]
 * Accessibility - Add ARIA label for events footer sub nav heading [32937]

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -11,7 +11,7 @@ class Tribe__Events__iCal {
 	 * @static
 	 */
 	public static function init() {
-		add_filter( 'tribe_events_after_footer', array( __CLASS__, 'maybe_add_link' ), 10, 1 );
+		add_action( 'tribe_events_after_footer', array( __CLASS__, 'maybe_add_link' ), 10, 1 );
 		add_action( 'tribe_events_single_event_after_the_content', array( __CLASS__, 'single_event_links' ) );
 		add_action( 'tribe_tec_template_chooser', array( __CLASS__, 'do_ical_template' ) );
 		add_filter( 'tribe_get_ical_link', array( __CLASS__, 'day_view_ical_link' ), 20, 1 );
@@ -91,7 +91,7 @@ class Tribe__Events__iCal {
 		if ( tribe_is_month() && ! tribe_events_month_has_events() ) {
 			return;
 		}
-		if ( is_single() || ! have_posts() ) {
+		if ( is_single() || empty( $wp_query->posts ) ) {
 			return;
 		}
 


### PR DESCRIPTION
_Ref:_ [C#46320](https://central.tri.be/issues/46320)

This fixes the block that Trisha found when trying to create a shortcode for the Month View. Using have_posts() in the maybe_add_link causes the query to be reset. Changed to checked against the global instead. 

Also, changed the method to be and action as it hooks into an action not a filter. 