### PR TITLE
Fix oversight where the featured img HTML was returned twice | #65895

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -906,7 +906,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 * @param bool $link
 		 */
 		if ( ! empty( $featured_image ) && apply_filters( 'tribe_event_featured_image_link', $link ) ) {
-			$featured_image .= '<a href="' . esc_url( tribe_get_event_link( $post_id ) ) . '">' . $featured_image . '</a>';
+			$featured_image = '<a href="' . esc_url( tribe_get_event_link( $post_id ) ) . '">' . $featured_image . '</a>';
 		}
 
 		/**


### PR DESCRIPTION
Addresses Leah's feedback [here](https://tribe.slack.com/archives/products-dev/p1478656237009966) - stupid oversight in a change I made yesterday :dunce:

https://central.tri.be/issues/65895