### PR TITLE
Better messaging/use of usage limits

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -280,7 +280,6 @@ class Tribe__Events__Aggregator__Cron {
 
 		$records = Tribe__Events__Aggregator__Records::instance();
 		$service = Tribe__Events__Aggregator__Service::instance();
-		$origins = null;
 
 		$query = $records->query( array(
 			'post_status' => Tribe__Events__Aggregator__Records::$status->schedule,
@@ -305,12 +304,8 @@ class Tribe__Events__Aggregator__Cron {
 				continue;
 			}
 
-			if ( ! $origins ) {
-				$origins = (object) $service->get_origins();
-			}
-
 			// if there are no remaining imports for today, log that and skip
-			if ( isset( $origins->usage->import->remaining ) && 0 >= $origins->usage->import->remaining ) {
+			if ( $service->is_over_limit( true ) ) {
 				$this->log( 'debug', sprintf( $service->get_service_message( 'error:usage-limit-exceeded' ) . ' (%1$d)', $record->id ) );
 				$record->update_meta( 'last_import_status', 'error:usage-limit-exceeded' );
 				continue;

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -393,11 +393,105 @@ class Tribe__Events__Aggregator__Service {
 	 *
 	 * @return string
 	 */
-	public function get_service_message( $key ) {
+	public function get_service_message( $key, $args = array() ) {
 		if ( empty( $this->service_messages[ $key ] ) ) {
 			return __( 'Unknown service message', 'the-events-calendar' );
 		}
 
-		return $this->service_messages[ $key ];
+		return vsprintf( $this->service_messages[ $key ], $args );
+	}
+
+	/**
+	 * Returns usage limits
+	 *
+	 * @param string $type Type of limits to return
+	 * @param boolean $ignore_cache Whether or not cache should be ignored when fetching the value
+	 *
+	 * @return array
+	 */
+	public function get_limit( $type, $ignore_cache = false ) {
+		static $origins;
+
+		if ( ! $origins || $ignore_cache ) {
+			$origins = (object) $this->get_origins();
+		}
+
+		if ( ! isset( $origins->limit->$type ) ) {
+			return 0;
+		}
+
+		return $origins->limit->$type;
+	}
+
+	/**
+	 * Returns limit usage
+	 *
+	 * @param string $type Type of usage to return
+	 * @param boolean $ignore_cache Whether or not cache should be ignored when fetching the value
+	 *
+	 * @return array
+	 */
+	public function get_usage( $type, $ignore_cache = false ) {
+		static $origins;
+
+		if ( ! $origins || $ignore_cache ) {
+			$origins = (object) $this->get_origins();
+		}
+
+		if ( ! isset( $origins->usage->$type ) ) {
+			return array(
+				'used' => 0,
+				'remaining' => 0,
+			);
+		}
+
+		return $origins->usage->$type;
+	}
+
+	/**
+	 * Returns whether or not the limit has been exceeded
+	 *
+	 * @param boolean $ignore_cache Whether or not cache should be ignored when fetching the value
+	 *
+	 * @return boolean
+	 */
+	public function is_over_limit( $ignore_cache = false ) {
+		$limits = $this->get_usage( 'import', $ignore_cache );
+
+		return isset( $limits->remaining ) && 0 >= $limits->remaining;
+	}
+
+	/**
+	 * Returns the currently used imports for the day
+	 *
+	 * @param boolean $ignore_cache Whether or not cache should be ignored when fetching the value
+	 *
+	 * @return int
+	 */
+	public function get_limit_usage( $ignore_cache = false ) {
+		$limits = $this->get_usage( 'import', $ignore_cache );
+
+		if ( isset( $limits->used ) ) {
+			return $limits->used;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Returns the remaining imports for the day
+	 *
+	 * @param boolean $ignore_cache Whether or not cache should be ignored when fetching the value
+	 *
+	 * @return int
+	 */
+	public function get_limit_remaining( $ignore_cache = false ) {
+		$limits = $this->get_usage( 'import', $ignore_cache );
+
+		if ( isset( $limits->remaining ) ) {
+			return $limits->remaining;
+		}
+
+		return 0;
 	}
 }

--- a/src/admin-views/aggregator/status.php
+++ b/src/admin-views/aggregator/status.php
@@ -48,9 +48,10 @@ $indicator_icons = array(
 			return ob_get_clean();
 		}
 
-		$import_limit = Tribe__Events__Aggregator::instance()->get_daily_limit();
-		$import_available = Tribe__Events__Aggregator::instance()->get_daily_limit_available();
-		$import_count = $import_limit - $import_available;
+		$service = Tribe__Events__Aggregator__Service::instance();
+		$import_limit = $service->get_limit( 'import' );
+		$import_available = $service->get_limit_remaining();
+		$import_count = $service->get_limit_usage();
 
 		$indicator = 'good';
 		$notes = '&nbsp;';


### PR DESCRIPTION
* Make sure we don't fetch cached usage limits when creating a schedule child - we always want fresh usage info
* Observe the usage limits when attempting to run a schedule interactively
* Resolve issues with the EA usage status on the Help page

See: https://central.tri.be/issues/68286#note-8