### PR TITLE
Update the-events-calendar-pt_BR.po

### DIFF
--- a/lang/the-events-calendar-pt_BR.po
+++ b/lang/the-events-calendar-pt_BR.po
@@ -1973,7 +1973,7 @@ msgstr "%s do dia"
 
 #: src/Tribe/iCal.php:116
 msgid "Listed %s"
-msgstr "Listado %s"
+msgstr "%s listados"
 
 #: src/Tribe/iCal.php:121
 msgid "Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"


### PR DESCRIPTION
In Portuguese the adjective usually comes after the substantive. Specially in this case, to be used in the export button, if you put the adjective before the substantive, makes no sense.