### PR TITLE
Add safety check 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-events-calendar",
-  "version": "4.4.0",
+  "version": "4.4.0.1",
   "repository": "git@github.com:moderntribe/the-events-calendar.git",
   "_zipname": "the-events-calendar",
   "_zipfoldername": "the-events-calendar",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar, event, venue, organizer, dates, date, google maps, confe
 Donate link: http://m.tri.be/29
 Requires at least: 3.9
 Tested up to: 4.7
-Stable tag: 4.4
+Stable tag: 4.4.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -314,6 +314,10 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 Please see the changelog for the complete list of changes in this release. Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
+
+= [4.4.0.1] 2017-01-09 =
+
+* Fix - Adds safety check to ensure a smooth activation process when earlier versions of Tribe Common are active
 
 = [4.4] 2017-01-09 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -31,9 +31,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const POSTTYPE            = 'tribe_events';
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
-		const VERSION           = '4.4';
-		const MIN_ADDON_VERSION = '4.4';
-		const WP_PLUGIN_URL     = 'http://wordpress.org/extend/plugins/the-events-calendar/';
+		const VERSION             = '4.4';
+		const MIN_ADDON_VERSION   = '4.4';
+		const MIN_COMMON_VERSION  = '4.4';
+		const WP_PLUGIN_URL       = 'http://wordpress.org/extend/plugins/the-events-calendar/';
 
 		/**
 		 * Maybe display data wrapper
@@ -312,6 +313,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 * After this method we can use any `Tribe__` classes
 			 */
 			$this->init_autoloading();
+
+			// Safety check: if Tribe Common is not at a certain minimum version, bail out
+			if ( version_compare( Tribe__Main::VERSION, self::MIN_COMMON_VERSION, '<' ) ) {
+				return;
+			}
 
 			/**
 			 * We need Common to be able to load text domains correctly.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const POSTTYPE            = 'tribe_events';
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
-		const VERSION             = '4.4';
+		const VERSION             = '4.4.0.1';
 		const MIN_ADDON_VERSION   = '4.4';
 		const MIN_COMMON_VERSION  = '4.4';
 		const WP_PLUGIN_URL       = 'http://wordpress.org/extend/plugins/the-events-calendar/';

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: The Events Calendar
 Description: The Events Calendar is a carefully crafted, extensible plugin that lets you easily share your events. Beautiful. Solid. Awesome.
-Version: 4.4
+Version: 4.4.0.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/1x
 Text Domain: the-events-calendar


### PR DESCRIPTION
Helps prevent fatal errors during plugin activation (if an earlier than required version of Tribe Common is already present and loaded).