### PR TITLE
Remove two null overrides that were there for debug purposes

### DIFF
--- a/src/Tribe/Aggregator/Meta_Box.php
+++ b/src/Tribe/Aggregator/Meta_Box.php
@@ -57,15 +57,14 @@ class Tribe__Events__Aggregator__Meta_Box {
 			$last_import = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$updated_key, true );
 			$source = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$source_key, true );
 			$origin = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$origin_key, true );
-			$source = null;
-			$last_import = null;
 		} else {
 			$last_import = $record->post->post_modified;
 			$source_info = $record->get_source_info();
 			$source = $source_info['title'];
-			$origin = $aggregator->api( 'origins' )->get_name( $record->origin );
+			$origin = $record->origin;
 		}
 
+		$origin = $aggregator->api( 'origins' )->get_name( $origin );
 		$datepicker_format = Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
 		$last_import = $last_import ? tribe_format_date( $last_import, true, $datepicker_format . ' h:i a' ) : null;
 		$settings_link = Tribe__Settings::instance()->get_url( array( 'tab' => 'imports' ) );


### PR DESCRIPTION
Additionally, make sure the origin gets pretty-fied.

See: https://central.tri.be/issues/68288