### PR TITLE
Set the featured image on posts if there is an image

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1228,7 +1228,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 					continue;
 				}
 
-				if ( isset( $image->status ) && 'created' === $image->status ) {
+				if ( ! empty( $image->post_id ) ) {
 					// Set as featured image
 					$featured_status = set_post_thumbnail( $event['ID'], $image->post_id );
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/69465

This PR fixes a check to make sure we set the featured image on EA imported posts if there is any image; whatever state of import the image is in.