### PR TITLE
Don't throw notices when old and new meta values are not set

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -220,6 +220,9 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 
 			if ( ! isset( $new[ $field ] ) && isset( $old[ $prefixed_field ] ) ) {
 				return true;
+			} elseif ( ! isset( $new[ $field ] ) ) {
+				// if the new field isn't set and the old field isn't set, there's no change
+				return false;
 			}
 
 			$data_value = $new[ $field ];


### PR DESCRIPTION
See: https://central.tri.be/issues/65030