### PR TITLE
Avoid breakages when front-page-events are enabled alongside Community Events

### DIFF
--- a/src/Tribe/Front_Page_View.php
+++ b/src/Tribe/Front_Page_View.php
@@ -21,8 +21,10 @@ class Tribe__Events__Front_Page_View {
 	 * @param WP_Query $query
 	 */
 	public function parse_query( WP_Query $query ) {
-		if ( ! $query->is_main_query() || ! $query->is_home() ) {
-			return $query;
+		// We're only interested in the main query (when it runs in relation to the site homepage),
+		// we also need to make an exception for compatibility with Community Events (WP_Route)
+		if ( ! $query->is_main_query() || ! $query->is_home() || $query->get( 'WP_Route' ) ) {
+			return;
 		}
 
 		// We don't need this to run again after this point


### PR DESCRIPTION
The global `$wp_query` object for CE pages passes the `is_home()` test. This can lead to breakages when front page events are enabled, which this change aims to fix.

https://central.tri.be/issues/38757