### PR TITLE
Fix/62523 jsonld event dates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -290,6 +290,10 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 
 == Changelog ==
 
+= [4.2.3] TBD =
+
+* Fix - Incorrect JSON-LD event start and end times [62523]
+
 = [4.2.2] 2016-07-06 =
 
 * Fix - Small CSS Issue on Welcome Page

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -20,11 +20,6 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	public    $type = 'Event';
 
 	/**
-	 * @var int
-	 */
-	protected $current_post_id;
-
-	/**
 	 * On PHP 5.2 the child class doesn't get spawned on the Parent one, so we don't have
 	 * access to that information on the other side unless we pass it around as a param
 	 * so we throw __CLASS__ to the parent::instance() method to be able to spawn new instance

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -51,7 +51,7 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			}
 
 			// Fetch first key
-			$post_id = $this->current_post_id = key( $data );
+			$post_id = key( $data );
 
 			// Fetch first Value
 			$data = reset( $data );

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -61,12 +61,16 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			// Fetch first Value
 			$data = reset( $data );
 
-			add_filter( 'pre_option_timezone_string', array( $this, '_filter_timezone_string' ), 10, 1 );
-
-			$data->startDate = get_gmt_from_date( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), 'c' );
-			$data->endDate   = get_gmt_from_date( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), 'c' );
-
-			remove_filter( 'pre_option_timezone_string', array( $this, '_filter_timezone_string' ), 10 );
+			$event_tz_string = get_post_meta( $post_id, '_EventTimezone', true );
+			$tz_string       = $event_tz_string ? $event_tz_string : get_option( 'timezone_string' );
+			
+			$utc_tz = new DateTimeZone( 'UTC' );
+			$event_tz = new DateTimeZone( $tz_string );
+			
+			$start_date = new DateTime( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $event_tz );
+			$end_date = new DateTime( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $event_tz );
+			$data->startDate = $start_date->setTimezone( $utc_tz )->format( 'c' );
+			$data->endDate = $end_date->setTimezone( $utc_tz )->format( 'c' );
 
 			if ( tribe_has_venue( $post_id ) ) {
 				$venue_data = Tribe__Events__JSON_LD__Venue::instance()->get_data( tribe_get_venue_id( $post_id ) );
@@ -94,19 +98,5 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 		}
 
 		return $return;
-	}
-
-	/**
-	 * Filters the timezone string returning the one assigned to the event if any.
-	 * 
-	 * The function has a `public` visibility for implementation reasons and should not be
-	 * relied upon for third-party implementations.
-	 *
-	 * @return string|bool Either the timezone string assigned to the event or `false`.
-	 */
-	public function _filter_timezone_string() {
-		$event_timezone = get_post_meta( $this->current_post_id, '_EventTimezone', true );
-
-		return ! empty( $event_timezone ) ? $event_timezone : false;
 	}
 }

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -58,14 +58,9 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 
 			$event_tz_string = get_post_meta( $post_id, '_EventTimezone', true );
 			$tz_string       = $event_tz_string ? $event_tz_string : get_option( 'timezone_string' );
-			
-			$utc_tz = new DateTimeZone( 'UTC' );
-			$event_tz = new DateTimeZone( $tz_string );
-			
-			$start_date = new DateTime( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $event_tz );
-			$end_date = new DateTime( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $event_tz );
-			$data->startDate = $start_date->setTimezone( $utc_tz )->format( 'c' );
-			$data->endDate = $end_date->setTimezone( $utc_tz )->format( 'c' );
+
+			$data->startDate = Tribe__Events__Timezones::to_utc( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
+			$data->endDate   = Tribe__Events__Timezones::to_utc( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
 
 			if ( tribe_has_venue( $post_id ) ) {
 				$venue_data = Tribe__Events__JSON_LD__Venue::instance()->get_data( tribe_get_venue_id( $post_id ) );

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -153,10 +153,12 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 	 *
 	 * @param string $datetime
 	 * @param string $tzstring
+	 * @param string $format The optional format of the resulting date, defaults to 
+	 *                      `Tribe__Date_Utils::DBDATETIMEFORMAT`.
 	 *
 	 * @return string
 	 */
-	public static function to_utc( $datetime, $tzstring ) {
+	public static function to_utc( $datetime, $tzstring, $format = null ) {
 		if ( self::is_utc_offset( $tzstring ) ) {
 			return self::apply_offset( $datetime, $tzstring, true );
 		}
@@ -167,7 +169,9 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 		$new_datetime = date_create( $datetime, $local );
 
 		if ( $new_datetime && $new_datetime->setTimezone( $utc ) ) {
-			return $new_datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			$format = ! empty( $format ) ? $format : Tribe__Date_Utils::DBDATETIMEFORMAT;
+
+			return $new_datetime->format( $format );
 		}
 
 		// Fallback to the unmodified datetime if there was a failure during conversion


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/62523

Filter the `timezone_string` when building the JSON-LD data to output correct start and end times.