### PR TITLE
Translate the main events page text (Settings > Reading) | #38757

### DIFF
--- a/src/Tribe/Admin/Front_Page_View.php
+++ b/src/Tribe/Admin/Front_Page_View.php
@@ -13,8 +13,9 @@ class Tribe__Events__Admin__Front_Page_View {
 				'localize' => array(
 					'name' => 'tribe_events_front_page_setting',
 					'data' => array(
-						'enabled' => (bool) tribe_get_option( 'front_page_event_archive', false ),
-						'check'   => wp_create_nonce( 'events_front_page_setting' ),
+						'enabled'           => (bool) tribe_get_option( 'front_page_event_archive', false ),
+						'check'             => wp_create_nonce( 'events_front_page_setting' ),
+						'events_page_label' => _x( 'Main events page', 'Static front page setting', 'the-events-calendar' )
 					),
 				),
 			)

--- a/src/Tribe/Admin/Front_Page_View.php
+++ b/src/Tribe/Admin/Front_Page_View.php
@@ -15,7 +15,7 @@ class Tribe__Events__Admin__Front_Page_View {
 					'data' => array(
 						'enabled'           => (bool) tribe_get_option( 'front_page_event_archive', false ),
 						'check'             => wp_create_nonce( 'events_front_page_setting' ),
-						'events_page_label' => _x( 'Main events page', 'Static front page setting', 'the-events-calendar' )
+						'events_page_label' => esc_html_x( 'Main events page', 'Static front page setting', 'the-events-calendar' ),
 					),
 				),
 			)


### PR DESCRIPTION
Follow up: ensure a piece of text used by our JS is localized.

https://central.tri.be/issues/38757