### PR TITLE
removed redundant meta key

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -712,7 +712,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
 					'do_not_inject_date'     => true,
-					'meta_key'               => '_EventStartDate',
 					'orderby'                => array(
 						'menu_order' => 'ASC',
 						'meta_value' => 'ASC',

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -712,10 +712,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
 					'do_not_inject_date'     => true,
-					'orderby'                => array(
-						'menu_order' => 'ASC',
-						'meta_value' => 'ASC',
-					),
+					'orderby'                => 'post__in',
 				), $this->args
 			);
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67495

This PR removes the `_EventStartDate` query args from the query.
At that point the events have been already pruned and sorted by the `_EventStartDate` meta and doing it again causes those that start at the start of day cutoff to "disappear".

This could very much use a second pair of eyes.