### PR TITLE
fix/38132-ical-export-borked-organizer

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *    Class that implements the export to iCal functionality
+ *  Class that implements the export to iCal functionality
  *  both for list and single events
  */
 class Tribe__Events__iCal {

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -318,7 +318,7 @@ class Tribe__Events__iCal {
 			}
 
 			// add organizer if available
-			$organizer_email = tribe_get_organizer_email( $event_post->ID, false);
+			$organizer_email = tribe_get_organizer_email( $event_post->ID, false );
 			if ( $organizer_email ) {
 				$organizer_id = tribe_get_organizer_id( $event_post->ID );
 				$organizer = get_post( $organizer_id );

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -318,7 +318,7 @@ class Tribe__Events__iCal {
 			}
 
 			// add organizer if available
-			$organizer_email = tribe_get_organizer_email( $event_post->ID );
+			$organizer_email = tribe_get_organizer_email( $event_post->ID, false);
 			if ( $organizer_email ) {
 				$organizer_id = tribe_get_organizer_id( $event_post->ID );
 				$organizer = get_post( $organizer_id );

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -186,13 +186,14 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * Returns the Organizer's Email
 	 *
 	 * @param int $postId Can supply either event id or organizer id, if none specified, current post is used
+	 * @param bool $antispambot Whether the email should pass through the `antispambot` function or not.
 	 *
 	 * @return string Organizer's Email
 	 */
-	function tribe_get_organizer_email( $postId = null ) {
+	function tribe_get_organizer_email( $postId = null, $antispambot = true ) {
 		$postId = Tribe__Events__Main::postIdHelper( $postId );
 		$unfiltered_email  = esc_html( tribe_get_event_meta( tribe_get_organizer_id( $postId ), '_OrganizerEmail', true ) );
-		$filtered_email = antispambot( $unfiltered_email );
+		$filtered_email = $antispambot ? antispambot( $unfiltered_email ) : $unfiltered_email;
 
 		/**
 		 * Allows for the organizer email to be filtered.


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/38132#note-23

Allow code using the `tribe_get_organizer_email` to have it in an unfiltered version.