### PR TITLE
Remove duplicate meta for Org and Venue title

### DIFF
--- a/src/Tribe/Integrations/WPML/Defaults.php
+++ b/src/Tribe/Integrations/WPML/Defaults.php
@@ -139,7 +139,6 @@ class Tribe__Events__Integrations__WPML__Defaults {
 			'_VenueZip',
 			'_VenuePhone',
 			'_VenueURL',
-			'_OrganizerOrganizer',
 			'_OrganizerEmail',
 			'_OrganizerWebsite',
 			'_OrganizerPhone',

--- a/src/Tribe/Integrations/WPML/Defaults.php
+++ b/src/Tribe/Integrations/WPML/Defaults.php
@@ -129,7 +129,6 @@ class Tribe__Events__Integrations__WPML__Defaults {
 			'_EventTimezone',
 			'_EventTimezoneAbbr',
 			'_EventRecurrenceRRULE',
-			'_VenueVenue',
 			'_VenueCountry',
 			'_VenueAddress',
 			'_VenueCity',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3580,8 +3580,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					$saved = true;
 				}
 
-				foreach ( $this->organizerTags as $tag ) {
-					if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
+				if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
+					foreach ( $this->organizerTags as $tag ) {
 						$$tag = get_post_meta( $postId, $tag, true );
 					}
 				}
@@ -3595,7 +3595,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			<div id='eventDetails' class="inside eventForm">
 				<table cellspacing="0" cellpadding="0" id="EventInfo" class="OrganizerInfo">
 					<?php
-					$hide_organizer_title = true;
 					$organizer_meta_box_template = apply_filters( 'tribe_events_organizer_meta_box_template', $this->plugin_path . 'src/admin-views/organizer-meta-box.php' );
 					if ( ! empty( $organizer_meta_box_template ) ) {
 						include( $organizer_meta_box_template );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3580,8 +3580,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					$saved = true;
 				}
 
-				if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
-					foreach ( $this->organizerTags as $tag ) {
+				foreach ( $this->organizerTags as $tag ) {
+					if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
 						$$tag = get_post_meta( $postId, $tag, true );
 					}
 				}
@@ -3595,6 +3595,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			<div id='eventDetails' class="inside eventForm">
 				<table cellspacing="0" cellpadding="0" id="EventInfo" class="OrganizerInfo">
 					<?php
+					$hide_organizer_title = true;
 					$organizer_meta_box_template = apply_filters( 'tribe_events_organizer_meta_box_template', $this->plugin_path . 'src/admin-views/organizer-meta-box.php' );
 					if ( ! empty( $organizer_meta_box_template ) ) {
 						include( $organizer_meta_box_template );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -169,7 +169,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		);
 
 		public $venueTags = array(
-			'_VenueVenue',
 			'_VenueCountry',
 			'_VenueAddress',
 			'_VenueCity',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -182,7 +182,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		);
 
 		public $organizerTags = array(
-			'_OrganizerOrganizer',
 			'_OrganizerEmail',
 			'_OrganizerWebsite',
 			'_OrganizerPhone',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3580,8 +3580,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					$saved = true;
 				}
 
-				foreach ( $this->organizerTags as $tag ) {
-					if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
+				if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
+					$organizer_title = apply_filters( 'the_title', $post->post_title );
+					foreach ( $this->organizerTags as $tag ) {
 						$$tag = get_post_meta( $postId, $tag, true );
 					}
 				}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3534,8 +3534,14 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					$saved = true;
 				}
 
