### PR TITLE
Remove the 'tribe_events_rewrite_rules' filter

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -112,6 +112,10 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 			 * @var Tribe__Events__Rewrite $rewrite
 			 */
 			do_action( 'tribe_events_pre_rewrite', $this );
+			
+			$this->rules = apply_filters( 'tribe_events_rewrite_rules_custom', $this->rules, $this );
+			
+			$wp_rewrite->rules = $this->rules + $wp_rewrite->rules;
 		}
 
 		/**

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -112,12 +112,6 @@ if ( ! class_exists( 'Tribe__Events__Rewrite' ) ) {
 			 * @var Tribe__Events__Rewrite $rewrite
 			 */
 			do_action( 'tribe_events_pre_rewrite', $this );
-
-			/**
-			 * Backwards Compatibility filter, this filters the WP Rewrite Rules.
-			 * @todo  Check if is worth deprecating this hook
-			 */
-			$wp_rewrite->rules = apply_filters( 'tribe_events_rewrite_rules', $this->rules + $wp_rewrite->rules, $this );
 		}
 
 		/**


### PR DESCRIPTION
Hi!

I propose to remove the filter 'tribe_events_rewrite_rules' because it conflicts with a WordPress filter of the same name. See https://github.com/WordPress/WordPress/blob/4.5.3/wp-includes/class-wp-rewrite.php#L1416

The WP filter has only one argument. Attempting to use the second argument of the TEC filter creates an error.

The WP filter sends only the rules related to the 'tribe_events' post type, while the TEC filter sends all rewrite rules. This can raise all sorts of conflicts in plugins using the WP filter and not aware of the existence of the TEC filter.

As is, the TEC filter is not very useful as the WP filter 'rewrite_rules_array' is already there to filter all rewrite rules if someone needs it.

Considering the inline comment, I propose to simply remove the existing filter, but IMHO, a different filter, only for `$this->rules` instead of `$this->rules + $wp_rewrite->rules`, and with a different name may be useful when a plugin needs to filter only the TEC rules.

_[Ticketed: [#66455](https://central.tri.be/issues/66455)]_