### PR TITLE
Better handling of CSV headers

### DIFF
--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -205,19 +205,19 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 			$content_type = $this->get_content_type();
 		}
 
-		switch ( $content_type ) {
-			case 'event':
-			case 'events':
-				$content_type = 'events';
-				break;
-			case 'organizer':
-			case 'organizers':
-				$content_type = 'organizers';
-				break;
-			case 'venue':
-			case 'venues':
-				$content_type = 'venues';
-				break;
+		$lowercase_content_type = strtolower( $content_type );
+
+		$map = array(
+			'event'      => 'events',
+			'events'     => 'events',
+			'organizer'  => 'organizers',
+			'organizers' => 'organizers',
+			'venue'      => 'venues',
+			'venues'     => 'venues',
+		);
+
+		if ( isset( $map[ $lowercase_content_type ] ) ) {
+			return $map[ $lowercase_content_type ];
 		}
 
 		return $content_type;

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -132,7 +132,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 			return tribe_error( 'core:aggregator:missing-csv-column-map' );
 		}
 
-		$content_type = $this->get_content_type();
+		$content_type = $this->get_csv_content_type();
 		update_option( 'tribe_events_import_column_mapping_' . $content_type, $data['column_map'] );
 
 		try {
@@ -149,7 +149,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$missing = array_diff( $required_fields, $data['column_map'] );
 
 		if ( ! empty( $missing ) ) {
-			$mapper = new Tribe__Events__Importer__Column_Mapper( $this->get_content_type() );
+			$mapper = new Tribe__Events__Importer__Column_Mapper( $content_type );
 
 			/**
 			 * @todo  allow to overwrite the default message
@@ -174,7 +174,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 
 	public function get_importer() {
 		if ( ! $this->importer ) {
-			$content_type = $this->get_content_type();
+			$content_type = $this->get_csv_content_type();
 
 			$file_path = get_attached_file( absint( $this->meta['file'] ) );
 			$file_reader = new Tribe__Events__Importer__File_Reader( $file_path );
@@ -190,6 +190,37 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 
 	public function get_content_type() {
 		return str_replace( 'tribe_', '', $this->meta['content_type'] );
+	}
+
+	/**
+	 * Translates the posttype-driven content types to content types that the CSV importer knows
+	 *
+	 * @param string $content_type Content Type
+	 *
+	 * @return string CSV Importer compatible content type
+	 */
+	public function get_csv_content_type( $content_type = null ) {
+
+		if ( ! $content_type ) {
+			$content_type = $this->get_content_type();
+		}
+
+		switch ( $content_type ) {
+			case 'event':
+			case 'events':
+				$content_type = 'events';
+				break;
+			case 'organizer':
+			case 'organizers':
+				$content_type = 'organizers';
+				break;
+			case 'venue':
+			case 'venues':
+				$content_type = 'venues';
+				break;
+		}
+
+		return $content_type;
 	}
 
 	/**

--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -14,9 +14,11 @@ class Tribe__Events__Importer__Column_Mapper {
 			case 'events':
 				$this->column_names = $this->get_event_column_names();
 				break;
+			case 'venue':
 			case 'venues':
 				$this->column_names = $this->get_venue_column_names();
 				break;
+			case 'organizer':
 			case 'organizers':
 				$this->column_names = $this->get_organizer_column_names();
 				break;


### PR DESCRIPTION
This resolves a couple of issues:

* CSV saving when mapping fields failed to render fields that _must_ be mapped
* CSV field settings for organizers and venues were not auto-selected because the wrong option was being saved

See: https://central.tri.be/issues/65945