### PR TITLE
Add some default constraints to month view caching | #46581

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -291,7 +291,6 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
 * Fix - add missing styles for screen reader text [62500]
-* Fix - allow '0' to be set as the value of additional fields [45674]
 * Tweak - adjust the month view caching rules [46581]
 
 = [4.2] 2016-06-08 =

--- a/readme.txt
+++ b/readme.txt
@@ -291,6 +291,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
 * Fix - add missing styles for screen reader text [62500]
+* Fix - allow '0' to be set as the value of additional fields [45674]
 * Tweak - adjust the month view caching rules [46581]
 
 = [4.2] 2016-06-08 =

--- a/readme.txt
+++ b/readme.txt
@@ -291,6 +291,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
 * Fix - add missing styles for screen reader text [62500]
+* Tweak - adjust the month view caching rules [46581]
 
 = [4.2] 2016-06-08 =
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -219,7 +219,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				return false;
 			}
 
-			// If the requested month is in the past, do not cache
+			// If the requested month is more than 2 months in the past, do not cache
 			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m', Tribe__Date_Utils::wp_strtotime( '-2 months' ) ) ) {
 				return false;
 			}

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -151,8 +151,21 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			// include child categories in the query, save categories for reuse
 			$this->set_queried_event_cats();
 
-			// decide if we should use the month view cache
-			$this->use_cache = tribe_get_option( 'enable_month_view_cache', false );
+
+
+			/**
+			 * Controls whether or not month view caching is enabled.
+			 *
+			 * Filtering this value can be useful if you need to implement
+			 * a fine grained caching policy for month view.
+			 *
+			 * @param boolean $enable
+			 * @param array   $args
+			 */
+			$this->use_cache = apply_filters( 'tribe_events_enable_month_view_cache',
+				$this->enable_month_view_cache(),
+				$this->args
+			);
 
 			// Cache the result of month/content.php
 			if ( $this->use_cache ) {
@@ -176,6 +189,48 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			parent::__construct();
+		}
+
+		/**
+		 * Indicates if month view cache should be enabled or not.
+		 *
+		 * If the month view cache setting itself is not enabled (or not set) then this
+		 * method will always return false.
+		 *
+		 * In other cases, the default rules are to cache everything except for past
+		 * months and months more than 1yr in the future. This policy can be refined
+		 * or replaced via the 'tribe_events_enable_month_view_cache' filter hook.
+		 *
+		 * @return bool
+		 */
+		protected function enable_month_view_cache() {
+			// Respect the month view caching setting
+			if ( ! tribe_get_option( 'enable_month_view_cache', false ) ) {
+				return false;
+			}
+
+			// Default to always caching the current month
+			if ( ! isset( $this->args[ 'eventDate' ] ) ) {
+				return true;
+			}
+
+			// If the eventDate argument is not in the expected format then do not cache
+			if ( ! preg_match( '/^[0-9]{4}-[0-9]{1,2}$/', $this->args[ 'eventDate' ] ) ) {
+				return false;
+			}
+
+			// If the requested month is in the past, do not cache
+			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m' ) ) {
+				return false;
+			}
+
+			// If the requested month is more than 1yr in the future, do not cache
+			if ( $this->args[ 'eventDate' ] > date_i18n( 'Y-m', Tribe__Date_Utils::wp_strtotime( '+1 year' ) ) ) {
+				return false;
+			}
+
+			// In all other cases, let's cache it!
+			return true;
 		}
 
 		/**

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -197,9 +197,9 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * If the month view cache setting itself is not enabled (or not set) then this
 		 * method will always return false.
 		 *
-		 * In other cases, the default rules are to cache everything except for past
-		 * months and months more than 1yr in the future. This policy can be refined
-		 * or replaced via the 'tribe_events_enable_month_view_cache' filter hook.
+		 * In other cases, the default rules are to cache everything in the 2 months past
+		 * to 12 months in the future range. This policy can be refined or replaced via
+		 * the 'tribe_events_enable_month_view_cache' filter hook.
 		 *
 		 * @return bool
 		 */
