### PR TITLE
fix tribe_get_event_link function when passing 2nd param as true 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -290,16 +290,17 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 = [4.2.1] Unreleased =
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
+* Fix - tribe_get_event_link() didn't work properly when passing second parameter as true [61891]
 
 = [4.2] 2016-06-08 =
 
 * Feature - Added Google Maps API key field in the Settings tab to avoid map timeouts and errors on larger sites (Thanks to Yan for reporting this!)
-* Feature - Added support for featured image, multiple organizers, excerpt and more custom fields in the .csv file import function for events (Thank you to Graphic Designer for posting on UserVoice!) 
-* Feature - Added support for featured image, description, map details and more custom fields in the .csv file import function for venues 
-* Feature - Added support for featured image and description in the .csv file import function for organizers (Thank you to Rebecca for posting on UserVoice!) 
-* Feature - Added an oEmbed template for events 
-* Feature - Improve performance of a query used to determine if there are free/uncosted events (Thank you @fabianmarz for the pull request!) 
-* Feature - Added support for attaching custom post types to events 
+* Feature - Added support for featured image, multiple organizers, excerpt and more custom fields in the .csv file import function for events (Thank you to Graphic Designer for posting on UserVoice!)
+* Feature - Added support for featured image, description, map details and more custom fields in the .csv file import function for venues
+* Feature - Added support for featured image and description in the .csv file import function for organizers (Thank you to Rebecca for posting on UserVoice!)
+* Feature - Added an oEmbed template for events
+* Feature - Improve performance of a query used to determine if there are free/uncosted events (Thank you @fabianmarz for the pull request!)
+* Feature - Added support for attaching custom post types to events
 * Tweak - Improved filtering of the `tribe_event_featured_image()` function (Cheers to @fabianmarz!)
 * Tweak - Add an encoding class for the CSV importer to prevent non utf8 characters from preventing imports (Thanks to screenrage for the report!)
 * Tweak - Improved our JSON-LD output to ensure consistency (Props to @garrettjohnson and Lars!)

--- a/readme.txt
+++ b/readme.txt
@@ -287,6 +287,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [4.2.1] Unreleased =
+
+* Fix - replace bad return type to avoid notices in the error log [62376]
+
 = [4.2] 2016-06-08 =
 
 * Feature - Added Google Maps API key field in the Settings tab to avoid map timeouts and errors on larger sites (Thanks to Yan for reporting this!)

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -272,7 +272,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( $full_link ) {
 			$title_args = array( 'post' => $postId, 'echo' => false );
-			$name = the_title( $title_args );
+			$name = get_the_title( $postId );
 			$attr_title = the_title_attribute( $title_args );
 			$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '" title="'.$attr_title.'"">' . $name . '</a>' : false;
 		} else {


### PR DESCRIPTION
See: https://central.tri.be/issues/61891

Note: we never call the function in this manner within our own code, this would only be used for theme-ing and customizations

Side note: I'm also sneaking in a submodule hash update to the latest common.