### PR TITLE
Skipped field is used by subclasses and so should not be private | spotfix

### DIFF
--- a/src/Tribe/Importer/File_Importer.php
+++ b/src/Tribe/Importer/File_Importer.php
@@ -16,9 +16,10 @@ abstract class Tribe__Events__Importer__File_Importer {
 	private $errors = array();
 	private $updated = 0;
 	private $created = 0;
-	private $skipped = array();
 	private $encoding = array();
 	private $log = array();
+
+	protected $skipped = array();
 
 	public $is_aggregator = false;
 	public $aggregator_record;


### PR DESCRIPTION
Changes the `skipped` field's access modifier to protected: as subclasses like `Tribe__Events__Importer__File_Importer_Events` try to work with the property it cannot be private.