### PR TITLE
Properly handle error states when running schedule records interactively

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -329,6 +329,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		);
 
 		foreach ( $this->meta as $key => $value ) {
+			// don't propagate these meta keys to the scheduled record
+			if (
+				'preview' === $key
+				|| 'activity' === $key
+				|| 'ids_to_import' === $key
+			) {
+				continue;
+			}
+
 			$post['meta_input'][ self::$meta_key_prefix . $key ] = $value;
 		}
 
@@ -466,8 +475,8 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			$defaults['radius'] = $this->meta['radius'];
 		}
 
-		if ( ! empty( $this->meta['preview'] ) ) {
-			$defaults['preview'] = $this->meta['preview'];
+		if ( $is_previewing ) {
+			$defaults['preview'] = true;
 		}
 
 		$args = wp_parse_args( $args, $defaults );
@@ -777,6 +786,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$items = $this->prep_import_data( $data );
 
 		if ( is_wp_error( $items ) ) {
+			$this->set_status_as_failed( $items );
 			return $items;
 		}
 

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -155,7 +155,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		);
 
 		if ( ! empty( $errors ) ) {
-			$args['error'] = $data->nonce;
+			$args['errors'] = $data->nonce;
 
 			// Set the errors
 			set_transient( $this->get_errors_transient_name( $data->nonce ), $errors, 5 * MINUTE_IN_SECONDS );
@@ -197,7 +197,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 				return false;
 		}
 
-		if ( empty( $_GET['ids'] ) ) {
+		if ( empty( $_GET['ids'] ) && empty( $_GET['errors'] ) ) {
 			return false;
 		}
 
@@ -206,7 +206,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			return $this->handle_post( $_GET );
 		}
 
-		$this->action_notice( $action, $_GET['ids'], isset( $_GET['error'] ) ? $_GET['error'] : null );
+		$this->action_notice( $action, empty( $_GET['ids'] ) ? array() : $_GET['ids'], isset( $_GET['errors'] ) ? $_GET['errors'] : null );
 	}
 
 	/**
@@ -217,7 +217,10 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 	 * @return string
 	 */
 	private function action_notice( $action, $ids = array(), $error = null ) {
-		$ids    = explode( ',', $ids );
+		if ( $ids && ! is_array( $ids ) ) {
+			$ids    = explode( ',', $ids );
+		}
+
 		$errors = array();
 
 		if ( is_string( $error ) ) {
@@ -235,10 +238,17 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		);
 
 		if ( ! empty( $errors ) ) {
-			$message->error[] = sprintf( esc_html__( 'Error: %d scheduled import was not %s.', 'the-events-calendar' ), $action, count( $errors ) );
-			foreach ( $errors as $post_id => $error ) {
-				$message->error[] = implode( '<br/>', sprintf( '%d: %s', $post_id, $error->get_error_message() ) );
+			if ( 'run-import' === $_GET['action'] ) {
+				foreach ( $errors as $post_id => $error ) {
+					$message->error[] = $error->get_error_message();
+				}
+			} else {
+				$message->error[] = sprintf( esc_html__( 'Error: %d scheduled import was not %s.', 'the-events-calendar' ), $action, count( $errors ) );
+				foreach ( $errors as $post_id => $error ) {
+					$message->error[] = implode( '<br/>', sprintf( '%d: %s', $post_id, $error->get_error_message() ) );
+				}
 			}
+
 			tribe_notice( 'tribe-aggregator-action-records-error', '<p>' . implode( '<br/>', $message->error ) . '</p>', 'type=error' );
 		}
 
@@ -295,15 +305,17 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			}
 
 			$child = $record->create_child_record();
-			$status = $child->queue_import();
 			$child->update_meta( 'interactive', true );
-			$child->finalize();
-			$child->process_posts();
+			$status = $child->queue_import();
 
 			if ( is_wp_error( $status ) ) {
 				$errors[ $record->id ] = $status;
 				continue;
 			}
+
+			$child->finalize();
+			$child->process_posts();
+			$success[ $record->id ] = $record;
 		}
 
 		return array( $success, $errors );

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -218,7 +218,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 	 */
 	private function action_notice( $action, $ids = array(), $error = null ) {
 		if ( $ids && ! is_array( $ids ) ) {
-			$ids    = explode( ',', $ids );
+			$ids = explode( ',', $ids );
 		}
 
 		$errors = array();


### PR DESCRIPTION
See: https://central.tri.be/issues/66891