### PR TITLE
Smart event cost and website fields in the REST API response

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -19,13 +19,8 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 	 * @return Tribe__Events__Cost_Utils
 	 */
 	public static function instance() {
-		static $instance;
-
-		if ( ! $instance ) {
-			$instance = new self;
-		}
-
-		return $instance;
+		_deprecated_function( 'Tribe__Events__Cost_Utils::instance()', '4.5', "tribe( 'tec.cost-utils' )" );
+		return tribe( 'tec.cost-utils' );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -370,6 +370,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @return void
 		 */
 		public function bind_implementations(  ) {
+			// Utils
+			tribe_singleton( 'tec.cost-utils', 'Tribe__Events__Cost_Utils' );
+
 			// Front page events archive support
 			tribe_singleton( 'tec.front-page-view', 'Tribe__Events__Front_Page_View' );
 			tribe_singleton( 'tec.admin.front-page-view', 'Tribe__Events__Admin__Front_Page_View' );

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -94,7 +94,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 				'currency_position' => isset( $meta['_EventCurrencyPosition'] ) ? $meta['_EventCurrencyPosition'] : '',
 				'cost'              => isset( $meta['_EventCost'] ) ? $meta['_EventCost'] : '',
 			),
-			'website'                => isset( $meta['_EventURL'] ) ? esc_html( $meta['_EventURL'] ) : '',
+			'website'                => isset( $meta['_EventURL'] ) ? esc_html( $meta['_EventURL'] ) : get_the_permalink( $event_id ),
 			'show_map'               => isset( $meta['_EventShowMap'] ) ? $meta['_EventShowMap'] : '0',
 			'show_map_link'          => isset( $meta['_EventShowMapLink'] ) ? $meta['_EventShowMapLink'] : '0',
 			'categories'             => $this->get_categories( $event_id ),

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -64,6 +64,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 
 		$venue = $this->get_venue_data( $event_id );
 		$organizer = $this->get_organizer_data( $event_id );
+
 		$data = array(
 			'ID'                     => $event_id,
 			'author'                 => $event->post_author,
@@ -88,11 +89,11 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 			'utc_end_date_details'   => $this->get_date_details( $meta['_EventEndDateUTC'] ),
 			'timezone'               => isset( $meta['_EventTimezone'] ) ? $meta['_EventTimezone'] : '',
 			'timezone_abbr'          => isset( $meta['_EventTimezoneAbbr'] ) ? $meta['_EventTimezoneAbbr'] : '',
-			'cost'                   => tribe_get_cost( $event_id ),
+			'cost'                   => tribe_get_cost( $event_id, true ),
 			'cost_details'           => array(
 				'currency_symbol'   => isset( $meta['_EventCurrencySymbol'] ) ? $meta['_EventCurrencySymbol'] : '',
 				'currency_position' => isset( $meta['_EventCurrencyPosition'] ) ? $meta['_EventCurrencyPosition'] : '',
-				'cost'              => isset( $meta['_EventCost'] ) ? $meta['_EventCost'] : '',
+				'values'              => $this->get_cost_values( $event_id ),
 			),
 			'website'                => isset( $meta['_EventURL'] ) ? esc_html( $meta['_EventURL'] ) : get_the_permalink( $event_id ),
 			'show_map'               => isset( $meta['_EventShowMap'] ) ? $meta['_EventShowMap'] : '0',
@@ -373,5 +374,19 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Returns an ASC array of event costs.
+	 *
+	 * @param int|WP_Post $event_id The event post or the post ID.
+	 *
+	 * @return array
+	 */
+	protected function get_cost_values( $event_id ) {
+		$cost_values = array_keys( tribe( 'tec.cost-utils' )->get_event_costs( $event_id ) );
+		sort( $cost_values, SORT_NUMERIC );
+
+		return $cost_values;
 	}
 }

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -755,7 +755,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$tribe_ecp = Tribe__Events__Main::instance();
 		$post_id    = Tribe__Events__Main::postIdHelper( $post_id );
 
-		$cost_utils = Tribe__Events__Cost_Utils::instance();
+		$cost_utils = tribe( 'tec.cost-utils' );
 		$cost = $cost_utils->get_formatted_event_cost( $post_id, $with_currency_symbol );
 
 		return apply_filters( 'tribe_get_cost', $cost, $post_id, $with_currency_symbol );
@@ -783,7 +783,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return int the minimum cost.
 	 */
 	function tribe_get_minimum_cost() {
-		return Tribe__Events__Cost_Utils::instance()->get_minimum_cost();
+		return tribe( 'tec.cost-utils' )->get_minimum_cost();
 	}
 
 	/**
@@ -793,7 +793,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return int the maximum cost.
 	 */
 	function tribe_get_maximum_cost() {
-		return Tribe__Events__Cost_Utils::instance()->get_maximum_cost();
+		return tribe( 'tec.cost-utils' )->get_maximum_cost();
 	}
 
 	/**
@@ -803,7 +803,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return bool if uncosted events exist
 	 */
 	function tribe_has_uncosted_events() {
-		return Tribe__Events__Cost_Utils::instance()->has_uncosted_events();
+		return tribe( 'tec.cost-utils' )->has_uncosted_events();
 	}
 
 	/**

--- a/tests/_support/Testcases/Events_TestCase.php
+++ b/tests/_support/Testcases/Events_TestCase.php
@@ -9,13 +9,32 @@ use Tribe\Events\Tests\Factories\Organizer;
 use Tribe\Events\Tests\Factories\Venue;
 
 class Events_TestCase extends WPTestCase {
+	/**
+	 * @var array An array of bound implementations we could replace during tests.
+	 */
+	protected $backups = [];
+
+	/**
+	 * @var array An associative array of backed up alias and bound implementations.
+	 */
+	protected $implementation_backups = [];
 
 	function setUp() {
 		parent::setUp();
 
-		$this->factory()->event = new Event();
-		$this->factory()->venue = new Venue();
+		$this->factory()->event     = new Event();
+		$this->factory()->venue     = new Venue();
 		$this->factory()->organizer = new Organizer();
+
+		foreach ( $this->backups as $alias ) {
+			$this->implementation_backups[ $alias ] = tribe( $alias );
+		}
 	}
 
+	public function tearDown() {
+		foreach ( $this->implementation_backups as $alias => $value ) {
+			tribe_singleton( $alias, $value );
+		}
+		parent::tearDown();
+	}
 }