@@ -220,7 +220,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			// If the requested month is in the past, do not cache
-			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m' ) ) {
+			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m', Tribe__Date_Utils::wp_strtotime( '-2 months' ) ) ){
 				return false;
 			}
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			 * @param array   $args
 			 */
 			$this->use_cache = apply_filters( 'tribe_events_enable_month_view_cache',
-				$this->enable_month_view_cache(),
+				$this->should_enable_month_view_cache(),
 				$this->args
 			);
 
@@ -203,7 +203,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 *
 		 * @return bool
 		 */
-		protected function enable_month_view_cache() {
+		protected function should_enable_month_view_cache() {
 			// Respect the month view caching setting
 			if ( ! tribe_get_option( 'enable_month_view_cache', false ) ) {
 				return false;

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -220,7 +220,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			// If the requested month is in the past, do not cache
-			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m', Tribe__Date_Utils::wp_strtotime( '-2 months' ) ) ){
+			if ( $this->args[ 'eventDate' ] < date_i18n( 'Y-m', Tribe__Date_Utils::wp_strtotime( '-2 months' ) ) ) {
 				return false;
 			}
 

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -236,8 +236,8 @@ class Tribe__Events__iCal {
 			$time = (object) array(
 				'start' => tribe_get_start_date( $event_post->ID, false, 'U' ),
 				'end' => tribe_get_end_date( $event_post->ID, false, 'U' ),
-				'modified' => self::wp_strtotime( $event_post->post_modified ),
-				'created' => self::wp_strtotime( $event_post->post_date ),
+				'modified' => Tribe__Date_Utils::wp_strtotime( $event_post->post_modified ),
+				'created' => Tribe__Date_Utils::wp_strtotime( $event_post->post_date ),
 			);
 
 			if ( 'yes' == get_post_meta( $event_post->ID, '_EventAllDay', true ) ) {
@@ -363,47 +363,4 @@ class Tribe__Events__iCal {
 		exit;
 
 	}
-
-	/**
-	 * Converts a locally-formatted date to a unix timestamp. This is a drop-in
-	 * replacement for `strtotime()`, except that where strtotime assumes GMT, this
-	 * assumes local time (as described below). If a timezone is specified, this
-	 * function defers to strtotime().
-	 *
-	 * If there is a timezone_string available, the date is assumed to be in that
-	 * timezone, otherwise it simply subtracts the value of the 'gmt_offset'
-	 * option.
-	 *
-	 * @see strtotime()
-	 * @uses get_option() to retrieve the value of 'gmt_offset'.
-	 * @param string $string A date/time string. See `strtotime` for valid formats.
-	 * @return int UNIX timestamp.
-	 */
-	private static function wp_strtotime( $string ) {
-		// If there's a timezone specified, we shouldn't convert it
-		try {
-			$test_date = new DateTime( $string );
-			if ( 'UTC' != $test_date->getTimezone()->getName() ) {
-				return strtotime( $string );
-			}
-		} catch ( Exception $e ) {
-			return strtotime( $string );
-		}
-
-		$tz = get_option( 'timezone_string' );
-		if ( ! empty( $tz ) ) {
-			$date = date_create( $string, new DateTimeZone( $tz ) );
-			if ( ! $date ) {
-				return strtotime( $string );
-			}
-			$date->setTimezone( new DateTimeZone( 'UTC' ) );
-			return $date->format( 'U' );
-		} else {
-			$offset = (float) get_option( 'gmt_offset' );
-			$seconds = intval( $offset * HOUR_IN_SECONDS );
-			$timestamp = strtotime( $string ) - $seconds;
-			return $timestamp;
-		}
-	}
-
 }


### PR DESCRIPTION
* Adds a new hook to make it easier to control when month view caching kicks in
* Adds some default rules to limit the occasions month view caching is used
* Depends on [Tribe Common PR 104](https://github.com/moderntribe/tribe-common/pull/104)

https://central.tri.be/issues/46581