### PR TITLE
Fix view categories link | spotfix

### DIFF
--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -328,7 +328,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 				_n( '%1$d new event category was created.', '%1$d new event categories were created.', $queue->activity->count( 'category', 'created' ), 'the-events-calendar' ),
 				$queue->activity->count( 'category', 'created' )
 			) .
-			' <a href="' . admin_url( 'edit.php?post_type=tribe_organizer' ) . '">' .
+			' <a href="' . admin_url( 'edit-tags.php?taxonomy=tribe_events_cat&post_type=tribe_events' ) . '">' .
 			__( 'View your event categories', 'the-events-calendar' ) .
 			'</a>';
 			;


### PR DESCRIPTION
*View your event categories* should link to event categories list, not the list of organizers.