### PR TITLE
Upgrade/compatibility fixes | spotfix

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -353,7 +353,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Setup the activation page only if the relevant class exists (in some edge cases, if another
 			// plugin hosting an earlier version of tribe-common is already active we could hit fatals
 			// if we don't take this precaution).
-
+			//
 			// @todo remove class_exists() test once enough time has elapsed and the risk has reduced
 			if ( empty( $this->activation_page ) && class_exists( 'Tribe__Admin__Activation_Page' ) ) {
 				$this->activation_page = new Tribe__Admin__Activation_Page( array(

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -350,7 +350,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @return Tribe__Admin__Activation_Page
 		 */
 		public function activation_page() {
-			if ( empty( $this->activation_page ) ) {
+			// Setup the activation page only if the relevant class exists (in some edge cases, if another
+			// plugin hosting an earlier version of tribe-common is already active we could hit fatals
+			// if we don't take this precaution).
+
+			// @todo remove class_exists() test once enough time has elapsed and the risk has reduced
+			if ( empty( $this->activation_page ) && class_exists( 'Tribe__Admin__Activation_Page' ) ) {
 				$this->activation_page = new Tribe__Admin__Activation_Page( array(
 					'slug'                  => 'the-events-calendar',
 					'activation_transient'  => '_tribe_events_activation_redirect',
@@ -595,10 +600,13 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Preview handling
 			add_action( 'template_redirect', array( Tribe__Events__Revisions__Preview::instance(), 'hook' ) );
 
-			/**
-			 * Register Notices
-			 */
-			tribe_notice( 'archive-slug-conflict', array( $this, 'render_notice_archive_slug_conflict' ), 'dismiss=1&type=error' );
+			// Register slug conflict notices (but test to see if tribe_notice() is indeed available, in case another plugin
+			// is hosting an earlier version of tribe-common which is already active)
+			//
+			// @todo remove this safety check when we're confident the risk has diminished
+			if ( function_exists( 'tribe_notice' ) ) {
+				tribe_notice( 'archive-slug-conflict', array( $this, 'render_notice_archive_slug_conflict' ), 'dismiss=1&type=error' );
+			}
 
 			/**
 			 * Expire notices


### PR DESCRIPTION
Adds safety checks to avoid possible _plugin cannot be activated due to a fatal error_ problems when ET 4.2.7 is active and an attempt is made to activate TEC 4.3. Bit of an edge case, but leaving this here so we can merge if we want to.