### PR TITLE
Supply the datepicker with *full* month names (for the month dropdown)

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2034,7 +2034,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Localize admin
+		 * Localize admin.
+		 *
+		 * Notice that we pass full length month names in the monthNamesShort property:
+		 * this is deliberate and meets a requirement to show full-length months in the
+		 * datepicker's month selector.
 		 *
 		 * @return array
 		 */
@@ -2044,7 +2048,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				'dayNamesShort'   => $this->daysOfWeekShort,
 				'dayNamesMin'     => $this->daysOfWeekMin,
 				'monthNames'      => array_values( $this->monthNames() ),
-				'monthNamesShort' => array_values( $this->monthNames( true ) ),
+				'monthNamesShort' => array_values( $this->monthNames() ),
 				'nextText'        => esc_html__( 'Next', 'the-events-calendar' ),
 				'prevText'        => esc_html__( 'Prev', 'the-events-calendar' ),
 				'currentText'     => esc_html__( 'Today', 'the-events-calendar' ),


### PR DESCRIPTION
Supply the datepicker with _full_ month names in place of short month names (we want the full month names to render in the month selector dropdown within that widget).

No changelog entry added as this is essentially a child of [#66550](https://central.tri.be/issues/66550).

https://central.tri.be/issues/69246 (Item 1)