### PR TITLE
Default end date should be based on site timezone | #69686

### DIFF
--- a/src/Tribe/Admin/Event_Meta_Box.php
+++ b/src/Tribe/Admin/Event_Meta_Box.php
@@ -203,7 +203,7 @@ class Tribe__Events__Admin__Event_Meta_Box {
 		}
 
 		// If we don't have a valid end date, assume today's date
-		$this->vars['EventEndDate'] = ( isset( $end ) && $end ) ? $end : date( $datepicker_format );
+		$this->vars['EventEndDate'] = ( isset( $end ) && $end ) ? $end : date_i18n( $datepicker_format );
 		$this->vars['EventEndTime'] = ( isset( $end_time ) && $end_time ? $end_time : null );
 
 		$this->vars['end_timepicker_step'] = $this->get_timepicker_step( 'end' );


### PR DESCRIPTION
Default end time in the event editor was 'today' in UTC, let's use 'today' in the local timezone instead.

https://central.tri.be/issues/69979