### PR TITLE
Tidy whitespace, add changelog entry | #63474

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -293,6 +293,7 @@ At no point during the 3.0 lifecycle will the major version change. But you can 
 = [4.3] unreleased =
 
 * Fix - Cease using GLOB_BRACE for including deprecated files due to limited server support [63172]
+* Fix - Avoid problems that can occur when hooking and unhooking actions (props @Chouby) [63474]
 
 = [4.2.2] 2016-07-06 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3085,14 +3085,13 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 */
 		public function addEventMeta( $postId, $post ) {
-			
 			static $avoid_recursion = false;
-			
+
 			// Avoid an infinite loop, because saveEventMeta calls wp_update_post when the post is set to always show in calendar
 			if ( $avoid_recursion ) {
 				return;
 			}
-			
+
 			$avoid_recursion = true;
 
 			// only continue if it's an event post
@@ -3132,7 +3131,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			Tribe__Events__API::saveEventMeta( $postId, $_POST, $post );
 
-			// Add this hook back in
+			// Allow this callback to run
 			$avoid_recursion = false;
 		}
 


### PR DESCRIPTION
Following this [community PR](https://github.com/moderntribe/the-events-calendar/pull/753), tidies up some whitespace issues and adds a changelog entry.

https://central.tri.be/issues/63474