### PR TITLE
Update add-new-linked post handler to match other changes

### DIFF
--- a/src/admin-views/linked-post-meta-box.php
+++ b/src/admin-views/linked-post-meta-box.php
@@ -13,15 +13,15 @@ $linked_post_name_field = "{$linked_post_container}[{$linked_post_name}][]";
 
 ?>
 <script type="text/template" id="tmpl-tribe-create-<?php echo esc_attr( $this->post_type ); ?>">
-<tbody class="new-<?php echo esc_attr( $this->post_type ); ?>">
-	<tr class="linked-post">
-		<td><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), $this->linked_posts->linked_post_types[ $this->post_type ]['singular_name'] ); ?></td>
-		<td>
-			<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='<?php echo esc_attr( $linked_post_name_field ); ?>' class='linked-post-name <?php echo esc_attr( $this->post_type ); ?>-name' size='25' value='' />
-		</td>
-	</tr>
-	<?php do_action( 'tribe_events_linked_post_new_form', $this->post_type ); ?>
-</tbody>
+	<tbody class="new-<?php echo esc_attr( $this->post_type ); ?>">
+		<tr class="linked-post">
+			<td><?php printf( esc_html__( '%s Name:', 'the-events-calendar' ), $this->linked_posts->linked_post_types[ $this->post_type ]['singular_name'] ); ?></td>
+			<td>
+				<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' name='<?php echo esc_attr( $linked_post_name_field ); ?>' class='linked-post-name <?php echo esc_attr( $this->post_type ); ?>-name' size='25' value='' />
+			</td>
+		</tr>
+		<?php do_action( 'tribe_events_linked_post_new_form', $this->post_type ); ?>
+	</tbody>
 </script>
 
 <script type="text/javascript">

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -325,9 +325,12 @@ jQuery( document ).ready( function( $ ) {
 				fields = $( create_template({}) );
 			}
 
-			section.find( 'tfoot' ).before( fields );
+			// The final <tbody> contains the add new post link, we should add this new selector before that
+			section.find( 'tbody:last' ).before( fields );
 			fields.prepend( dropdown );
-			fields.find( '.chosen' ).chosen().trigger( 'change' );
+
+			tribe_dropdowns.dropdown( fields.find( '.linked-post-dropdown' ) );
+			fields.find( '.linked-post-dropdown' ).trigger( 'change' );
 		});
 
 		section.on( 'change', '.linked-post-dropdown', toggle_linked_post_fields );


### PR DESCRIPTION
Transitioning from Chosen to Select2 for various elements and some other adjustments left the add-new-linked-post functionality broken; this should fix.

Depends on [tribe-common PR 285](https://github.com/moderntribe/tribe-common/pull/285) for access to existing dropdown methods.

[#69686/R125 findings](https://central.tri.be/issues/69686)