### PR TITLE
Fix iCal export.

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -13,7 +13,7 @@ class Tribe__Events__iCal {
 	public static function init() {
 		add_action( 'tribe_events_after_footer', array( __CLASS__, 'maybe_add_link' ), 10, 1 );
 		add_action( 'tribe_events_single_event_after_the_content', array( __CLASS__, 'single_event_links' ) );
-		add_action( 'tribe_tec_template_chooser', array( __CLASS__, 'do_ical_template' ) );
+		add_action( 'template_redirect', array( __CLASS__, 'do_ical_template' ) );
 		add_filter( 'tribe_get_ical_link', array( __CLASS__, 'day_view_ical_link' ), 20, 1 );
 		add_action( 'wp_head', array( __CLASS__, 'set_feed_link' ), 2, 0 );
 	}


### PR DESCRIPTION
Hi,

I encounter an issue regarding the iCal Export template button from a single event view.

The errors I got is "Cannot modify header information - headers already sent by..." This issue appears because you have some code inside your `Tribe__Events__iCal` class that is called after some rendered output in the browser.

Here are the lines the error report points to:
```php
$filename = apply_filters( 'tribe_events_ical_feed_filename', $site . '-' . $hash . '.ics', $post );
header( 'Content-type: text/calendar; charset=UTF-8' );
header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
```
This code is run once the hook `tribe_tec_template_chooser` is called which is too late.
By changing the hook name to a more appropriate one: `template_redirect`, no more errors were triggered and the plugin runs smoothly with the iCal export.

I suggest you to test this. So inside your `Tribe__Events__iCal` class in the static method init, replace the hook `tribe_tec_template_chooser` to `template_redirect`. Test it and let us know when there is an update to this. The fix is available in this PR.

Here we keep the altered plugin on our development but it would be best if it is fixed generally.

The error and fix is working on plugin version 4.2.1 and 4.2.1.1. It runs on PHP 5.6.

Here is a link to changed code (image): https://cloudup.com/c5wYbNiQfnz

The project is under local development so no access to it but if you need more information, do not hesitate to ask.

Regards,

[C#64141](https://central.tri.be/issues/64141)