+				$is_saved = $event->ID && isset( $saved ) && $saved;
+
+				if ( $is_saved ) {
+					$venue_title = apply_filters( 'the_title', $post->post_title );
+				}
+
 				foreach ( $this->venueTags as $tag ) {
-					if ( $event->ID && isset( $saved ) && $saved ) { //if there is a post AND the post has been saved at least once.
+					if ( $is_saved ) { //if there is a post AND the post has been saved at least once.
 						$$tag = esc_html( get_post_meta( $event->ID, $tag, true ) );
 					} else {
 						$cleaned_tag = str_replace( '_Venue', '', $tag );

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -280,6 +280,9 @@ class Tribe__Events__Organizer {
 			unset( $data['FeaturedImage'] );
 		}
 
+		// the organizer name is saved in the the post_title
+		unset($data['Organizer']);
+
 		foreach ( $data as $key => $var ) {
 			update_post_meta( $organizerId, '_Organizer' . $key, $var );
 		}

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -281,7 +281,7 @@ class Tribe__Events__Organizer {
 		}
 
 		// the organizer name is saved in the the post_title
-		unset($data['Organizer']);
+		unset( $data['Organizer'] );
 
 		foreach ( $data as $key => $var ) {
 			update_post_meta( $organizerId, '_Organizer' . $key, $var );

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -294,6 +294,8 @@ class Tribe__Events__Venue {
 			unset( $data['FeaturedImage'] );
 		}
 
+		unset( $data['Venue'] );
+
 		foreach ( $data as $key => $var ) {
 			update_post_meta( $venue_id, '_Venue' . $key, $var );
 		}

--- a/src/admin-views/organizer-meta-box.php
+++ b/src/admin-views/organizer-meta-box.php
@@ -23,7 +23,7 @@ do_action( 'tribe_events_organizer_before_metabox', $post );
 	<tr class="organizer">
 		<td><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), tribe_get_organizer_label_singular() ); ?></td>
 		<td>
-			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='organizer[Organizer]' size='25' value='<?php echo isset( $_OrganizerOrganizer ) ? esc_attr( $_OrganizerOrganizer ) : ''; ?>' />
+			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='organizer[Organizer]' size='25' value='<?php echo isset( $organizer_title ) ? esc_attr( $organizer_title ) : ''; ?>' />
 		</td>
 	</tr>
 <?php endif; ?>

--- a/src/admin-views/organizer-meta-box.php
+++ b/src/admin-views/organizer-meta-box.php
@@ -19,6 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 do_action( 'tribe_events_organizer_before_metabox', $post );
 ?>
+<?php if ( empty( $hide_organizer_title ) ): ?>
+	<tr class="organizer">
+		<td><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), tribe_get_organizer_label_singular() ); ?></td>
+		<td>
+			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='organizer[Organizer]' size='25' value='<?php echo isset( $_OrganizerOrganizer ) ? esc_attr( $_OrganizerOrganizer ) : ''; ?>' />
+		</td>
+	</tr>
+<?php endif; ?>
 <tr class="organizer">
 	<td><?php esc_html_e( 'Phone:', 'the-events-calendar' ); ?></td>
 	<td>

--- a/src/admin-views/organizer-meta-box.php
+++ b/src/admin-views/organizer-meta-box.php
@@ -19,14 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 do_action( 'tribe_events_organizer_before_metabox', $post );
 ?>
-<?php if ( empty( $hide_organizer_title ) ): ?>
-	<tr class="organizer">
-		<td><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), tribe_get_organizer_label_singular() ); ?></td>
-		<td>
-			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='organizer[Organizer]' size='25' value='<?php echo isset( $_OrganizerOrganizer ) ? esc_attr( $_OrganizerOrganizer ) : ''; ?>' />
-		</td>
-	</tr>
-<?php endif; ?>
 <tr class="organizer">
 	<td><?php esc_html_e( 'Phone:', 'the-events-calendar' ); ?></td>
 	<td>

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tr class="venue">
 		<td class='tribe-table-field-label'><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), tribe_get_venue_label_singular() ); ?></td>
 		<td>
-			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='venue[Venue]' size='25' value='<?php if ( isset( $_VenueVenue ) ) {
-				echo esc_attr( $_VenueVenue );
+			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='venue[Venue]' size='25' value='<?php if ( isset( $venue_title ) ) {
+				echo esc_attr( $venue_title );
 			} ?>' />
 		</td>
 	</tr>


### PR DESCRIPTION
Ticket https://central.tri.be/issues/25084

This PR removes the use in read and write operations of the `OrganizerOrganizer` meta field when creating organizers; the same I've applie to venues due to similarity removing use of the `VenueVenue` meta field.

Note the consequent PR here: https://github.com/moderntribe/events-eventbrite/pull/137