### PR TITLE
Don't make a useless call to fetch data

### DIFF
--- a/src/Tribe/Aggregator/API/Origins.php
+++ b/src/Tribe/Aggregator/API/Origins.php
@@ -49,15 +49,10 @@ class Tribe__Events__Aggregator__API__Origins extends Tribe__Events__Aggregator_
 	 */
 	public function get() {
 		if ( Tribe__Events__Aggregator::instance()->is_service_active() ) {
-			$this->initialize_origin_data();
+			$this->enable_service_origins();
 		}
 
 		return apply_filters( 'tribe_aggregator_origins', $this->origins );
-	}
-
-	private function initialize_origin_data() {
-		$this->fetch_origin_data();
-		$this->enable_service_origins();
 	}
 
 	/**


### PR DESCRIPTION
Forcing a fetching of origin data all the time is stupid. Let's not do that.

See: https://central.tri.be/issues/66538