### PR TITLE
Prefer the activity() getter function over naked access to the (possibly null) property

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -365,8 +365,10 @@ class Tribe__Events__Aggregator__Cron {
 			$queue = $record->process_posts();
 
 			if ( ! is_wp_error( $queue ) ) {
+				/** @var Tribe__Events__Aggregator__Record__Queue $queue */
 				$this->log( 'debug', sprintf( 'Record (%d) has processed queue ', $queue->record->id ) );
-				$activity = $queue->activity->get();
+				$activity = $queue->activity()->get();
+
 				foreach ( $activity as $key => $actions ) {
 					foreach ( $actions as $action => $ids ) {
 						if ( empty( $ids ) ) {


### PR DESCRIPTION
`$queue->activity` may be null; prefer `$queue->activity()` instead. Thanks to Jeff for [catching this!](https://tribe.slack.com/archives/quality-assurance/p1475188920001344)