### PR TITLE
Update select2 slug for tribe-ea-fields dependencies | spotfix

### DIFF
--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -122,7 +122,7 @@ class Tribe__Events__Aggregator__Page {
 						'underscore',
 						'tribe-bumpdown',
 						'tribe-dependency',
-						'tribe-events-select2',
+						'tribe-select2',
 						'tribe-ea-facebook-login',
 					),
 				),


### PR DESCRIPTION
Further fix in the saga of select2 problems.

See also: https://central.tri.be/issues/69468