### PR TITLE
Communicate that a preview is a preview to the EA Service

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -173,6 +173,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$defaults = array(
 			'frequency' => null,
 			'hash'      => wp_generate_password( 32, true, true ),
+			'preview'   => false,
 		);
 
 		$meta = wp_parse_args( $meta, $defaults );
@@ -463,6 +464,10 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		if ( ! empty( $this->meta['radius'] ) ) {
 			$defaults['radius'] = $this->meta['radius'];
+		}
+
+		if ( ! empty( $this->meta['preview'] ) ) {
+			$defaults['preview'] = $this->meta['preview'];
 		}
 
 		$args = wp_parse_args( $args, $defaults );

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -97,6 +97,9 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 		$post_data = $submission['post_data'];
 		$meta      = $submission['meta'];
 
+		// mark the record creation as a preview record
+		$meta['preview'] = true;
+
 		if ( ! empty( $post_data['import_id'] ) ) {
 			$this->handle_import_finalize( $post_data );
 			return;


### PR DESCRIPTION
This way we can track hard limits remotely.

See: https://central.tri.be/issues/66891