### PR TITLE
Set CSV default post status and categories correctly

### DIFF
--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -145,6 +145,10 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 			$importer = $this->maybe_set_default_category( $importer );
 		}
 
+		if ( ! empty( $data['post_status'] ) ) {
+			$importer = $this->maybe_set_default_post_status( $importer );
+		}
+
 		$required_fields = $importer->get_required_fields();
 		$missing = array_diff( $required_fields, $data['column_map'] );
 
@@ -260,6 +264,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$importer->is_aggregator = true;
 		$importer->aggregator_record = $this;
 		$importer = $this->maybe_set_default_category( $importer );
+		$importer = $this->maybe_set_default_post_status( $importer );
 		$offset = get_option( 'tribe_events_importer_offset', 1 );
 		if ( -1 === $offset ) {
 			$this->state = 'complete';
@@ -274,9 +279,31 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		return get_option( 'tribe_events_import_log', array( 'updated' => 0, 'created' => 0, 'skipped' => 0, 'encoding' => 0 ) );
 	}
 
+	/**
+	 * If a custom category has been specified, set it in the importer
+	 *
+	 * @param Tribe__Events__Importer__File_Importer $importer Importer object
+	 *
+	 * @return Tribe__Events__Importer__File_Importer
+	 */
 	public function maybe_set_default_category( $importer ) {
 		if ( ! empty( $this->meta['category'] ) ) {
 			$importer->default_category = (int) $this->meta['category'];
+		}
+
+		return $importer;
+	}
+
+	/**
+	 * If a custom post_status has been specified, set it in the importer
+	 *
+	 * @param Tribe__Events__Importer__File_Importer $importer Importer object
+	 *
+	 * @return Tribe__Events__Importer__File_Importer
+	 */
+	public function maybe_set_default_post_status( $importer ) {
+		if ( ! empty( $this->meta['post_status'] ) ) {
+			$importer->default_post_status = $this->meta['post_status'];
 		}
 
 		return $importer;

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -174,16 +174,15 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 			return $this->messages;
 		}
 
+		// Make sure we have a post status set no matter what
 		if ( empty( $data['post_status'] ) ) {
 			$data['post_status'] = Tribe__Events__Aggregator__Settings::instance()->default_post_status( $data['origin'] );
 		}
 
-		if ( empty( $data['category'] ) ) {
-			$data['category'] = Tribe__Events__Aggregator__Settings::instance()->default_category( $data['origin'] );
-		}
-
+		// If the submitted category is null, that means the user intended to de-select the default
+		// category if there is one, so setting it to null is ok here
+		$record->update_meta( 'category', empty( $data['category'] ) ? null : $data['category'] );
 		$record->update_meta( 'post_status', $data['post_status'] );
-		$record->update_meta( 'category', $data['category'] );
 		$record->update_meta( 'ids_to_import', empty( $data['selected_rows'] ) ? 'all' : json_decode( stripslashes( $data['selected_rows'] ) ) );
 
 		// if we get here, we're good! Set the status to pending

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -174,8 +174,16 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 			return $this->messages;
 		}
 
-		$record->update_meta( 'post_status', empty( $data['post_status'] ) ? 'draft' : $data['post_status'] );
-		$record->update_meta( 'category', empty( $data['category'] ) ? null : $data['category'] );
+		if ( empty( $data['post_status'] ) ) {
+			$data['post_status'] = Tribe__Events__Aggregator__Settings::instance()->default_post_status( $data['origin'] );
+		}
+
+		if ( empty( $data['category'] ) ) {
+			$data['category'] = Tribe__Events__Aggregator__Settings::instance()->default_category( $data['origin'] );
+		}
+
+		$record->update_meta( 'post_status', $data['post_status'] );
+		$record->update_meta( 'category', $data['category'] );
 		$record->update_meta( 'ids_to_import', empty( $data['selected_rows'] ) ? 'all' : json_decode( stripslashes( $data['selected_rows'] ) ) );
 
 		// if we get here, we're good! Set the status to pending

--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -23,6 +23,7 @@ abstract class Tribe__Events__Importer__File_Importer {
 	public $is_aggregator = false;
 	public $aggregator_record;
 	public $default_category;
+	public $default_post_status;
 
 	/**
 	 * @var Tribe__Events__Importer__Featured_Image_Uploader

--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -140,6 +140,8 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 		if ( empty( $this->is_aggregator ) ) {
 			$post_status_setting = Tribe__Events__Importer__Options::get_default_post_status( 'csv' );
+		} elseif ( $this->default_post_status ) {
+			$post_status_setting = $this->default_post_status;
 		} else {
 			$post_status_setting = Tribe__Events__Aggregator__Settings::instance()->default_post_status( 'csv' );
 		}


### PR DESCRIPTION
Post statuses, when submitted via the New Import form, were not getting applied when inserting posts during CSV imports. This resolves that as well as ensures that default categories are set appropriately.

See: https://central.tri.be/issues/65358