### PR TITLE
Fix/69835 featured events ajax

### DIFF
--- a/src/Tribe/Featured_Events.php
+++ b/src/Tribe/Featured_Events.php
@@ -75,18 +75,6 @@ class Tribe__Events__Featured_Events {
 	 * @return bool
 	 */
 	public function featured_events_requested() {
-		$featured_request_var = tribe_get_request_var( 'featured', false );
-
-		switch ( strtolower( $featured_request_var ) ) {
-			case 'true':
-				return true;
-				break;
-
-			case 'false':
-				return false;
-				break;
-		}
-
-		return (bool) $featured_request_var;
+		return tribe_is_truthy( tribe_get_request_var( 'featured', false ) );
 	}
 }

--- a/src/Tribe/Featured_Events.php
+++ b/src/Tribe/Featured_Events.php
@@ -67,4 +67,26 @@ class Tribe__Events__Featured_Events {
 
 		return (bool) $query->get( 'featured' );
 	}
+
+	/**
+	 * Indicates if 'featured' is set to a positive value either in the URL query
+	 * or the posted data (if any).
+	 *
+	 * @return bool
+	 */
+	public function featured_events_requested() {
+		$featured_request_var = tribe_get_request_var( 'featured', false );
+
+		switch ( strtolower( $featured_request_var ) ) {
+			case 'true':
+				return true;
+				break;
+
+			case 'false':
+				return false;
+				break;
+		}
+
+		return (bool) $featured_request_var;
+	}
 }

--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -169,7 +169,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 					'post_status'  => $post_status,
 					'eventDate'    => $_POST['eventDate'],
 					'eventDisplay' => 'day',
-					'featured'     => (bool) tribe_get_request_var( 'featured', false ),
+					'featured'     => tribe( 'tec.featured_events' )->featured_events_requested(),
 				);
 
 				Tribe__Events__Main::instance()->displaying = 'day';

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 				'post_type'    => Tribe__Events__Main::POSTTYPE,
 				'post_status'  => $post_status,
 				'paged'        => $tribe_paged,
-				'featured'     => (bool) tribe_get_request_var( 'featured', false ),
+				'featured'     => tribe( 'tec.featured_events' )->featured_events_requested(),
 			);
 
 			// check & set display

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -318,7 +318,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'eventDisplay' => 'month',
 					'eventDate'    => $_POST['eventDate'],
 					'post_status'  => $post_status,
-					'featured'     => (bool) tribe_get_request_var( 'featured', false ),
+					'featured'     => tribe( 'tec.featured_events' )->featured_events_requested(),
 				);
 			}
 


### PR DESCRIPTION
* Adds a helper to test if `'featured'` is set to a positive value (either in the URL query or post data, if any)
* Updates the ajax response methods to use the new helper

https://central.tri.be/issues/69835