### PR TITLE
Use 'tribe-event-featured' CSS class for featured events | #65895

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -627,6 +627,11 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$classes[] = 'tribe-events-last';
 		}
 
+		// Mark 'featured' events
+		if ( tribe( 'tec.featured_events' )->is_featured( $event_id ) ) {
+			$classes[] = 'tribe-event-featured';
+		}
+
 		$classes = apply_filters( 'tribe_events_event_classes', $classes );
 		if ( $echo ) {
 			echo implode( ' ', $classes );


### PR DESCRIPTION
By default, apply `.tribe-event-featured` if the event is featured.

https://central.tri.be/issues/65895