### PR TITLE
take sitewide timezone setting into account when generating event jso…

### DIFF
--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -57,8 +57,8 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			$data = reset( $data );
 
 			$event_tz_string = get_post_meta( $post_id, '_EventTimezone', true );
-			$tz_string       = $event_tz_string ? $event_tz_string : get_option( 'timezone_string' );
-
+			$tz_mode         = tribe_get_option( 'tribe_events_timezone_mode', 'event' );
+			$tz_string       = $event_tz_string && $tz_mode === 'event' ? $event_tz_string : Tribe__Events__Timezones::wp_timezone_string();
 			$data->startDate = Tribe__Events__Timezones::to_utc( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
 			$data->endDate   = Tribe__Events__Timezones::to_utc( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/62523

Take site wide timezone setting into account when generating jsonld data