### PR TITLE
Use array instead of [] for PHP 5.2 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -296,6 +296,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 * Tweak - reduce font size of titles in month view for skeleton styles [41461]
 * Fix - added styling to adjust list view description to 100% [62512]
 * Fix - miscellaneous tweaks to css to improve layout in month and day views [61651]
+* Fix - Fix shorthand array that was causing errors in PHP 5.2 and 5.3 on Event Import
 
 = [4.2] 2016-06-08 =
 

--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -306,7 +306,7 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 	 */
 	private function get_currency_position( array $record ) {
 		$currency_position = $this->get_value_by_key( $record, 'event_currency_position' );
-		$after_aliases     = [ 'suffix', 'after' ];
+		$after_aliases     = array( 'suffix', 'after' );
 
 		foreach ( $after_aliases as $after_alias ) {
 			if ( preg_match( '/' . $after_alias . '/i', $currency_position ) ) {


### PR DESCRIPTION
_Ref:_ [C#62699](https://central.tri.be/issues/62699) This is late in the game, but the only change is to remove the short array syntax and use the 5.2 and 5.3 compatible array(). 