### PR TITLE
avoid appending post type to network admin pages

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -320,6 +320,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed comment count and visibility issues due to Event Aggregator records [68297]
 * Fix - Fixed PHP notices and warnings raised when importing .ics files [69960]
 * Fix - Only show link to Venues if Pro is active in List View [69887]
+* Fix - Avoid error screen when saving licenses on multisite installations [68599]
 
 = [4.3.4.1] 2016-12-09 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4807,6 +4807,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @return string
 		 */
 		public function tribe_settings_url( $url ) {
+			if ( is_network_admin() ) {
+				return $url;
+			}
 			return add_query_arg( array( 'post_type' => self::POSTTYPE ), $url );
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/68599

When in the context of the network admin do not append the post type query arg: the menu is now in Settings.