### PR TITLE
is_embed fix for older versions of WordPress

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -291,17 +291,20 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
 * Fix - add missing styles for screen reader text [62500]
-* Fix - prevent fatal error of is_embed on WordPress 4.3 and lower [62577]
+* Tweak - adjust the month view caching rules [46581]
+* Fix - tribe_get_event_link() didn't work properly when passing second parameter as true [61891]
+* Tweak - reduce font size of titles in month view for skeleton styles [41461]
+* Fix - added styling to adjust list view description to 100% [62512]
 
 = [4.2] 2016-06-08 =
 
 * Feature - Added Google Maps API key field in the Settings tab to avoid map timeouts and errors on larger sites (Thanks to Yan for reporting this!)
-* Feature - Added support for featured image, multiple organizers, excerpt and more custom fields in the .csv file import function for events (Thank you to Graphic Designer for posting on UserVoice!) 
-* Feature - Added support for featured image, description, map details and more custom fields in the .csv file import function for venues 
-* Feature - Added support for featured image and description in the .csv file import function for organizers (Thank you to Rebecca for posting on UserVoice!) 
-* Feature - Added an oEmbed template for events 
-* Feature - Improve performance of a query used to determine if there are free/uncosted events (Thank you @fabianmarz for the pull request!) 
-* Feature - Added support for attaching custom post types to events 
+* Feature - Added support for featured image, multiple organizers, excerpt and more custom fields in the .csv file import function for events (Thank you to Graphic Designer for posting on UserVoice!)
+* Feature - Added support for featured image, description, map details and more custom fields in the .csv file import function for venues
+* Feature - Added support for featured image and description in the .csv file import function for organizers (Thank you to Rebecca for posting on UserVoice!)
+* Feature - Added an oEmbed template for events
+* Feature - Improve performance of a query used to determine if there are free/uncosted events (Thank you @fabianmarz for the pull request!)
+* Feature - Added support for attaching custom post types to events
 * Tweak - Improved filtering of the `tribe_event_featured_image()` function (Cheers to @fabianmarz!)
 * Tweak - Add an encoding class for the CSV importer to prevent non utf8 characters from preventing imports (Thanks to screenrage for the report!)
 * Tweak - Improved our JSON-LD output to ensure consistency (Props to @garrettjohnson and Lars!)

--- a/readme.txt
+++ b/readme.txt
@@ -291,6 +291,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 * Fix - replace bad return type to avoid notices in the error log [62376]
 * Fix - add missing styles for screen reader text [62500]
+* Fix - prevent fatal error of is_embed on WordPress 4.3 and lower [62577]
 
 = [4.2] 2016-06-08 =
 

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -145,7 +145,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			}
 
 			// if this is an oembed, override the wrapping template and use the embed template
-			if ( is_embed() ) {
+			if ( Tribe__Templates::is_embed() ) {
 				$template = self::getTemplateHierarchy( 'embed' );
 			}
 
@@ -405,7 +405,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 				$template = self::getTemplateHierarchy( 'day' );
 			}
 
-			if ( is_embed() ) {
+			if ( Tribe__Templates::is_embed() ) {
 				$template = self::getTemplateHierarchy( 'embed' );
 			}
 
@@ -413,7 +413,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			if (
 				is_singular( Tribe__Events__Main::POSTTYPE )
 				&& ! tribe_is_showing_all()
-				&& ! is_embed()
+				&& ! Tribe__Templates::is_embed()
 			) {
 				$template = self::getTemplateHierarchy( 'single-event', array( 'disable_view_check' => true ) );
 			}
@@ -445,7 +445,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 			elseif ( tribe_is_day() || tribe_is_ajax_view_request( 'day' ) ) {
 				$class = 'Tribe__Events__Template__Day';
 			}
-			elseif ( is_embed() ) {
+			elseif ( Tribe__Templates::is_embed() ) {
 				$class = 'Tribe__Events__Template__Embed';
 			}
 			// single event view

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1532,19 +1532,4 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		return $url;
 	}
-
-	/**
-	 * Add a check for WordPress Version and Below at the is_embed function to prevent fatals
-	 * in this file the-events-calendar/src/Tribe/Templates.php
-	 *
-	 * @version 4.2.1
-	 */
-	global $wp_version;
-	if ( version_compare( $wp_version, '4.4', '<' ) ) {
-		if ( ! function_exists( 'is_embed' ) ) {
-			function is_embed() {
-				return false;
-			}
-		}
-	}
 }

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1532,4 +1532,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		return $url;
 	}
+
+	/**
+	 * Add a check for WordPress Version and Below at the is_embed function to prevent fatals
+	 * in this file the-events-calendar/src/Tribe/Templates.php
+	 *
+	 * @version 4.2.1
+	 */
+	global $wp_version;
+	if( version_compare( $wp_version, '4.4', '<' ) ) {
+	    if ( ! function_exists( 'is_embed' ) ) {
+	        function is_embed() { return false; }
+	    }
+	}
 }

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1540,9 +1540,11 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @version 4.2.1
 	 */
 	global $wp_version;
-	if( version_compare( $wp_version, '4.4', '<' ) ) {
-	    if ( ! function_exists( 'is_embed' ) ) {
-	        function is_embed() { return false; }
-	    }
+	if ( version_compare( $wp_version, '4.4', '<' ) ) {
+		if ( ! function_exists( 'is_embed' ) ) {
+			function is_embed() {
+				return false;
+			}
+		}
 	}
 }


### PR DESCRIPTION
_Ref:_ [C#62577](https://central.tri.be/issues/62577) - We use is_embed 4 different times in this template: the-events-calendar/src/Tribe/Templates.php 

Instead of wrapping those with a version check I added one to the general.php file 

Not sure if this is the best approach, but this would help prevent fatals in WordPress 3.9 to WordPress 4.3

Method for commit is in common: https://github.com/moderntribe/tribe-common/pull/108