### PR TITLE
Fix/70614 stuck importing notice

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,6 +9,47 @@
     "packages": [],
     "packages-dev": [
         {
+            "name": "antecedent/patchwork",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "698b39d41c1786ef065b3fb3d0a82e9257c36178"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/698b39d41c1786ef065b3fb3d0a82e9257c36178",
+                "reference": "698b39d41c1786ef065b3fb3d0a82e9257c36178",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "http://patchwork2.org/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "time": "2016-08-12 18:56:30"
+        },
+        {
             "name": "bacon/bacon-string-utils",
             "version": "1.1.0",
             "source": {
@@ -63,16 +104,16 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "v4.4.4",
+            "version": "v4.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "cf8cc94647101e02a33d690245896d83d880aea1"
+                "reference": "5c14cff4f955b17d20d088dec1bde61c0539ec74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/cf8cc94647101e02a33d690245896d83d880aea1",
-                "reference": "cf8cc94647101e02a33d690245896d83d880aea1",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/5c14cff4f955b17d20d088dec1bde61c0539ec74",
+                "reference": "5c14cff4f955b17d20d088dec1bde61c0539ec74",
                 "shasum": ""
             },
             "require": {
@@ -118,20 +159,20 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-09-18 12:16:14"
+            "time": "2016-10-30 11:50:56"
         },
         {
             "name": "codeception/codeception",
-            "version": "2.2.5",
+            "version": "2.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "b4729341e469d0f174f3cade85718ff5bf8dd751"
+                "reference": "86770e89d266557c20dd0b1de5390e706f4770c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/b4729341e469d0f174f3cade85718ff5bf8dd751",
-                "reference": "b4729341e469d0f174f3cade85718ff5bf8dd751",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/86770e89d266557c20dd0b1de5390e706f4770c1",
+                "reference": "86770e89d266557c20dd0b1de5390e706f4770c1",
                 "shasum": ""
             },
             "require": {
@@ -149,7 +190,7 @@
                 "symfony/browser-kit": ">=2.7 <4.0",
                 "symfony/console": ">=2.7 <4.0",
                 "symfony/css-selector": ">=2.7 <4.0",
-                "symfony/dom-crawler": ">=2.7 <4.0",
+                "symfony/dom-crawler": ">=2.7.5 <4.0",
                 "symfony/event-dispatcher": ">=2.7 <4.0",
                 "symfony/finder": ">=2.7 <4.0",
                 "symfony/yaml": ">=2.7 <4.0"
@@ -165,7 +206,8 @@
                 "pda/pheanstalk": "~3.0",
                 "php-amqplib/php-amqplib": "~2.4",
                 "predis/predis": "^1.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "squizlabs/php_codesniffer": "~2.0",
+                "vlucas/phpdotenv": "^2.4.0"
             },
             "suggest": {
                 "codeception/specify": "BDD-style code blocks",
@@ -209,20 +251,20 @@
                 "functional testing",
                 "unit testing"
             ],
-            "time": "2016-09-29 01:29:59"
+            "time": "2016-12-05 04:12:24"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.0.4",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "ec21a59414b99501e723b63fd664aa8ead9c5680"
+                "reference": "a795611394b3c05164fd0eb291b492b39339cba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/ec21a59414b99501e723b63fd664aa8ead9c5680",
-                "reference": "ec21a59414b99501e723b63fd664aa8ead9c5680",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/a795611394b3c05164fd0eb291b492b39339cba4",
+                "reference": "a795611394b3c05164fd0eb291b492b39339cba4",
                 "shasum": ""
             },
             "require": {
@@ -267,20 +309,20 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2016-09-04 19:00:06"
+            "time": "2016-11-02 18:11:27"
         },
         {
             "name": "composer/composer",
-            "version": "1.2.1",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "16422c4b1ac4286f7caecf5211136dc073191672"
+                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/16422c4b1ac4286f7caecf5211136dc073191672",
-                "reference": "16422c4b1ac4286f7caecf5211136dc073191672",
+                "url": "https://api.github.com/repos/composer/composer/zipball/7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
+                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
                 "shasum": ""
             },
             "require": {
@@ -344,7 +386,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2016-09-12 09:27:20"
+            "time": "2016-12-06 21:00:51"
         },
         {
             "name": "composer/semver",
@@ -738,16 +780,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
                 "shasum": ""
             },
             "require": {
@@ -785,7 +827,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-11-18 17:47:58"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -891,7 +933,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v5.3.16",
+            "version": "v5.3.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -933,16 +975,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v5.3.16",
+            "version": "v5.3.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "aa685c61c88a69b2e0e86310e65ef5ad2ebf2448"
+                "reference": "050d0ed3e1c0e1d129d73b2eaa14044e46a66f77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/aa685c61c88a69b2e0e86310e65ef5ad2ebf2448",
-                "reference": "aa685c61c88a69b2e0e86310e65ef5ad2ebf2448",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/050d0ed3e1c0e1d129d73b2eaa14044e46a66f77",
+                "reference": "050d0ed3e1c0e1d129d73b2eaa14044e46a66f77",
                 "shasum": ""
             },
             "require": {
@@ -986,7 +1028,7 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "time": "2016-10-02 01:14:47"
+            "time": "2016-11-03 15:25:28"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1098,19 +1140,20 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "1.16.0",
+            "version": "1.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "b0dcc775b80feb5709a71cf57236ef461cdf8c2e"
+                "reference": "9f12066faa3b0e87cab11f29067b0ddcce546d1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/b0dcc775b80feb5709a71cf57236ef461cdf8c2e",
-                "reference": "b0dcc775b80feb5709a71cf57236ef461cdf8c2e",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/9f12066faa3b0e87cab11f29067b0ddcce546d1d",
+                "reference": "9f12066faa3b0e87cab11f29067b0ddcce546d1d",
                 "shasum": ""
             },
             "require": {
+                "antecedent/patchwork": "^2.0",
                 "lucatume/codeception-setup-local": "~1.0",
                 "lucatume/wp-browser-commons": "^1.2.5",
                 "symfony/process": "~2.1",
@@ -1118,7 +1161,9 @@
             },
             "require-dev": {
                 "codeception/codeception": "~2.2",
-                "mikey179/vfsstream": "^1.6"
+                "mikey179/vfsstream": "^1.6",
+                "ofbeaton/console-tester": "^1.1",
+                "site5/phantoman": "^1.1"
             },
             "bin": [
                 "wpcept"
@@ -1128,7 +1173,10 @@
                 "psr-4": {
                     "Codeception\\": "src\\Codeception",
                     "tad\\": "src\\tad"
-                }
+                },
+                "files": [
+                    "src/tad/WPBrowser/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1148,20 +1196,20 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2016-09-05 14:21:20"
+            "time": "2016-12-07 09:34:59"
         },
         {
             "name": "lucatume/wp-browser-commons",
-            "version": "1.2.6",
+            "version": "1.2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser-commons.git",
-                "reference": "652afb100271d5e49a9f014a66d014ab1ee1df0c"
+                "reference": "ed4769d2b908b9f110c83e0e55f4052f18bcb211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser-commons/zipball/652afb100271d5e49a9f014a66d014ab1ee1df0c",
-                "reference": "652afb100271d5e49a9f014a66d014ab1ee1df0c",
+                "url": "https://api.github.com/repos/lucatume/wp-browser-commons/zipball/ed4769d2b908b9f110c83e0e55f4052f18bcb211",
+                "reference": "ed4769d2b908b9f110c83e0e55f4052f18bcb211",
                 "shasum": ""
             },
             "require": {
@@ -1193,7 +1241,7 @@
                 }
             ],
             "description": "Common libraries of the WP-Browser package.",
