### PR TITLE
take slug translation of post slug into account

### DIFF
--- a/src/Tribe/Integrations/WPML/Rewrites.php
+++ b/src/Tribe/Integrations/WPML/Rewrites.php
@@ -121,13 +121,13 @@ class Tribe__Events__Integrations__WPML__Rewrites {
 		return preg_match( '/^' . $this->organizer_slug . '/', $candidate_rule );
 	}
 
-	private function get_post_slug_translations_for( $type ) {
+	protected function get_post_slug_translations_for( $type ) {
 		/** @var SitePress $sitepress */
 		global $sitepress;
 
 		$post_slug_translation_settings = $sitepress->get_setting( 'posts_slug_translation', array() );
 
-		if ( ! isset( $post_slug_translation_settings['types'][ $type ] ) || ! $post_slug_translation_settings['types'][ $type ]
+		if ( empty( $post_slug_translation_settings['types'][ $type ] )
 		     || ! $sitepress->is_translated_post_type( $type )
 		) {
 			return array();

--- a/src/Tribe/Integrations/WPML/Utils.php
+++ b/src/Tribe/Integrations/WPML/Utils.php
@@ -72,7 +72,7 @@ class Tribe__Events__Integrations__WPML__Utils {
 	/**
 	 * Fetches the optional post slug translations for a post type.
 	 *
-	 * WPML allows transalating a custom post type slug  when the String Translation
+	 * WPML allows translating a custom post type slug  when the String Translation
 	 * accessory plugin is active.
 	 *
 	 * @param string $type The custom post type slug.
@@ -82,7 +82,7 @@ class Tribe__Events__Integrations__WPML__Utils {
 	 *               the post type slug is not translated. Please note that the translation does not
 	 *               include the original slug.
 	 */
-	public static function get_post_slug_translations_for( $POSTTYPE ) {
+	public static function get_post_slug_translations_for( $type ) {
 		/** @var SitePress $sitepress */
 		global $sitepress;
 

--- a/src/Tribe/Integrations/WPML/Utils.php
+++ b/src/Tribe/Integrations/WPML/Utils.php
@@ -19,24 +19,21 @@ class Tribe__Events__Integrations__WPML__Utils {
 	 * @return array
 	 */
 	public static function get_wpml_i18n_strings( array $strings, $locale = null, array $domains = null ) {
-		array_multisort($strings);
-		$cache = new Tribe__Cache();
-		$cache_key = 'wpml-i18n-strings_' . serialize($strings);
+		array_multisort( $strings );
+		$cache     = new Tribe__Cache();
+		$cache_key = 'wpml-i18n-strings_' . serialize( $strings );
 
 		$cached_translations = $cache->get_transient( $cache_key, 'wpml_updates' );
 
-		if (!empty( $cached_translations)) {
+		if ( ! empty( $cached_translations ) ) {
 			return $cached_translations;
 		}
 
-		$tec = Tribe__Events__Main::instance();
-		$domains = apply_filters (
-			'tribe_events_rewrite_i18n_domains',
-			array(
-				'default'             => true, // Default doesn't need file path
-				'the-events-calendar' => $tec->pluginDir . 'lang/',
-			)
-		);
+		$tec     = Tribe__Events__Main::instance();
+		$domains = apply_filters( 'tribe_events_rewrite_i18n_domains', array(
+			'default'             => true, // Default doesn't need file path
+			'the-events-calendar' => $tec->pluginDir . 'lang/',
+		) );
 
 		/** @var SitePress $sitepress */
 		global $sitepress;
@@ -69,5 +66,48 @@ class Tribe__Events__Integrations__WPML__Utils {
 		$cache->set_transient( $cache_key, $translations, 0, 'wpml_updates' );
 
 		return $translations;
+	}
+
+
+	/**
+	 * Fetches the optional post slug translations for a post type.
+	 *
+	 * WPML allows transalating a custom post type slug  when the String Translation
+	 * accessory plugin is active.
+	 *
+	 * @param string $type The custom post type slug.
+	 *
+	 * @return array An associative array in the format [ <language> => <translation> ] of
+	 *               translations for the slug or an empty array if String Translation is not active or
+	 *               the post type slug is not translated. Please note that the translation does not
+	 *               include the original slug.
+	 */
+	public static function get_post_slug_translations_for( $POSTTYPE ) {
+		/** @var SitePress $sitepress */
+		global $sitepress;
+
+		$post_slug_translation_settings = $sitepress->get_setting( 'posts_slug_translation', array() );
+
+		if ( empty( $post_slug_translation_settings['types'][ $type ] )
+		     || ! $sitepress->is_translated_post_type( $type )
+		) {
+			return array();
+		}
+
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+
+		$results = $wpdb->get_results( $wpdb->prepare( "
+						SELECT t.language, t.value
+						FROM {$wpdb->prefix}icl_string_translations t
+							JOIN {$wpdb->prefix}icl_strings s ON t.string_id = s.id
+						WHERE s.name = %s AND t.status = %d
+					", 'URL slug: ' . $type, ICL_TM_COMPLETE ) );
+
+		if ( empty( $results ) ) {
+			return array();
+		}
+
+		return array_combine( wp_list_pluck( $results, 'language' ), wp_list_pluck( $results, 'value' ) );
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/63262#note-19

This PR makes sure we take WPML slug translation into account when generating our rewrite rules.
The `$wpdb` low level access is to circumvent the lack of a function to do so.