### PR TITLE
Fix for single/multiple linked post submission handling | spotfix

### DIFF
--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -643,7 +643,14 @@ class Tribe__Events__Linked_Posts {
 
 			$data = array();
 			foreach ( $fields as $field_name ) {
-				$data[ $field_name ] = isset( $submission[ $field_name ][ $key ] ) ? $submission[ $field_name ][ $key ] : null;
+				// If allow_multiple := true then each submission field may be an array
+				if ( is_array( $submission[ $field_name ] ) ) {
+					$data[ $field_name ] = isset( $submission[ $field_name ][ $key ] ) ? $submission[ $field_name ][ $key ] : null;
+				}
+				// In other cases, such as if multiple := false each submission field will contain a single value
+				else {
+					$data[ $field_name ] = isset( $submission[ $field_name ] ) ? $submission[ $field_name ] : null;
+				}
 			}
 
 			// set the post status to the event post status


### PR DESCRIPTION
Found this en route to fixing [#61871](https://central.tri.be/issues/61871) though this isn't directly related and [#61847](https://central.tri.be/issues/61847) may be a better fit: ensures when a new single linked post (ie a venue) is submitted it retains the correct field values.

Previously, `$key` would be `0` in these situations so if `$submission[ $field_name ] == 'String'` then `$submission[ $field_name ][ $key ]` would reference the first character, `S`, effectively lopping off the remainder.

https://central.tri.be/issues/61847