-            "time": "2016-09-05 12:39:35"
+            "time": "2016-10-31 17:56:30"
         },
         {
             "name": "mikemclin/laravel-wp-password",
@@ -1393,16 +1441,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.4",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
                 "shasum": ""
             },
             "require": {
@@ -1431,7 +1479,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-09-16 13:37:59"
+            "time": "2016-10-31 17:19:45"
         },
         {
             "name": "nb/oxymel",
@@ -1476,16 +1524,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "c0125896dbb151380ab47e96c621741e79623beb"
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c0125896dbb151380ab47e96c621741e79623beb",
-                "reference": "c0125896dbb151380ab47e96c621741e79623beb",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
                 "shasum": ""
             },
             "require": {
@@ -1520,7 +1568,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-10-17 15:23:22"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1623,16 +1671,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -1666,20 +1714,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -1687,10 +1735,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -1728,20 +1777,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.1",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
-                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/903fd6318d0a90b4770a009ff73e4a4e9c437929",
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929",
                 "shasum": ""
             },
             "require": {
@@ -1791,20 +1840,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-26 14:39:29"
+            "time": "2016-11-28 16:00:31"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -1838,7 +1887,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1927,16 +1976,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -1972,20 +2021,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.6.2",
+            "version": "5.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01"
+                "reference": "de164acc2f2bb0b79beb892a36260264b2a03233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de164acc2f2bb0b79beb892a36260264b2a03233",
+                "reference": "de164acc2f2bb0b79beb892a36260264b2a03233",
                 "shasum": ""
             },
             "require": {
@@ -1996,18 +2045,18 @@
                 "ext-xml": "*",
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0.1",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.3",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
                 "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
+                "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
@@ -2028,7 +2077,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.6.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -2054,27 +2103,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-10-25 07:40:25"
+            "time": "2016-12-09 02:48:53"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.0",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.6 || ^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "sebastian/exporter": "^1.2 || ^2.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.4.0"
@@ -2113,7 +2162,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-10-09 07:01:45"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "psr/http-message",
@@ -2353,22 +2402,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -2413,7 +2462,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -2469,28 +2518,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2515,25 +2564,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -2542,7 +2591,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2582,7 +2631,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -2637,21 +2686,21 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~5"
@@ -2659,7 +2708,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2679,20 +2728,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -2704,7 +2753,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2732,7 +2781,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2778,16 +2827,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
@@ -2817,7 +2866,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "seld/cli-prompt",
@@ -2869,16 +2918,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "e827b5254d3e58c736ea2c5616710983d80b0b70"
+                "reference": "19495c181d6d53a0a13414154e52817e3b504189"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/e827b5254d3e58c736ea2c5616710983d80b0b70",
-                "reference": "e827b5254d3e58c736ea2c5616710983d80b0b70",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/19495c181d6d53a0a13414154e52817e3b504189",
+                "reference": "19495c181d6d53a0a13414154e52817e3b504189",
                 "shasum": ""
             },
             "require": {
@@ -2911,7 +2960,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2016-09-14 15:17:56"
+            "time": "2016-11-14 17:59:58"
         },
         {
             "name": "seld/phar-utils",
@@ -2959,16 +3008,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.1.5",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "901319a31c9b3cee7857b4aeeb81b5d64dfa34fc"
+                "reference": "34348c2691ce6254e8e008026f4c5e72c22bb318"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/901319a31c9b3cee7857b4aeeb81b5d64dfa34fc",
-                "reference": "901319a31c9b3cee7857b4aeeb81b5d64dfa34fc",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/34348c2691ce6254e8e008026f4c5e72c22bb318",
+                "reference": "34348c2691ce6254e8e008026f4c5e72c22bb318",
                 "shasum": ""
             },
             "require": {
@@ -2985,7 +3034,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3012,20 +3061,20 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-10-13 13:35:11"
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde"
+                "reference": "1361bc4e66f97b6202ae83f4190e962c624b5e61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f8b1922bbda9d2ac86aecd649399040bce849fde",
-                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde",
+                "url": "https://api.github.com/repos/symfony/config/zipball/1361bc4e66f97b6202ae83f4190e962c624b5e61",
+                "reference": "1361bc4e66f97b6202ae83f4190e962c624b5e61",
                 "shasum": ""
             },
             "require": {
@@ -3065,20 +3114,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-14 20:31:12"
+            "time": "2016-11-03 07:52:58"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d7a5a88178f94dcc29531ea4028ea614e35452d4"
+                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7a5a88178f94dcc29531ea4028ea614e35452d4",
-                "reference": "d7a5a88178f94dcc29531ea4028ea614e35452d4",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a871ba00e0f604dceac64c56c27f99fbeaf4854e",
+                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e",
                 "shasum": ""
             },
             "require": {
@@ -3126,20 +3175,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:10:16"
+            "time": "2016-11-15 23:02:12"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.5",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac"
+                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e1241f275814827c411d922ba8e64cf2a00b2994",
+                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994",
                 "shasum": ""
             },
             "require": {
@@ -3148,7 +3197,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3179,7 +3228,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-03 08:11:03"
         },
         {
             "name": "symfony/debug",
@@ -3240,16 +3289,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "ee9ec9ac2b046462d341e9de7c4346142d335e75"
+                "reference": "9d2c5033ca70ceade8d7584f997a9d3943f0fe5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/ee9ec9ac2b046462d341e9de7c4346142d335e75",
-                "reference": "ee9ec9ac2b046462d341e9de7c4346142d335e75",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/9d2c5033ca70ceade8d7584f997a9d3943f0fe5f",
+                "reference": "9d2c5033ca70ceade8d7584f997a9d3943f0fe5f",
                 "shasum": ""
             },
             "require": {
@@ -3299,20 +3348,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-24 09:47:20"
+            "time": "2016-11-18 21:10:01"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.5",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "bb7395e8b1db3654de82b9f35d019958276de4d7"
+                "reference": "c6b6111f5aae7c58698cdc10220785627ac44a2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/bb7395e8b1db3654de82b9f35d019958276de4d7",
-                "reference": "bb7395e8b1db3654de82b9f35d019958276de4d7",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/c6b6111f5aae7c58698cdc10220785627ac44a2c",
+                "reference": "c6b6111f5aae7c58698cdc10220785627ac44a2c",
                 "shasum": ""
             },
             "require": {
@@ -3328,7 +3377,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3355,20 +3404,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-05 08:37:39"
+            "time": "2016-11-25 12:32:42"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8"
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/889983a79a043dfda68f38c38b6dba092dd49cd8",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
                 "shasum": ""
             },
             "require": {
@@ -3415,20 +3464,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 16:56:28"
+            "time": "2016-10-13 01:43:15"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf"
+                "reference": "a3784111af9f95f102b6411548376e1ae7c93898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/44b499521defddf2eae17a18c811bbdae4f98bdf",
-                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a3784111af9f95f102b6411548376e1ae7c93898",
+                "reference": "a3784111af9f95f102b6411548376e1ae7c93898",
                 "shasum": ""
             },
             "require": {
@@ -3464,20 +3513,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-10-18 04:28:30"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "bc24c8f5674c6f6841f2856b70e5d60784be5691"
+                "reference": "0023b024363dfc0cd21262e556f25a291fe8d7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/bc24c8f5674c6f6841f2856b70e5d60784be5691",
-                "reference": "bc24c8f5674c6f6841f2856b70e5d60784be5691",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0023b024363dfc0cd21262e556f25a291fe8d7fd",
+                "reference": "0023b024363dfc0cd21262e556f25a291fe8d7fd",
                 "shasum": ""
             },
             "require": {
@@ -3513,20 +3562,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:10:16"
+            "time": "2016-11-03 07:52:58"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -3538,7 +3587,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -3572,11 +3621,11 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -3625,16 +3674,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7"
+                "reference": "edbe67e8f729885b55421d5cc58223d48540df07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/edbe67e8f729885b55421d5cc58223d48540df07",
+                "reference": "edbe67e8f729885b55421d5cc58223d48540df07",
                 "shasum": ""
             },
             "require": {
@@ -3685,20 +3734,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-11-18 21:10:01"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.12",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
                 "shasum": ""
             },
             "require": {
@@ -3734,24 +3783,24 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
+            "time": "2016-11-14 16:15:57"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -3760,7 +3809,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -3784,7 +3833,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         },
         {
             "name": "wp-cli/php-cli-tools",

--- a/readme.txt
+++ b/readme.txt
@@ -318,9 +318,9 @@ Please see the changelog for the complete list of changes in this release. Remem
 = [4.3.5] tbd =
 
 * Fix - Fixed comment count and visibility issues due to Event Aggregator records [68297]
-* Fix - Avoid running import notices from stucking in administration area [70614]
 * Fix - Fixed PHP notices and warnings raised when importing .ics files [69960]
 * Fix - Only show link to Venues if Pro is active in List View [69887]
+* Fix - Fixed and issue that would make Event Aggregator importing notices remain stuck in the Import screen [70614]
 
 = [4.3.4.1] 2016-12-09 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.3.5] tbd =