--- a/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
+++ b/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
@@ -366,6 +366,7 @@ class Post_RepositoryTest extends Events_TestCase {
 
 	/**
 	 * @test
+<<<<<<< Updated upstream
 	 * it should return the event website if set
 	 */
 	public function it_should_return_the_event_website_if_set() {
@@ -397,6 +398,14 @@ class Post_RepositoryTest extends Events_TestCase {
 		$this->assertEquals( get_the_permalink( $event ), $data['website'] );
 	}
 
+=======
+	 * it should set the cost details to an array of values if an events has more than one price components
+	 */
+	public function it_should_set_the_cost_details_to_an_array_of_values_if_an_events_has_more_than_one_price_components() {
+		$this->markTestIncomplete();
+	}	
+	
+>>>>>>> Stashed changes
 	/**
 	 * @return Post_Repository
 	 */

--- a/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
+++ b/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
@@ -365,6 +365,39 @@ class Post_RepositoryTest extends Events_TestCase {
 	}
 
 	/**
+	 * @test
+	 * it should return the event website if set
+	 */
+	public function it_should_return_the_event_website_if_set() {
+		// need to be able to assign terms to use `tax_input`
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$event = $this->factory()->event->create( [ 'meta_input' => [ '_EventURL' => 'http://example.com' ] ] );
+
+		$sut = $this->make_instance();
+
+		$data = $sut->get_event_data( $event );
+
+		$this->assertArrayHasKey( 'website', $data );
+		$this->assertEquals( 'http://example.com', $data['website'] );
+	}
+
+	/**
+	 * @test
+	 * it should use the event permalink as website if event website is empty
+	 */
+	public function it_should_use_the_event_permalink_as_website_if_event_website_is_empty() {
+		$event = $this->factory()->event->create();
+		delete_post_meta($event,'_EventURL');
+
+		$sut = $this->make_instance();
+
+		$data = $sut->get_event_data( $event );
+
+		$this->assertArrayHasKey( 'website', $data );
+		$this->assertEquals( get_the_permalink( $event ), $data['website'] );
+	}
+
+	/**
 	 * @return Post_Repository
 	 */
 	private function make_instance() {

--- a/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
+++ b/tests/integration/Tribe/Events/REST/V1/Post_RepositoryTest.php
@@ -2,12 +2,18 @@
 
 namespace Tribe\Events\REST\V1;
 
+use Prophecy\Argument;
 use Tribe\Events\Tests\Testcases\Events_TestCase;
+use Tribe__Events__Cost_Utils as Cost_Utils;
 use Tribe__Events__Main as Main;
 use Tribe__Events__REST__V1__Messages as Messages;
 use Tribe__Events__REST__V1__Post_Repository as Post_Repository;
 
 class Post_RepositoryTest extends Events_TestCase {
+
+	protected $backups = [
+		'tec.cost-utils',
+	];
 
 	/**
 	 * @var \Tribe__REST__Messages_Interface
@@ -366,7 +372,6 @@ class Post_RepositoryTest extends Events_TestCase {
 
 	/**
 	 * @test
-<<<<<<< Updated upstream
 	 * it should return the event website if set
 	 */
 	public function it_should_return_the_event_website_if_set() {
@@ -388,7 +393,7 @@ class Post_RepositoryTest extends Events_TestCase {
 	 */
 	public function it_should_use_the_event_permalink_as_website_if_event_website_is_empty() {
 		$event = $this->factory()->event->create();
-		delete_post_meta($event,'_EventURL');
+		delete_post_meta( $event, '_EventURL' );
 
 		$sut = $this->make_instance();
 
@@ -398,14 +403,52 @@ class Post_RepositoryTest extends Events_TestCase {
 		$this->assertEquals( get_the_permalink( $event ), $data['website'] );
 	}
 
-=======
+	public function cost_details() {
+		return [
+			[ [ 0 => 0 ], [ 0 => 0 ] ],
+			[ [], [] ],
+			[ [ 0 => 0 ], [ 0 ] ],
+			[ [ 0 => 0, 12 => 12 ], [ 0, 12 ] ],
+			[ [ 0 => 0, 12 => 12, 23 => 23 ], [ 0, 12, 23 ] ],
+			[ [ 23 => 23, 12 => 12, 0 => 0 ], [ 0, 12, 23 ] ],
+		];
+	}
+
+	/**
+	 * @test
 	 * it should set the cost details to an array of values if an events has more than one price components
+	 * @dataProvider cost_details
 	 */
-	public function it_should_set_the_cost_details_to_an_array_of_values_if_an_events_has_more_than_one_price_components() {
-		$this->markTestIncomplete();
-	}	
-	
->>>>>>> Stashed changes
+	public function it_should_set_the_cost_details_to_an_array_of_values_if_an_events_has_more_than_one_price_components( $costs,
+		$expected
+	) {
+		// need to be able to assign terms to use `meta_input`
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$event_id = $this->factory()->event->create( [
+			'meta_input' => [
+				'_EventCurrencySymbol'   => '$',
+				'_EventCurrencyPosition' => 'prefix'
+			]
+		] );
+		/** @var Cost_Utils $cost_utils */
+		$cost_utils = $this->prophesize( Cost_Utils::class );
+		$cost_utils->get_formatted_event_cost( Argument::any(), true )->willReturn( 'foo cost' );
+		$cost_utils->get_event_costs( Argument::any() )->will( function () use ( $costs ) {
+			return $costs;
+		} );
+		tribe_singleton( 'tec.cost-utils', $cost_utils->reveal() );
+
+		$sut  = $this->make_instance();
+		$data = $sut->get_event_data( $event_id );
+
+		$this->assertArrayHasKey( 'cost', $data );
+		$this->assertEquals( 'foo cost', $data['cost'] );
+		$this->assertArrayHasKey( 'cost_details', $data );
+		$this->assertEquals( '$', $data['cost_details']['currency_symbol'] );
+		$this->assertEquals( 'prefix', $data['cost_details']['currency_position'] );
+		$this->assertEquals( $expected, $data['cost_details']['values'] );
+	}
+
 	/**
 	 * @return Post_Repository
 	 */

--- a/tests/integration/Tribe__Events__Cost_Utils_Test.php
+++ b/tests/integration/Tribe__Events__Cost_Utils_Test.php
@@ -115,7 +115,7 @@ class Tribe__Events__Cost_Utils_Test extends Tribe__Events__WP_UnitTestCase {
 			'$6',
 		);
 
-		$cost_utils = Tribe__Events__Cost_Utils::instance();
+		$cost_utils = tribe( 'tec.cost-utils' );
 		$range = $cost_utils->parse_cost_range( $costs );
 
 		$this->assertEquals( array(

--- a/tests/restv1/SingleEventCest.php
+++ b/tests/restv1/SingleEventCest.php
@@ -199,12 +199,12 @@ class SingleEventCest extends BaseRestCest {
 		] );
 		$I->seeResponseContainsJson( [ 'timezone' => 'America/New_York' ] );
 		$I->seeResponseContainsJson( [ 'timezone_abbr' => 'EST' ] );
-		$I->seeResponseContainsJson( [ 'cost' => '23' ] );
+		$I->seeResponseContainsJson( [ 'cost' => '$23' ] );
 		$I->seeResponseContainsJson( [
 			'cost_details' => [
 				'currency_symbol'   => '$',
 				'currency_position' => 'prefix',
-				'cost'              => '23'
+				'values'              => [ '23'  ]
 			]
 		] );
 		$I->seeResponseContainsJson( [ 'website' => 'http://tri.be' ] );


### PR DESCRIPTION
Tickets:

* https://central.tri.be/issues/70386
* https://central.tri.be/issues/70385

This PR:

* will make sure that the REST response for an event website will be set to the event permalink itself if empty
* will set the cost of the event according to how we would format it on the front-end returning the complete cost string ("Free" or "$34") and the cost components in ASC order (`[0, 12, 15,30]` for an event that has tickets with prices ranging from free to $30)
* updates the tests (REST and Integration) accordingly

Notice that while the ticket deals with the other side of the import (the destination) setting the event data in the REST response makes sense.