### PR TITLE
get_daily_events() is an instance method, call it appropriately | spotfix

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -751,7 +751,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			// Populate complete date range including leading/trailing days from adjacent months
 			while ( $date <= $this->final_grid_date ) {
 
-				$day_events = self::get_daily_events( $date );
+				$day_events = $this->get_daily_events( $date );
 				$day = (int) substr( $date, - 2 );
 
 				$prev_month = (int) substr( $date, 5, 2 ) < (int) substr( $this->requested_date, 5, 2 );


### PR DESCRIPTION
`get_daily_events()` is not a static method.