### PR TITLE
Whitelist the vendor lib that does UTF8 Encoding

### DIFF
--- a/package-whitelist.json
+++ b/package-whitelist.json
@@ -16,6 +16,7 @@
   "vendor/chosen/public/*.js",
   "vendor/chosen/public/*.css",
   "vendor/chosen/public/*.png",
+  "vendor/ForceUTF8/Encoding.php",
   "vendor/jquery/*.css",
   "vendor/jquery/*.js",
   "vendor/jquery/smoothness/*.css",


### PR DESCRIPTION
See: https://central.tri.be/issues/61694