### PR TITLE
Use activity() to avoid calling methods on null | spotfix

### DIFF
--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -234,7 +234,7 @@ class Tribe__Events__Aggregator__Record__Queue {
 			$activity = $this->record->insert_posts( $this->next );
 		}
 
-		$this->activity = $this->activity->merge( $activity );
+		$this->activity = $this->activity()->merge( $activity );
 
 		return $this->save();
 	}


### PR DESCRIPTION
`activity` property may be null.