### PR TITLE
add an isset check

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -159,7 +159,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 					else {
 						update_post_meta( $event_id, $tag, $data[ $htmlElement ] );
 					}
-	//here
+
 					if ( self::is_meta_value_changed( $tag, $data, $post_meta ) ) {
 						$modified[ $tag ] = $now;
 					}

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -159,7 +159,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 					else {
 						update_post_meta( $event_id, $tag, $data[ $htmlElement ] );
 					}
-
+	//here
 					if ( self::is_meta_value_changed( $tag, $data, $post_meta ) ) {
 						$modified[ $tag ] = $now;
 					}
@@ -231,7 +231,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				$data_value = null;
 			}
 
-			if ( $data_value !== $old[ $prefixed_field ] ) {
+			if ( ! isset( $old[ $prefixed_field ] ) || $data_value !== $old[ $prefixed_field ] ) {
 				return true;
 			}
 


### PR DESCRIPTION
emerged while working on ticket https://central.tri.be/issues/61724 to restore ET tests:

add an `isset` check to avoid errors when a meta field is not set on `old` 