### PR TITLE
Ensure that submitted venue/organizer fields are arrays

### DIFF
--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -612,17 +612,15 @@ class Tribe__Events__Linked_Posts {
 		$event_post_status         = get_post_status( $event_id );
 
 		if ( ! isset( $submission[ $linked_post_type_id_field ] ) ) {
-			$submission[ $linked_post_type_id_field ] = array();
+			$submission[ $linked_post_type_id_field ] = array( 0 );
 		}
 
-		// if multiple post types are not supported, ensure that the submission array is set up appropriately
-		if ( ! $this->allow_multiple( $linked_post_type ) && ! is_array( $submission[ $linked_post_type_id_field ] ) ) {
-			$temp_submission = $submission;
-			$submission = array();
+		$temp_submission = $submission;
+		$submission = array();
 
-			foreach ( $temp_submission as $key => $value ) {
-				$submission[ $key ] = array( $value );
-			}
+		// make sure all elements are arrays
+		foreach ( $temp_submission as $key => $value ) {
+			$submission[ $key ] = is_array( $value ) ? $value : array( $value );
 		}
 
 		$fields = array_keys( $submission );


### PR DESCRIPTION
Eventbrite imports events and formats venues/organizers with the old pre-linked post method...where the fields are not arrays. This changes ensures that the fields are all arrays as the new way expects. This change should help any third party submissions to saveEventMeta in the API class as well!

See: https://central.tri.be/issues/61942