### PR TITLE
Unhook iCal deactivation hook so recurring imports aren't purged

### DIFF
--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -135,6 +135,11 @@ class Tribe__Events__Aggregator {
 
 		// Notify users about expiring Facebook Token if oauth is enabled
 		add_action( 'plugins_loaded', array( $this, 'setup_notices' ), 11 );
+
+		// Let's prevent events-importer-ical from DESTROYING its saved recurring imports when it gets deactivated
+		if ( class_exists( 'Tribe__Events__Ical_Importer__Main' ) ) {
+			remove_action( 'deactivate_' . plugin_basename( Tribe__Events__Ical_Importer__Main::$plugin_path . 'the-events-calendar-ical-importer.php' ), 'tribe_events_ical_deactivate' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Events Importer: iCal does a silly thing. When you deactivate the plugin, it purges the saved recurring imports with a deactivation hook.  This PR removes iCal's action that does the purging.

See: https://central.tri.be/issues/61940#note-15