### PR TITLE
Remove exception for CSV-imported events re Hide & Ignore functionality

### DIFF
--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -578,6 +578,9 @@ class Tribe__Events__Aggregator__Records {
 	 * @param string $origin Import Origin
 	 */
 	public function add_record_to_event( $id, $record_id, $origin ) {
+		// Set the event origin
+		update_post_meta( $id, '_EventOrigin', Tribe__Events__Aggregator__Event::$event_origin );
+
 		// Add the Aggregator Origin
 		update_post_meta( $id, Tribe__Events__Aggregator__Event::$origin_key, $origin );
 

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -709,11 +709,6 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 
 			if ( Tribe__Events__Aggregator__Event::$event_origin === $origin ) {
 				$aggregator_origin = get_post_meta( $event->ID, Tribe__Events__Aggregator__Event::$origin_key, true );
-
-				// You cannot Ignore CSV
-				if ( 'csv' === $aggregator_origin ) {
-					return false;
-				}
 			}
 
 			return true;


### PR DESCRIPTION
Ensures that the `_EventOrigin` is reliably set for all events pulled in through EA, and removes the exception for CSV-sourced events re Hide & Ignore (ie, make it so they can be ignored rather than trashed).

[#61161](https://central.tri.be/issues/61161)