+
+* Fix - Avoid running import notices from stucking in administration area [70614]
+
 = [4.3.4.1] 2016-12-09 =
 
 * Fix - Updates Tribe Common to remove some stray characters that were impacting page layouts (props: @Aetles) [70536]

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -1,0 +1,118 @@
+<?php
+
+
+class Tribe__Events__Aggregator__Record__Queue_Cleaner {
+
+	/**
+	 * @var int The time a record is allowed to stall before having
+	 *          its status set to failed in seconds.
+	 */
+	protected $stall_limit = 1800;
+
+	/**
+	 * Removes duplicate records for the same import ID.
+	 *
+	 * While it makes sense to keep track of past import records it does not make sense
+	 * to keep more than one pending record for the same import ID.
+	 *
+	 * @param Tribe__Events__Aggregator__Record__Abstract $record A record object or a record post ID.
+	 *
+	 * @return int[] An array containing the deleted posts IDs.
+	 */
+	public function remove_duplicate_pending_records_for( Tribe__Events__Aggregator__Record__Abstract $record ) {
+		if ( empty( $record->meta['import_id'] ) ) {
+			return array();
+		}
+
+		$import_id = $record->meta['import_id'];
+
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+
+		$pending_status = Tribe__Events__Aggregator__Records::$status->pending;
+
+		$query = $wpdb->prepare( "SELECT ID
+			FROM {$wpdb->postmeta} pm
+			JOIN {$wpdb->posts} p
+			ON pm.post_id = p.ID
+			WHERE p.post_type = %s
+			AND p.post_status = %s
+			AND pm.meta_key = '_tribe_aggregator_import_id'
+			AND pm.meta_value = %s
+			ORDER BY p.post_modified_gmt DESC", Tribe__Events__Aggregator__Records::$post_type, $pending_status, $import_id );
+
+		$records = $wpdb->get_col( $query );
+		array_shift( $records );
+
+		$deleted = array();
+		foreach ( $records as $to_delete ) {
+			$post = wp_delete_post( $to_delete, true );
+			if ( ! empty( $post ) ) {
+				$deleted[] = $post->ID;
+			}
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * Depending from how long a record has been pending and the allowed lifespan
+	 * update the record status to failed.
+	 *
+	 * @param Tribe__Events__Aggregator__Record__Abstract $record
+	 *
+	 * @return bool If the record status has been set to failed or not.
+	 */
+	public function maybe_fail_stalled_record( Tribe__Events__Aggregator__Record__Abstract $record ) {
+		$pending = Tribe__Events__Aggregator__Records::$status->pending;
+		$failed = Tribe__Events__Aggregator__Records::$status->failed;
+
+		$post_status = $record->post->post_status;
+
+		if ( ! in_array( $post_status, array( $pending, $failed ) ) ) {
+			return false;
+		}
+
+		$id = $record->post->ID;
+
+		if( $post_status === $failed){
+			delete_post_meta( $id, '_tribe_aggregator_queue' );
+			Tribe__Post_Transient::instance()->delete( $id, '_tribe_aggregator_queue' );
+
+			return true;
+		}
+
+		$last_updated = strtotime( $record->post->post_modified_gmt );
+		$pending_for = time() - $last_updated;
+
+
+		if ( $pending_for > $this->stall_limit ) {
+			$failed = Tribe__Events__Aggregator__Records::$status->failed;
+			wp_update_post( array( 'ID' => $id, 'post_status' => $failed ) );
+			delete_post_meta( $id, '_tribe_aggregator_queue' );
+			Tribe__Post_Transient::instance()->delete( $id, '_tribe_aggregator_queue' );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets the time, in seconds, after which a pending record is considered stalling.
+	 *
+	 * @return int
+	 */
+	public function get_stall_limit() {
+		return $this->stall_limit;
+	}
+
+	/**
+	 * Sets the time, in seconds, after which a pending record is considered stalling.
+	 *
+	 * @param int $stall_limit
+	 */
+	public function set_stall_limit( $stall_limit ) {
+		$this->stall_limit = $stall_limit;
+	}
+}

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -75,7 +75,7 @@ class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 
 		$id = $record->post->ID;
 
-		if( $post_status === $failed){
+		if ( $post_status === $failed ) {
 			delete_post_meta( $id, '_tribe_aggregator_queue' );
 			Tribe__Post_Transient::instance()->delete( $id, '_tribe_aggregator_queue' );
 

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -41,6 +41,23 @@ class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 			AND pm.meta_value = %s
 			ORDER BY p.post_modified_gmt DESC", Tribe__Events__Aggregator__Records::$post_type, $pending_status, $import_id );
 
+		/**
+		 * Filters the query to find duplicate pending import records in respect to an
+		 * import id.
+		 *
+		 * If the filter returns an empty value then the delete operation will be voided.
+		 * This is a maintenance query that should really run so take care while modifying
+		 * or voiding it!
+		 *
+		 * @param string $query The SQL query used to find duplicate pending import records
+		 *                      in respect to an import id.
+		 */
+		$query = apply_filters( 'tribe_aggregator_import_queue_cleaner_query', $query );
+
+		if ( empty( $query ) ) {
+			return array();
+		}
+
 		$records = $wpdb->get_col( $query );
 		array_shift( $records );
 

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -7,7 +7,7 @@ class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 	 * @var int The time a record is allowed to stall before having
 	 *          its status set to failed in seconds.
 	 */
-	protected $stall_limit = 1800;
+	protected $stall_limit = HOUR_IN_SECONDS;
 
 	/**
 	 * Removes duplicate records for the same import ID.

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -205,7 +205,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 	protected function get_current_queue() {
 		try {
 			$this->current_queue = new Tribe__Events__Aggregator__Record__Queue( $this->current_record_id );
-		} catch ( Exception $e ) {
+		} catch ( InvalidArgumentException $e ) {
 			do_action( 'log', sprintf( __( 'Could not process queue for Import Record %1$d: %2$s', 'the-events-calendar' ), $this->current_record_id, $e->getMessage() ) );
 			return false;
 		}

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -16,7 +16,7 @@
  */
 class IntegrationTester extends \Codeception\Actor {
 
-	use \_generated\FunctionalTesterActions;
+	use \_generated\IntegrationTesterActions;
 
 	/**
 	 * Define custom actions here

--- a/tests/integration/Tribe/Events/Aggregator/Record/Queue_CleanerTest.php
+++ b/tests/integration/Tribe/Events/Aggregator/Record/Queue_CleanerTest.php
@@ -1,0 +1,252 @@
+<?php
+namespace Tribe\Events\Aggregator\Record;
+
+use Tribe__Events__Aggregator__Record__Abstract as Record;
+use Tribe__Events__Aggregator__Record__Queue_Cleaner as Cleaner;
+use Tribe__Events__Aggregator__Records as Records;
+
+class Queue_CleanerTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( Cleaner::class, $sut );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will return empty array if record ID is missing from meta
+	 */
+	public function test_remove_duplicate_records_pending_for_will_return_empty_array_if_record_id_is_missing_from_meta() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$record->meta = [];
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertEquals( [], $deleted );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will return empty array if there is only one record pending
+	 */
+	public function test_remove_duplicate_records_pending_for_will_return_empty_array_if_there_is_only_one_record_pending() {
+
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$pending = Records::$status->pending;
+		$record->post = $this->factory()->post->create_and_get( [ 'post_type' => Records::$post_type, 'post_status' => $pending ] );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertEquals( [], $deleted );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will return empty array if record is not pending
+	 */
+	public function test_remove_duplicate_records_pending_for_will_return_empty_array_if_record_is_not_pending() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->failed;
+		$record->post = $this->factory()->post->create_and_get( [ 'post_type' => Records::$post_type, 'post_status' => $status ] );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertEquals( [], $deleted );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will return empty array if record is schedule
+	 */
+	public function test_remove_duplicate_records_pending_for_will_return_empty_array_if_record_is_schedule() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->schedule;
+		$record->post = $this->factory()->post->create_and_get( [ 'post_type' => Records::$post_type, 'post_status' => $status ] );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertEquals( [], $deleted );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will remove duplicate pending records
+	 */
+	public function test_remove_duplicate_records_pending_for_will_remove_duplicate_pending_records() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->pending;
+		$post_array = [ 'post_type' => Records::$post_type, 'post_status' => $status ];
+		$record->post = $this->factory()->post->create_and_get( $post_array );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+		$more_pending = $this->factory()->post->create_many( 3, $post_array );
+		foreach ( $more_pending as $id ) {
+			add_post_meta( $id, '_tribe_aggregator_import_id', $import_id );
+		}
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertCount( 3, $deleted );
+	}
+
+	/**
+	 * remove_duplicate_records_pending_for will only remove duplicate pending records
+	 */
+	public function test_remove_duplicate_records_pending_for_will_only_remove_duplicate_pending_records() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->pending;
+		$post_array = [ 'post_type' => Records::$post_type, 'post_status' => $status ];
+		$record->post = $this->factory()->post->create_and_get( $post_array );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+		$more_pending = $this->factory()->post->create_many( 3, $post_array );
+		foreach ( $more_pending as $id ) {
+			add_post_meta( $id, '_tribe_aggregator_import_id', $import_id );
+		}
+		$schedule_post_arr = [
+			'post_type'   => Records::$post_type,
+			'post_status' => Records::$status->schedule
+		];
+		$schedule = $this->factory()->post->create( $schedule_post_arr );
+		$failed_post_arr = [
+			'post_type'   => Records::$post_type,
+			'post_status' => Records::$status->failed
+		];
+		$failed = $this->factory()->post->create_many( 4, $failed_post_arr );
+
+		$sut = $this->make_instance();
+		$deleted = $sut->remove_duplicate_pending_records_for( $record );
+
+		$this->assertCount( 3, $deleted );
+		$this->assertCount( 1, array_diff( array_merge( $more_pending, [ $record->post->ID ] ), $deleted ) );
+	}
+
+	/**
+	 * maybe_fail_stalled_record will not fail record that has not been stalling for long
+	 */
+	public function test_maybe_fail_stalled_record_will_not_fail_record_that_has_not_been_stalling_for_long() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$post_array = [ 'post_type' => Records::$post_type, 'post_status' => Records::$status->pending ];
+		$record->post = $this->factory()->post->create_and_get( $post_array );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+
+		$sut = $this->make_instance();
+		$sut->set_stall_limit( HOUR_IN_SECONDS );
+		$failed = $sut->maybe_fail_stalled_record( $record );
+
+		$this->assertFalse( $failed );
+		$this->assertEquals( Records::$status->pending, ( get_post( $record->post->ID ) )->post_status );
+	}
+
+	/**
+	 * maybe_fail_stalled_record will fail record that has been stalling for too long
+	 */
+	public function test_maybe_fail_stalled_record_will_fail_record_that_has_been_stalling_for_too_long() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->pending;
+		$hours_ago = date( 'Y-m-d H:i:s', time() - 4 * HOUR_IN_SECONDS );
+		$post_array = [ 'post_type' => Records::$post_type, 'post_status' => $status, 'post_date' => $hours_ago ];
+		$record->post = $this->factory()->post->create_and_get( $post_array );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_queue', 'fetch' );
+		\Tribe__Post_Transient::instance()->set( $record->post->ID, '_tribe_aggregator_queue', HOUR_IN_SECONDS );
+
+		$sut = $this->make_instance();
+		$sut->set_stall_limit( HOUR_IN_SECONDS );
+		$failed = $sut->maybe_fail_stalled_record( $record );
+
+		$this->assertTrue( $failed );
+		$this->assertEquals( Records::$status->failed, ( get_post( $record->post->ID ) )->post_status );
+		$this->assertEmpty( get_post_meta( $record->post->ID, '_tribe_aggregator_queue', true ) );
+		$this->assertEmpty( get_post_meta( $record->post->ID, '_transient_tribe_aggregator_queue', true ) );
+		$this->assertEmpty( get_post_meta( $record->post->ID, '_transient_timeout_tribe_aggregator_queue', true ) );
+	}
+
+	    /**
+	         * maybe_fail_stalled_record will empty queue meta for failed records
+	         */
+	        public function test_maybe_fail_stalled_record_will_empty_queue_meta_for_failed_records()
+	        {
+				$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+				$import_id = uniqid();
+				$record->meta = [ 'import_id' => $import_id ];
+				$status = Records::$status->failed;
+				$post_array = [ 'post_type' => Records::$post_type, 'post_status' => $status];
+				$record->post = $this->factory()->post->create_and_get( $post_array );
+				add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+				add_post_meta( $record->post->ID, '_tribe_aggregator_queue', 'fetch' );
+				\Tribe__Post_Transient::instance()->set( $record->post->ID, '_tribe_aggregator_queue', HOUR_IN_SECONDS );
+
+				$sut = $this->make_instance();
+				$sut->set_stall_limit( HOUR_IN_SECONDS );
+				$failed = $sut->maybe_fail_stalled_record( $record );
+
+				$this->assertTrue( $failed );
+				$this->assertEquals( Records::$status->failed, ( get_post( $record->post->ID ) )->post_status );
+				$this->assertEmpty( get_post_meta( $record->post->ID, '_tribe_aggregator_queue', true ) );
+				$this->assertEmpty( get_post_meta( $record->post->ID, '_transient_tribe_aggregator_queue', true ) );
+				$this->assertEmpty( get_post_meta( $record->post->ID, '_transient_timeout_tribe_aggregator_queue', true ) );
+	        }
+
+	/**
+	 * maybe_fail_stalled_record will not change status of record that is not pending
+	 */
+	public function test_maybe_fail_stalled_record_will_not_change_status_of_record_that_is_not_pending() {
+		$record = $this->getMockBuilder( Record::class )->disableOriginalConstructor()->getMock();
+		$import_id = uniqid();
+		$record->meta = [ 'import_id' => $import_id ];
+		$status = Records::$status->schedule;
+		$hours_ago = date( 'Y-m-d H:i:s', time() - 4 * HOUR_IN_SECONDS );
+		$post_array = [ 'post_type' => Records::$post_type, 'post_status' => $status, 'post_date' => $hours_ago ];
+		$record->post = $this->factory()->post->create_and_get( $post_array );
+		add_post_meta( $record->post->ID, '_tribe_aggregator_import_id', $import_id );
+
+		$sut = $this->make_instance();
+		$sut->set_stall_limit( HOUR_IN_SECONDS );
+		$failed = $sut->maybe_fail_stalled_record( $record );
+
+		$this->assertFalse( $failed );
+		$this->assertEquals( Records::$status->schedule, ( get_post( $record->post->ID ) )->post_status );
+	}
+
+	/**
+	 * @return Cleaner
+	 */
+	private function make_instance() {
+		return new Cleaner();
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/70614

This PR adds a `Queue_Cleaner` class to garbage collect stalling/failed pending records.
The garbage collection happens whenever the current record q is processed so it could be during an admin visit made from the user as well as during a cron job.

The cleaner will do 2 things:
* delete duplicate pending posts for the same import ID; the idea being that the user could attempt importing the same feed multiple times and one pending/fetching record is enough
* remove the `fetch` state from failed posts (this is what was actually stucking the notice) to avoid the wait lock of a failed record not running and hence its currenty activity, fetching, never being removed.

Please note: in the `Tribe__Events__Aggregator__Record__Queue::__construct` method I'm voiding subsequent calls to the the `process` method setting a `null_process` property: that's to get around the wrong previous existing use of `__construct` method return values, `__construct` will always return an instance of the object and the way to stop that is with exceptions. Putting in place `try/catch` blocks anywhere the constructor and `process` are used would require some major refactoring since in all use cases but one a valid `Tribe__Events__Aggregator__Record__Queue` instance is taken as granted. Voiding the `process` call shortcircuiting it is kind of an abuse of the "tell, don't ask" principle but still bearable.