### PR TITLE
Bail if $response does not have a status property | spotfix

### DIFF
--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -197,7 +197,7 @@ class Tribe__Events__Aggregator__Service {
 		$response = $this->get( 'origin' );
 
 		// If we have an WP_Error we return only CSV
-		if ( is_wp_error( $response ) ) {
+		if ( is_wp_error( $response ) || ! property_exists( $response, 'status' ) ) {
 			return $origins;
 		}
 

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -197,7 +197,7 @@ class Tribe__Events__Aggregator__Service {
 		$response = $this->get( 'origin' );
 
 		// If we have an WP_Error we return only CSV
-		if ( is_wp_error( $response ) || ! property_exists( $response, 'status' ) ) {
+		if ( is_wp_error( $response ) || ! empty( $response->status ) ) {
 			return $origins;
 		}
 

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -197,7 +197,7 @@ class Tribe__Events__Aggregator__Service {
 		$response = $this->get( 'origin' );
 
 		// If we have an WP_Error we return only CSV
-		if ( is_wp_error( $response ) || ! empty( $response->status ) ) {
+		if ( is_wp_error( $response ) || empty( $response->status ) ) {
 			return $origins;
 		}
 


### PR DESCRIPTION
Even if `$response` is not a `WP_Error`, there may be no `status` property (if the site doesn't have an EA key for example).