### PR TITLE
We don't need to sanitize in such a limited manner. wpdb prepare is fine

### DIFF
--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -134,11 +134,6 @@ class Tribe__Events__Aggregator__Event {
 
 		$key = "_{$fields[ $origin ]['target']}";
 
-		// sanitize values
-		foreach ( $values as &$value ) {
-			$value = preg_replace( '/[^a-zA-Z0-9]/', '', $value );
-		}
-
 		$sql = "
 			SELECT
 				meta_value,


### PR DESCRIPTION
We were sanitizing aggressively for no real reason. We need to search for the uid values that are inserted.

See: Findings compilation doc