### PR TITLE
Fix broken 'all' page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.3.4.2] 2016-12-13 =
+
+* Fix - Correct an oversight leading to breakages of the /all/ events archive for Events Calendar PRO users [70662]
+
 = [4.3.4.1] 2016-12-09 =
 
 * Fix - Updates Tribe Common to remove some stray characters that were impacting page layouts (props: @Aetles) [70536]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2375,7 +2375,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// If single and not All for Recurring events From Pro
-			if ( $query->is_single() && 'all' !== $this->displaying ) {
+			if ( $query->is_single() && 'all' !== $display ) {
 				$display = 'single-event';
 			}
 


### PR DESCRIPTION
Fixes a typo/oversight: we need to test against `$display` rather than `$this->displaying`: the latter isn't set until the end of the method.

This change should restore normal behaviour of the `/all/` view. Placing on hold in case we need to re-target to a hotfix branch.

https://central.tri.be/issues/70623