### PR TITLE
add language switcher filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -321,6 +321,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed PHP notices and warnings raised when importing .ics files [69960]
 * Fix - Only show link to Venues if Pro is active in List View [69887]
 * Fix - Avoid error screen when saving licenses on multisite installations [68599]
+* Fix - Fix calendar view links in WPML language switcher [67134]
 
 = [4.3.4.1] 2016-12-09 =
 

--- a/src/Tribe/Integrations/WPML/Language_Switcher.php
+++ b/src/Tribe/Integrations/WPML/Language_Switcher.php
@@ -1,0 +1,55 @@
+<?php
+
+
+class Tribe__Events__Integrations__WPML__Language_Switcher {
+
+	/**
+	 * @var Tribe__Events__Integrations__WPML__Language_Switcher
+	 */
+	protected static $instance;
+
+	/**
+	 * @return Tribe__Events__Integrations__WPML__Language_Switcher
+	 */
+	public static function instance() {
+		if ( empty( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Updates the `url` field in each language information array to preserve correct calendar links.
+	 *
+	 * While the default view of the calendar will will be served on `/events` non default calendar
+	 * views like `list` or `photo` will be served, respectively, at `/events/list`, `/events/photo`
+	 * and so on.
+	 * For any view that's not the default one the `url` field in the language informtion array has to
+	 * be set to the correct one.
+	 *
+	 * @param array $languages The original languages information array.
+	 *
+	 * @return array The languages with maybe updated URLs
+	 */
+	public function filter_icl_ls_languages( array $languages = array() ) {
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return $languages;
+		}
+
+		if ( is_admin() || ! ( tribe_is_event_query() && is_archive() ) ) {
+			return $languages;
+		}
+
+		$current_url = home_url( $_SERVER['REQUEST_URI'] );
+
+		/** @var SitePress $sitepress */
+		global $sitepress;
+
+		foreach ( $languages as &$language ) {
+			$language['url'] = $sitepress->convert_url( $current_url, $language['code'] );
+		}
+
+		return $languages;
+	}
+}

--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -51,11 +51,10 @@ class Tribe__Events__Integrations__WPML__WPML {
 	}
 
 	protected function hook_filters() {
-		$filters = Tribe__Events__Integrations__WPML__Filters::instance();
-
 		add_filter( 'tribe_events_post_type_permalink', 'wpml_permalink_filter' );
-		add_filter( 'tribe_events_rewrite_i18n_slugs_raw', array( $filters, 'filter_tribe_events_rewrite_i18n_slugs_raw' ), 10,
-			3 );
+
+		$filters = Tribe__Events__Integrations__WPML__Filters::instance();
+		add_filter( 'tribe_events_rewrite_i18n_slugs_raw', array( $filters, 'filter_tribe_events_rewrite_i18n_slugs_raw' ), 10, 3 );
 
 		$linked_posts = Tribe__Events__Integrations__WPML__Linked_Posts::instance();
 		add_filter( 'tribe_events_linked_posts_query', array( $linked_posts, 'filter_tribe_events_linked_posts_query' ), 10, 2 );
@@ -66,6 +65,9 @@ class Tribe__Events__Integrations__WPML__WPML {
 
 		$permalinks = Tribe__Events__Integrations__WPML__Permalinks::instance();
 		add_filter( 'post_type_link', array( $permalinks, 'filter_post_type_link' ), 20, 2 );
+
+		$language_switcher = Tribe__Events__Integrations__WPML__Language_Switcher::instance();
+		add_filter( 'icl_ls_languages', array( $language_switcher, 'filter_icl_ls_languages' ), 5 );
 
 		if ( ! is_admin() ) {
 			$category_translation = Tribe__Events__Integrations__WPML__Category_Translation::instance();


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67134

This PR adds a filter in the WPML integration to make sure archive links are still built in a way that makes sense.