### PR TITLE
added check for post orders type plugin to add arg to ignore it's ord…

### DIFF
--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -95,6 +95,11 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 				$args[ Tribe__Events__Main::TAXONOMY ] = $_POST['tribe_event_category'];
 			}
 
+			// if post types order plugin is installed, set args to ignore their custom order
+			if ( is_plugin_active( 'post-types-order/post-types-order.php' ) ) {
+				$args['ignore_custom_sort'] = true;
+			}
+
 			$args = apply_filters( 'tribe_events_listview_ajax_get_event_args', $args, $_POST );
 
 			$query = tribe_get_events( $args, true );


### PR DESCRIPTION
…ering

This will fix the conflict with the Post Types Order plugin that causes the ajax call for the list order to not be ordered correctly. The other plugin accepts the parameter ignore_custom_sort so I created a check to see if the plugin is active and if it is to add the parameter. There are numerous people with this issue throughout your forms and this would fix the issue.

https://theeventscalendar.com/support/forums/topic/post-types-order-plugin-compatability/