### PR TITLE
Remove defaults in the Customizer for links and buttons

### DIFF
--- a/src/Tribe/Customizer/Global_Elements.php
+++ b/src/Tribe/Customizer/Global_Elements.php
@@ -107,12 +107,6 @@ final class Tribe__Events__Customizer__Global_Elements extends Tribe__Customizer
 	}
 
 	public function setup() {
-		$this->defaults = array(
-			'link_color' => '#21759b',
-			'filterbar_color' => '#f5f5f5',
-			'button_color' => '#21759b',
-		);
-
 		$this->arguments = array(
 			'priority'    => 20,
 			'capability'  => 'edit_theme_options',


### PR DESCRIPTION
With the defaults in place, they override all kinds of things. Let's let the theme's stylesheet (and TEC stylesheet) be the base and allow users to set/clear their selections rather than always forcing a default.

See: https://central.tri.be/issues/69755