### PR TITLE
Let scheduled imports be deactivated and reactivated

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -87,29 +87,34 @@ class Tribe__Events__Aggregator__Cron {
 		 */
 		$found = $schedules = apply_filters( 'tribe_aggregator_record_frequency', array(
 			(object) array(
-				'id'     => 'every30mins',
+				'id'       => 'inactive',
+				'interval' => false,
+				'text'     => esc_html_x( 'Inactive (manual/on demand)', 'aggregator schedule frequency', 'the-events-calendar' ),
+			),
+			(object) array(
+				'id'       => 'every30mins',
 				'interval' => MINUTE_IN_SECONDS * 30,
-				'text'  => esc_html_x( 'Every 30 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Every 30 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
-				'id'     => 'hourly',
+				'id'       => 'hourly',
 				'interval' => HOUR_IN_SECONDS,
-				'text'  => esc_html_x( 'Hourly', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Hourly', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
-				'id'     => 'daily',
+				'id'       => 'daily',
 				'interval' => DAY_IN_SECONDS,
-				'text'  => esc_html_x( 'Daily', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Daily', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
-				'id'     => 'weekly',
+				'id'       => 'weekly',
 				'interval' => WEEK_IN_SECONDS,
-				'text'  => esc_html_x( 'Weekly', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Weekly', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
-				'id'     => 'monthly',
+				'id'       => 'monthly',
 				'interval' => DAY_IN_SECONDS * 30,
-				'text'  => esc_html_x( 'Monthly', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Monthly', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 		) );
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -222,8 +222,8 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		// Record the previous frequency setting for this record
 		$previous_frequency = get_post_field( 'post_content' );
 
-		if ( is_object( $previous_frequency ) && isset( $previous_frequency->id ) ) {
-			$meta['prev_frequency'] = $previous_frequency->id;
+		if ( ! empty( $previous_frequency ) ) {
+			$meta['prev_frequency'] = $previous_frequency;
 		}
 
 		$post = $this->prep_post_args( $meta['type'], $args, $meta );

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -220,7 +220,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$meta = wp_parse_args( $meta, $defaults );
 
 		// Record the previous frequency setting for this record
-		$previous_frequency = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post_id )->frequency;
+		$previous_frequency = get_post_field( 'post_content' );
 
 		if ( is_object( $previous_frequency ) && isset( $previous_frequency->id ) ) {
 			$meta['prev_frequency'] = $previous_frequency->id;

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -772,16 +772,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	}
 
 	/**
-	 * Returns the previously saved frequency or null if this information is not
-	 * available.
-	 *
-	 * @return string|null
-	 */
-	public function previous_frequency() {
-		return ! empty( $this->meta['prev_frequency'] ) ? $this->meta['prev_frequency'] : null;
-	}
-
-	/**
 	 * Get info about the source, via and title
 	 *
 	 * @return array

--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -348,8 +348,8 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		}
 
 		$post_type_object = get_post_type_object( $post->post_type );
+		$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post->ID );
 		$actions = array();
-		$title = _draft_or_post_title();
 
 		if ( current_user_can( $post_type_object->cap->edit_post, $post->ID ) ) {
 			$actions['edit'] = sprintf(
@@ -370,6 +370,27 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 				esc_attr__( 'Start an import from this source now, regardless of schedule. Check the import status in History. Doing a manual import will not impact your scheduled imports.', 'the-events-calendar' ),
 				esc_html__( 'Run Import', 'the-events-calendar' )
 			);
+
+			// Add a reactivation link for sources which were previously disabled
+			if ( $record->is_inactive() ) {
+				$args['action'] = 'reactivate';
+				$actions['reactivate'] = sprintf(
+					'<a href="%1$s" title="%2$s">%3$s</a>',
+					Tribe__Events__Aggregator__Page::instance()->get_url( $args ),
+					esc_attr__( 'Restore automatic imports for this source.', 'the-events-calendar' ),
+					esc_html__( 'Reactivate', 'the-events-calendar' )
+				);
+			}
+			// Add a deactivation link to let site admins disable automated imports without actually deleting them
+			else {
+				$args['action'] = 'deactivate';
+				$actions['deactivate'] = sprintf(
+					'<a href="%1$s" title="%2$s">%3$s</a>',
+					Tribe__Events__Aggregator__Page::instance()->get_url( $args ),
+					esc_attr__( 'Turn off automatic imports from this source. The source will not be deleted and you will still be able to manually trigger imports.', 'the-events-calendar' ),
+					esc_html__( 'Deactivate', 'the-events-calendar' )
+				);
+			}
 		}
 
 		if ( current_user_can( $post_type_object->cap->delete_post, $post->ID ) ) {

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -138,10 +138,22 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		// Ensures Records is an Array
 		$data->records = (array) $data->records;
 
-		if ( 'delete' === $data->action ) {
-			list( $success, $errors ) = $this->action_delete_record( $data->records );
-		} elseif ( 'run-import' === $data->action ) {
-			list( $success, $errors ) = $this->action_run_import( $data->records );
+		switch ( $data->action ) {
+			case 'delete':
+				list( $success, $errors ) = $this->action_delete_record( $data->records );
+				break;
+
+			case 'run-import':
+				list( $success, $errors ) = $this->action_run_import( $data->records );
+				break;
+
+			case 'deactivate':
+				list( $success, $errors ) = $this->action_deactivate( $data->records );
+				break;
+
+			case 'reactivate':
+				list( $success, $errors ) = $this->action_reactivate( $data->records );
+				break;
 		}
 
 		$args = array(
@@ -175,10 +187,20 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		switch ( $_GET['action'] ) {
 			case 'run-import';
 				$action = __( 'queued', 'the-events-calendar' );
-			break;
+				break;
+
 			case 'delete';
 				$action = __( 'delete', 'the-events-calendar' );
-			break;
+				break;
+
+			case 'reactivate':
+				$action = __( 'activate', 'the-events-calendar' );
+				break;
+
+			case 'deactivate':
+				$action = __( 'reactivate', 'the-events-calendar' );
+				break;
+
 			default:
 				return false;
 		}
@@ -290,6 +312,44 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 				$errors[ $record->id ] = $status;
 				continue;
 			}
+		}
+
+		return array( $success, $errors );
+	}
+
+	private function action_deactivate( $records = array() ) {
+		$records = array_filter( (array) $records, 'is_numeric' );
+		$success = array();
+		$errors = array();
+
+		foreach ( $records as $record_id ) {
+			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
+
+			if ( is_wp_error( $record ) ) {
+				$errors[ $record_id ] = $record;
+				continue;
+			}
+
+			$record->deactivate();
+		}
+
+		return array( $success, $errors );
+	}
+
+	private function action_reactivate( $records = array() ) {
+		$records = array_filter( (array) $records, 'is_numeric' );
+		$success = array();
+		$errors = array();
+
+		foreach ( $records as $record_id ) {
+			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
+
+			if ( is_wp_error( $record ) ) {
+				$errors[ $record_id ] = $record;
+				continue;
+			}
+
+			$record->reactivate();
 		}
 
 		return array( $success, $errors );

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -194,11 +194,11 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 				break;
 
 			case 'reactivate':
-				$action = __( 'activate', 'the-events-calendar' );
+				$action = __( 'reactivated', 'the-events-calendar' );
 				break;
 
 			case 'deactivate':
-				$action = __( 'reactivate', 'the-events-calendar' );
+				$action = __( 'deactivated', 'the-events-calendar' );
 				break;
 
 			default:
@@ -331,6 +331,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			}
 
 			$record->deactivate();
+			$success[ $record_id ] = true;
 		}
 
 		return array( $success, $errors );
@@ -350,6 +351,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			}
 
 			$record->reactivate();
+			$success[ $record_id ] = true;
 		}
 
 		return array( $success, $errors );


### PR DESCRIPTION
Allows a scheduled import to be deactivated (so that automatic imports stop happening) and for deactivated imports to be reactivated (restoring the previously scheduled interval).

https://central.tri.be/issues/66838