### PR TITLE
Fix CREATED and LAST-MODIFIED fields in iCal export

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -233,6 +233,7 @@ class Tribe__Events__iCal {
 			$item = array();
 
 			$full_format = 'Ymd\THis';
+			$utc_format = 'Ymd\THis\Z';
 			$time = (object) array(
 				'start' => tribe_get_start_date( $event_post->ID, false, 'U' ),
 				'end' => tribe_get_end_date( $event_post->ID, false, 'U' ),
@@ -251,8 +252,8 @@ class Tribe__Events__iCal {
 			$tzoned = (object) array(
 				'start'    => date( $format, $time->start ),
 				'end'      => date( $format, $time->end ),
-				'modified' => date( $format, $time->modified ),
-				'created'  => date( $format, $time->created ),
+				'modified' => date( $utc_format, $time->modified ),
+				'created'  => date( $utc_format, $time->created ),
 			);
 
 			if ( 'DATE' === $type ){


### PR DESCRIPTION
According to [RFC 5545 section 3.8.7.3](https://tools.ietf.org/html/rfc5545#section-3.8.7.3) and [section 3.8.7.1](https://tools.ietf.org/html/rfc5545#section-3.8.7.1) the LAST-MODIFIED and CREATED properties are of DATE-TIME type and MUST be specified in UTC time format.

The current code in src/Tribe/iCal.php is buggy: It switches the type for these two fields (together with DTSTART and DTEND, where that's allowed) between DATE and DATE-TIME based on the _EventAllDay meta. For an "all day" event, invalid output (such as `CREATED:20160831`) is generated. Other software doesn't react well to this (Example: Python [vobject](http://eventable.github.io/vobject/): `vobject.base.ParseError: At line 13: '20160831' is not a valid DATE-TIME`).

This pull request changes both fields to UTC DATE-TIME format and type.

[Ticketed - [#65968](https://central.tri.be/issues/65968)]