### PR TITLE
don't change post modified on schedule update

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -180,6 +180,8 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 * @return WP_Post|WP_Error
 	 */
 	public function save( $post_id, $args = array(), $meta = array() ) {
+		global $wp_version;
+
 		if ( ! isset( $meta['type'] ) || 'schedule' !== $meta['type'] ) {
 			return tribe_error( 'core:aggregator:invalid-edit-record-type', $type );
 		}
@@ -199,10 +201,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$post['ID'] = absint( $post_id );
 		$post['post_status'] = Tribe__Events__Aggregator__Records::$status->schedule;
 
+		add_filter( 'wp_insert_post_data', array( $this, 'dont_change_post_modified' ), 10, 2 );
 		$result = wp_update_post( $post );
+		remove_filter( 'wp_insert_post_data', array( $this, 'dont_change_post_modified' ) );
 
 		// meta_input was introduced in 4.4. Deal with old versions
-		if ( -1 === version_compare( WP_VERSION, '4.4' ) && ! is_wp_error( $result ) ) {
+		if ( -1 === version_compare( $wp_version, '4.4' ) && ! is_wp_error( $result ) ) {
 			foreach ( $post['meta_input'] as $key => $value ) {
 				update_post_meta( $result, $key, $value );
 			}
@@ -210,6 +214,23 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		// After Creating the Post Load and return
 		return $this->load( $result );
+	}
+
+	/**
+	 * Filter the post_modified dates to be unchanged
+	 * conditionally hooked to wp_insert_post_data and then unhooked after wp_update_post
+	 *
+	 * @param array $data new data to be used in the update
+	 * @param array $postarr existing post data
+	 *
+	 * @return array
+	 */
+	public function dont_change_post_modified( $data, $postarr ) {
+		$post = get_post( $postarr['ID'] );
+		$data['post_modified'] = $postarr['post_modified'];
+		$data['post_modified_gmt'] = $postarr['post_modified_gmt'];
+
+		return $data;
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Tabs/Edit.php
+++ b/src/Tribe/Aggregator/Tabs/Edit.php
@@ -102,9 +102,9 @@ class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__T
 	 */
 	public function finalize_schedule_edit( $record, $post_data, $meta ) {
 		$this->messages = array(
-			'error',
-			'success',
-			'warning',
+			'error' => array(),
+			'success' => array(),
+			'warning' => array(),
 		);
 
 		$meta[ 'post_status' ] = empty( $post_data['post_status'] ) ? 'draft' : $post_data['post_status'];
@@ -112,7 +112,7 @@ class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__T
 		$result = $record->save( $post_data['post_id'], array(), $meta );
 
 		if ( is_wp_error( $result ) ) {
-			$this->messages[ 'error' ][] = $result->get_error_message();
+			$this->messages['error'][] = $result->get_error_message();
 
 			ob_start();
 			?>
@@ -126,6 +126,8 @@ class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__T
 			tribe_notice( 'tribe-aggregator-schedule-edit-failed', $html, 'type=error' );
 			return $result;
 		}
+
+		$this->messages['success'][] = esc_html__( 'Scheduled import was successfully updated.' );
 
 		ob_start();
 		?>


### PR DESCRIPTION
We set that field for the Last Import date, so we don't want to update it
if the settings change.

Also fixed a couple of notices.