### PR TITLE
When rendering the state drop-down, match by abbreviation OR full name

### DIFF
--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -92,7 +92,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php
 			foreach ( Tribe__View_Helpers::loadStates() as $abbr => $fullname ) {
 				echo '<option value="' . esc_attr( $abbr ) . '"';
-				selected( ( ( $_VenueStateProvince != - 1 ? $_VenueStateProvince : $currentState ) == $abbr ) );
+
+				$state = -1 !== $_VenueStateProvince ? $_VenueStateProvince : $currentState;
+
+				// support matching by state abbreviation OR fullname.
+				// NOTE: converts to abbreviation on save
+				selected( ( $state === $abbr || $state === $fullname ) );
 				echo '>' . esc_html( $fullname ) . '</option>';
 			}
 			?>


### PR DESCRIPTION
*NOTE:* This should be re-pull-requested against `release/4.3.1` when that branch has been created and is ready for use.

See: https://central.tri.be/issues/67820