### PR TITLE
Document new filter, add changelog entry | #46476

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -297,6 +297,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Tweak - Language files in the `wp-content/languages/plugins` path will be loaded before attempting to load internal language files [36246]
 * Tweak - Switch to HTTPS for the "Powered by The Events Calendar" link [46542]
 * Tweak - Improved filterability of calendar excerpts by introducing the new tribe_events_get_the_excerpt filter hook [46477]
+* Tweak - Improved filterability of organizer details when importing by CSV (props: @Geir) [46476]
 * Deprecated - Tribe__Events__PUE__Checker, Tribe__Events__PUE__Plugin_Info, and Tribe__Events__PUE__Utility classes are deprecated and are replaced by Tribe__PUE__Checker, Tribe__PUE__Plugin_Info, and Tribe__PUE__Utility classes [46188]
 * Fixed - Changed the use of have_posts() in the maybe iCal links for the main views that could cause an infinite loop [46320]
 * Accessibility - Focus styles added for search fields [32936]

--- a/src/Tribe/Importer/File_Importer_Organizers.php
+++ b/src/Tribe/Importer/File_Importer_Organizers.php
@@ -38,6 +38,12 @@ class Tribe__Events__Importer__File_Importer_Organizers extends Tribe__Events__I
 			'FeaturedImage' => $featured_image,
 		);
 
-		return apply_filters( 'tribe_events_csv_import_organizer_fields', $organizer );
+		/**
+		 * Provides an opportunity to modify organizer details during CSV imports.
+		 *
+		 * @param array $organizer
+		 * @param array $record
+		 */
+		return apply_filters( 'tribe_events_csv_import_organizer_fields', $organizer, $record );
 	}
 }


### PR DESCRIPTION
Adds changelog entry and inline docs for new hook, also makes the original $record array available to callbacks.

https://central.tri.be/issues/46476