### PR TITLE
Fetch locale translation for bases

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -322,6 +322,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Resolved the support for translated event category archive slug that could lead to broken links on the front-end while using WPML [62018]
 * Fix - Resolved a bug where searching for past events in the List view would always yield no results [61863]
 * Fix - Resolved an issue where long file names would break plugin updates on some Windows installations [62552]
+* Fix - Resolved an issue where the `/all` link on recurring events on non English websites could be broken [68062] 
 * Tweak - Improve `tribe_create_event` documentation (Props to Keith) [44871]
 
 = [4.3.0.1] 2016-10-14 =

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -112,15 +112,15 @@ defined( 'WPINC' ) or die;
 			do_action( 'tribe_events_pre_rewrite', $this );
 
 			/**
-		 * Provides an opportunity to modify The Events Calendar's rewrite rules before they
-		 * are merged in to WP's own rewrite rules.
-		 *
-		 * @param array $events_rewrite_rules
-		 * @param Tribe__Events__Rewrite $tribe_rewrite
-			 */
-		$this->rules = apply_filters( 'tribe_events_rewrite_rules_custom', $this->rules, $this );
+			 * Provides an opportunity to modify The Events Calendar's rewrite rules before they
+			 * are merged in to WP's own rewrite rules.
+			 *
+			 * @param array $events_rewrite_rules
+			 * @param Tribe__Events__Rewrite $tribe_rewrite
+				 */
+			$this->rules = apply_filters( 'tribe_events_rewrite_rules_custom', $this->rules, $this );
 
-		$wp_rewrite->rules = $this->rules + $wp_rewrite->rules;
+			$wp_rewrite->rules = $this->rules + $wp_rewrite->rules;
 		}
 
 		/**
@@ -272,14 +272,21 @@ defined( 'WPINC' ) or die;
 			// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)
 			$bases = array_map( 'array_unique', $bases );
 
+
 			// By default we always have `en_US` to avoid 404 with older URLs
-			$languages = apply_filters( 'tribe_events_rewrite_i18n_languages', array_unique( array( 'en_US', get_locale() ) ) );
+			$current_locale = get_locale();
+			$languages      = apply_filters( 'tribe_events_rewrite_i18n_languages', array_unique( array( 'en_US', $current_locale ) ) );
 
 			// By default we load the Default and our plugin domains
 			$domains = apply_filters( 'tribe_events_rewrite_i18n_domains', array(
 				'default' => true, // Default doesn't need file path
 				'the-events-calendar' => $tec->plugin_dir . 'lang/',
 			) );
+
+			if ( $current_locale !== 'en_US' ) {
+				// get the translated version of each base in the site locale
+				$bases = $tec->get_i18n_strings( $bases, $languages, $domains, $current_locale );
+			}
 
 			/**
 			 * Use `tribe_events_rewrite_i18n_slugs_raw` to modify the raw version of the l10n slugs bases.


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/68062

This PR handles the case where we want to suport translated version of our rewrite bases, `/all` in the ticket instance but it would apply to *any*, when a site language is not English.  

What we were previously relying on WPML to do can be done by WPML *and* the available translations.  
In case you are wondering the WPML integration fires off on the `tribe_events_rewrite_i18n_slugs_raw` filter.