### PR TITLE
Allow Venues and Organizers metas to be pre-populated by plugin

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3627,9 +3627,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				}
 
 				foreach ( $this->venueTags as $tag ) {
-					$meta = get_post_meta( $event->ID, $tag, true );
-					if ( ! empty( $meta ) ) {
-						$$tag = esc_html( $meta );
+					if ( metadata_exists( 'post', $event->ID, $tag ) ) {
+						$$tag = esc_html( get_post_meta( $event->ID, $tag, true ) );
 					} else {
 						$cleaned_tag = str_replace( '_Venue', '', $tag );
 						$$tag = call_user_func( array( $this->defaults(), $cleaned_tag ) );
@@ -3675,14 +3674,13 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 				if ( $postId ) {
 
-					if ( $saved ) {
+					if ( $saved ) { //if there is a post AND the post has been saved at least once.
 						$organizer_title = apply_filters( 'the_title', $post->post_title );
 					}
 
 					foreach ( $this->organizerTags as $tag ) {
-						$meta = get_post_meta( $postId, $tag, true );
-						if ( ! empty( $meta ) ) {
-							$$tag = $meta;
+						if ( metadata_exists( 'post', $postId, $tag ) ) {
+							$$tag = get_post_meta( $postId, $tag, true );
 						}
 					}
 				}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3627,8 +3627,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				}
 
 				foreach ( $this->venueTags as $tag ) {
-					if ( $is_saved ) { //if there is a post AND the post has been saved at least once.
-						$$tag = esc_html( get_post_meta( $event->ID, $tag, true ) );
+					$meta = get_post_meta( $event->ID, $tag, true );
+					if ( ! empty( $meta ) ) {
+						$$tag = esc_html( $meta );
 					} else {
 						$cleaned_tag = str_replace( '_Venue', '', $tag );
 						$$tag = call_user_func( array( $this->defaults(), $cleaned_tag ) );
@@ -3672,10 +3673,17 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					$saved = true;
 				}
 
-				if ( $postId && $saved ) { //if there is a post AND the post has been saved at least once.
-					$organizer_title = apply_filters( 'the_title', $post->post_title );
+				if ( $postId ) {
+
+					if ( $is_saved ) {
+						$organizer_title = apply_filters( 'the_title', $post->post_title );
+					}
+
 					foreach ( $this->organizerTags as $tag ) {
-						$$tag = get_post_meta( $postId, $tag, true );
+						$meta = get_post_meta( $postId, $tag, true );
+						if ( ! empty( $meta ) ) {
+							$$tag = $meta;
+						}
 					}
 				}
 			}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3675,7 +3675,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 				if ( $postId ) {
 
-					if ( $is_saved ) {
+					if ( $saved ) {
 						$organizer_title = apply_filters( 'the_title', $post->post_title );
 					}
 


### PR DESCRIPTION
I am currently working on an integration between Polylang and The Event Calendar.

Generally when creating a post translation, we automatically duplicate the post meta in the new translation to avoid a boring manual duplicated work by the end user. In Polylang, this is done by duplicating the post meta and associating them to the 'auto-draft' post.

With the current code for venue and organizer metaboxes, even if the post meta is non empty and has been pre-populated by a plugin, it is not read because the test is not done on the post meta value itself but on the post status. There is a possible workaround for Venues, using the 'tribe_events_default_value_strategy' filter, but I don't like it because it would conflict with any other plugin using the same filter. There is no workaround for Organizers.

I propose to always read post metas when they are not empty (if pre-populated by another plugin such as Polylang).