### PR TITLE
Prevent notice when executing CSV import and created|updated|skipped = 0

### DIFF
--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -362,9 +362,17 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$created = $importer->get_new_post_count();
 		$skipped = $importer->get_skipped_row_count();
 
-		$this->meta['activity']->add( 'updated', $this->meta['content_type'], array_fill( 0, $updated, 1 ) );
-		$this->meta['activity']->add( 'created', $this->meta['content_type'], array_fill( 0, $created, 1 ) );
-		$this->meta['activity']->add( 'skipped', $this->meta['content_type'], array_fill( 0, $skipped, 1 ) );
+		if ( $updated ) {
+			$this->meta['activity']->add( 'updated', $this->meta['content_type'], array_fill( 0, $updated, 1 ) );
+		}
+
+		if ( $created ) {
+			$this->meta['activity']->add( 'created', $this->meta['content_type'], array_fill( 0, $created, 1 ) );
+		}
+
+		if ( $skipped ) {
+			$this->meta['activity']->add( 'skipped', $this->meta['content_type'], array_fill( 0, $skipped, 1 ) );
+		}
 
 		$log['updated']  += $updated;
 		$log['created']  += $created;


### PR DESCRIPTION
Found this while hunting down a CSV state/province import bug