### PR TITLE
added missing found file filtering

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -621,6 +621,8 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 					if ( $file ) {
 						_deprecated_function( sprintf( esc_html__( 'Template overrides should be moved to the correct subdirectory: %s', 'the-events-calendar' ), str_replace( get_stylesheet_directory() . '/tribe-events/', '', $file ) ), '3.2', $template );
 					}
+				} else {
+					$file = apply_filters( 'tribe_events_template', $file, $template );
 				}
 			}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/62525

Simply call the same filter we call when a template file is not found when a template file is found.