### PR TITLE
DRY-up interval change code; avoid side effect of updating post_modifed_gmt

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -89,12 +89,12 @@ class Tribe__Events__Aggregator__Cron {
 			(object) array(
 				'id'       => 'on_demand',
 				'interval' => false,
-				'text'     => esc_html_x( 'On demand', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'On Demand', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
 				'id'       => 'every30mins',
 				'interval' => MINUTE_IN_SECONDS * 30,
-				'text'     => esc_html_x( 'Every 30 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'Every 30 Minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
 				'id'       => 'hourly',

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -87,9 +87,9 @@ class Tribe__Events__Aggregator__Cron {
 		 */
 		$found = $schedules = apply_filters( 'tribe_aggregator_record_frequency', array(
 			(object) array(
-				'id'       => 'inactive',
+				'id'       => 'on_demand',
 				'interval' => false,
-				'text'     => esc_html_x( 'Inactive (manual/on demand)', 'aggregator schedule frequency', 'the-events-calendar' ),
+				'text'     => esc_html_x( 'On demand', 'aggregator schedule frequency', 'the-events-calendar' ),
 			),
 			(object) array(
 				'id'       => 'every30mins',

--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -348,7 +348,6 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		}
 
 		$post_type_object = get_post_type_object( $post->post_type );
-		$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post->ID );
 		$actions = array();
 
 		if ( current_user_can( $post_type_object->cap->edit_post, $post->ID ) ) {
@@ -370,27 +369,6 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 				esc_attr__( 'Start an import from this source now, regardless of schedule. Check the import status in History. Doing a manual import will not impact your scheduled imports.', 'the-events-calendar' ),
 				esc_html__( 'Run Import', 'the-events-calendar' )
 			);
-
-			// Add a reactivation link for sources which were previously disabled
-			if ( $record->is_inactive() ) {
-				$args['action'] = 'reactivate';
-				$actions['reactivate'] = sprintf(
-					'<a href="%1$s" title="%2$s">%3$s</a>',
-					Tribe__Events__Aggregator__Page::instance()->get_url( $args ),
-					esc_attr__( 'Restore automatic imports for this source.', 'the-events-calendar' ),
-					esc_html__( 'Reactivate', 'the-events-calendar' )
-				);
-			}
-			// Add a deactivation link to let site admins disable automated imports without actually deleting them
-			else {
-				$args['action'] = 'deactivate';
-				$actions['deactivate'] = sprintf(
-					'<a href="%1$s" title="%2$s">%3$s</a>',
-					Tribe__Events__Aggregator__Page::instance()->get_url( $args ),
-					esc_attr__( 'Turn off automatic imports from this source. The source will not be deleted and you will still be able to manually trigger imports.', 'the-events-calendar' ),
-					esc_html__( 'Deactivate', 'the-events-calendar' )
-				);
-			}
 		}
 
 		if ( current_user_can( $post_type_object->cap->delete_post, $post->ID ) ) {

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -146,14 +146,6 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			case 'run-import':
 				list( $success, $errors ) = $this->action_run_import( $data->records );
 				break;
-
-			case 'deactivate':
-				list( $success, $errors ) = $this->action_deactivate( $data->records );
-				break;
-
-			case 'reactivate':
-				list( $success, $errors ) = $this->action_reactivate( $data->records );
-				break;
 		}
 
 		$args = array(
@@ -312,46 +304,6 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 				$errors[ $record->id ] = $status;
 				continue;
 			}
-		}
-
-		return array( $success, $errors );
-	}
-
-	private function action_deactivate( $records = array() ) {
-		$records = array_filter( (array) $records, 'is_numeric' );
-		$success = array();
-		$errors = array();
-
-		foreach ( $records as $record_id ) {
-			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
-
-			if ( is_wp_error( $record ) ) {
-				$errors[ $record_id ] = $record;
-				continue;
-			}
-
-			$record->deactivate();
-			$success[ $record_id ] = true;
-		}
-
-		return array( $success, $errors );
-	}
-
-	private function action_reactivate( $records = array() ) {
-		$records = array_filter( (array) $records, 'is_numeric' );
-		$success = array();
-		$errors = array();
-
-		foreach ( $records as $record_id ) {
-			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
-
-			if ( is_wp_error( $record ) ) {
-				$errors[ $record_id ] = $record;
-				continue;
-			}
-
-			$record->reactivate();
-			$success[ $record_id ] = true;
 		}
 
 		return array( $success, $errors );


### PR DESCRIPTION
This change has us using an update query instead of `wp_update_post()` when we modify the import interval, because the latter function has a side effect of updating `post_modified_gmt` (which we use to track the last import operation - and so is something we don't want to alter when the interval changes).

[#66838](https://central.tri.be/issues/66838)