### PR TITLE
Use date_i18n() to get the date in the current site timezone | #69686

### DIFF
--- a/src/Tribe/Admin/Event_Meta_Box.php
+++ b/src/Tribe/Admin/Event_Meta_Box.php
@@ -183,7 +183,7 @@ class Tribe__Events__Admin__Event_Meta_Box {
 		}
 
 		// If we don't have a valid start date, assume today's date
-		$this->vars['EventStartDate'] = ( isset( $start ) && $start ) ? $start : date( $datepicker_format );
+		$this->vars['EventStartDate'] = ( isset( $start ) && $start ) ? $start : date_i18n( $datepicker_format );
 		$this->vars['EventStartTime'] = ( isset( $start_time ) && $start_time ? $start_time : null );
 
 		$this->vars['start_timepicker_step'] = $this->get_timepicker_step( 'start' );


### PR DESCRIPTION
When setting up the datepicker, if a date hasn't been selected let's use `date_i18n()` rather than `date()` to avoid discrepancies between the local timezone and UTC.

[#69686/R125 findings](https://central.tri.be/issues/69686)