### PR TITLE
add theme version to css override

### DIFF
--- a/src/Tribe/Asset/Events_Css.php
+++ b/src/Tribe/Asset/Events_Css.php
@@ -50,7 +50,9 @@ class Tribe__Events__Asset__Events_Css extends Tribe__Events__Asset__Abstract_As
 			if ( $name == 'tribe-events-calendar-override-style' ) {
 				$user_stylesheet_url = Tribe__Events__Templates::locate_stylesheet( 'tribe-events/tribe-events.css' );
 				if ( $user_stylesheet_url ) {
-					wp_enqueue_style( $name, $user_stylesheet_url );
+					$current_theme = wp_get_theme();
+					$theme_version = $current_theme->get( 'Version' );
+					wp_enqueue_style( $name, $user_stylesheet_url, array(), $theme_version );
 				}
 			} else {
 


### PR DESCRIPTION
Since the tribe-events.css override comes from the theme, it makes sense
to use the theme version when enqueuing the css. This makes it possible
for themes to release an update that changes the css override. Otherwise
browsers can have the old version of the theme's css cached.