### PR TITLE
Add and handle REST V1 (Other URL) messages

### DIFF
--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -110,6 +110,13 @@ class Tribe__Events__Aggregator__Page {
 		 */
 		$localize_data['data']['csv_column_mapping'] = apply_filters( 'tribe_aggregator_csv_column_mapping', $localize_data['data']['csv_column_mapping'] );
 
+		/**
+		 * filters the whole array that will be localized for event aggregator.
+		 *
+		 * @param array $localize_data
+		 */
+		$localize_data['data'] = apply_filters( 'tribe_aggregator_localized_data', $localize_data['data'] );
+
 		// Load these on all the pages
 		tribe_assets( $plugin,
 			array(

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -59,32 +59,7 @@ class Tribe__Events__Aggregator__Service {
 	 * Constructor!
 	 */
 	public function __construct( Tribe__Events__Aggregator__API__Requests $requests ) {
-		// These messages are delivered by the EA service and don't need to be registered. They just
-		// need to exist here so that they can be translated
-		$this->service_messages = array(
-			'error:create-import-failed'         => __( 'Sorry, but something went wrong. Please try again.', 'the-events-calendar' ),
-			'error:create-import-invalid-params' => __( 'The import parameters were invalid.', 'the-events-calendar' ),
-			'error:fb-permissions'               => __( 'Events cannot be imported because Facebook has returned an error. This could mean that the event ID does not exist, the event or source is marked as Private, or the event or source has been otherwise restricted by Facebook. You can <a href="https://theeventscalendar.com/knowledgebase/import-errors/" target="_blank">read more about Facebook restrictions in our knowledgebase</a>.', 'the-events-calendar' ),
-			'error:fetch-404'                    => __( 'The URL provided could not be reached.', 'the-events-calendar' ),
-			'error:fetch-failed'                 => __( 'The URL provided failed to load.', 'the-events-calendar' ),
-			'error:get-image'                    => __( 'The image associated with your event could not be imported.', 'the-events-calendar' ),
-			'error:get-image-bad-association'    => __( 'The image associated with your event is not accessible with your API key.', 'the-events-calendar' ),
-			'error:import-failed'                => __( 'The import failed for an unknown reason. Please try again. If the problem persists, please contact support.', 'the-events-calendar' ),
-			'error:invalid-ical-url'             => __( 'The URL provided did not have events in the proper format.', 'the-events-calendar' ),
-			'error:invalid-ics-file'             => __( 'The file provided could not be opened. Please confirm that it is a properly formatted .ics file.', 'the-events-calendar' ),
-			'error:meetup-api-key'               => __( 'Your Meetup API key is invalid.', 'the-events-calendar' ),
-			'error:meetup-api-quota'             => __( 'Event Aggregator cannot reach Meetup.com because you exceeded the request limit for your Meetup API key.', 'the-events-calendar' ),
-			'error:usage-limit-exceeded'         => __( 'The daily limit of %d import requests to the Event Aggregator service has been reached. Please try again later.', 'the-events-calendar' ),
-			'fetching'                           => __( 'The import is in progress.', 'the-events-calendar' ),
-			'queued'                             => __( 'The import will be starting soon.', 'the-events-calendar' ),
-			'success'                            => __( 'Success', 'the-events-calendar' ),
-			'success:create-import'              => __( 'Import created', 'the-events-calendar' ),
-			'success:facebook-get-token'         => __( 'Successfully fetched Facebook Token', 'the-events-calendar' ),
-			'success:get-origin'                 => __( 'Successfully loaded import origins', 'the-events-calendar' ),
-			'success:import-complete'            => __( 'Import is complete', 'the-events-calendar' ),
-			'success:queued'                     => __( 'Import queued', 'the-events-calendar' ),
-		);
-
+		$this->register_messages();
 		$this->requests = $requests;
 	}
 
@@ -504,5 +479,45 @@ class Tribe__Events__Aggregator__Service {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Registers the message map used to translate message slugs returned from EA service into localized strings.
+	 *
+	 * These messages are delivered by the EA service and don't need to be registered. They just need to exist
+	 * here so that they can be translated.
+	 */
+	protected function register_messages()
+	{
+		$this->service_messages = array(
+			'error:create-import-failed' => __( 'Sorry, but something went wrong. Please try again.', 'the-events-calendar' ),
+			'error:create-import-invalid-params' => __( 'The import parameters were invalid.', 'the-events-calendar' ),
+			'error:fb-permissions' => __( 'Events cannot be imported because Facebook has returned an error. This could mean that the event ID does not exist, the event or source is marked as Private, or the event or source has been otherwise restricted by Facebook. You can <a href="https://theeventscalendar.com/knowledgebase/import-errors/" target="_blank">read more about Facebook restrictions in our knowledgebase</a>.', 'the-events-calendar' ),
+			'error:fetch-404' => __( 'The URL provided could not be reached.', 'the-events-calendar' ),
+			'error:fetch-failed' => __( 'The URL provided failed to load.', 'the-events-calendar' ),
+			'error:get-image' => __( 'The image associated with your event could not be imported.', 'the-events-calendar' ),
+			'error:get-image-bad-association' => __( 'The image associated with your event is not accessible with your API key.', 'the-events-calendar' ),
+			'error:import-failed' => __( 'The import failed for an unknown reason. Please try again. If the problem persists, please contact support.', 'the-events-calendar' ),
+			'error:invalid-ical-url' => __( 'The URL provided did not have events in the proper format.', 'the-events-calendar' ),
+			'error:invalid-ics-file' => __( 'The file provided could not be opened. Please confirm that it is a properly formatted .ics file.', 'the-events-calendar' ),
+			'error:meetup-api-key' => __( 'Your Meetup API key is invalid.', 'the-events-calendar' ),
+			'error:meetup-api-quota' => __( 'Event Aggregator cannot reach Meetup.com because you exceeded the request limit for your Meetup API key.', 'the-events-calendar' ),
+			'error:usage-limit-exceeded' => __( 'The daily limit of %d import requests to the Event Aggregator service has been reached. Please try again later.', 'the-events-calendar' ),
+			'fetching' => __( 'The import is in progress.', 'the-events-calendar' ),
+			'queued' => __( 'The import will be starting soon.', 'the-events-calendar' ),
+			'success' => __( 'Success', 'the-events-calendar' ),
+			'success:create-import' => __( 'Import created', 'the-events-calendar' ),
+			'success:facebook-get-token' => __( 'Successfully fetched Facebook Token', 'the-events-calendar' ),
+			'success:get-origin' => __( 'Successfully loaded import origins', 'the-events-calendar' ),
+			'success:import-complete' => __( 'Import is complete', 'the-events-calendar' ),
+			'success:queued' => __( 'Import queued', 'the-events-calendar' ),
+		);
+
+		/**
+		 * Filters the service messages map to allow addition and removal of messages.
+		 *
+		 * @param array $service_messages An associative array of service messages in the `[ <slug> => <localized text> ]` format.
+		 */
+		$this->service_messages = apply_filters( 'tribe_aggregator_service_messages', $this->service_messages );
 	}
 }

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -487,8 +487,7 @@ class Tribe__Events__Aggregator__Service {
 	 * These messages are delivered by the EA service and don't need to be registered. They just need to exist
 	 * here so that they can be translated.
 	 */
-	protected function register_messages()
-	{
+	protected function register_messages() {
 		$this->service_messages = array(
 			'error:create-import-failed' => __( 'Sorry, but something went wrong. Please try again.', 'the-events-calendar' ),
 			'error:create-import-invalid-params' => __( 'The import parameters were invalid.', 'the-events-calendar' ),

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -456,6 +456,8 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		$result = $record->get_import_data();
 
+		$result->origin = $record->origin;
+
 		if ( is_wp_error( $result ) ) {
 			wp_send_json_error( $result );
 		}

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -456,7 +456,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		$result = $record->get_import_data();
 
-		if ( isset( $result->data ) ){
+		if ( isset( $result->data ) ) {
 			$result->data->origin = $record->origin;
 		}
 

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -456,7 +456,9 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		$result = $record->get_import_data();
 
-		$result->origin = $record->origin;
+		if ( isset( $result->data ) ){
+			$result->data->origin = $record->origin;
+		}
 
 		if ( is_wp_error( $result ) ) {
 			wp_send_json_error( $result );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -411,6 +411,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			// REST API v1
 			tribe_singleton( 'tec.rest-v1.main', 'Tribe__Events__REST__V1__Main', array( 'bind_implementations', 'hook' ) );
+			tribe( 'tec.rest-v1.main' );
 
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.

--- a/src/Tribe/REST/V1/EA_Messages.php
+++ b/src/Tribe/REST/V1/EA_Messages.php
@@ -1,0 +1,14 @@
+<?php
+
+class Tribe__Events__REST__V1__EA_Messages extends Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interface
+{
+	public function __construct()
+	{
+		$this->messages = array(
+			'not-tec-rest-api-site' => __( 'The Events Calendar is not active or is not at least version 4.5 on the requested URL.', 'the-events-calendar' ),
+			'tec-rest-api-unsupported' => __( 'The requested URL does not support The Events Calendar REST API.', 'the-events-calendar' ),
+			'tec-rest-api-disabled' => __( 'The Events Calendar REST API is disabled on the requested URL.', 'the-events-calendar' ),
+			'no_results' => __( 'The requested URL does not have any upcoming and published events.', 'the-events-calendar' ),
+		);
+	}
+}

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -170,8 +170,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		return $this->url_prefix;
 	}
 
-	protected function hook_messages()
-	{
+	protected function hook_messages() {
 		add_filter( 'tribe_aggregator_service_messages', array( $this, 'filter_service_messages' ) );
 		add_filter( 'tribe_aggregator_localized_data', array( $this, 'filter_localized_data' ) );
 	}
@@ -182,13 +181,15 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 * @param array $messages
 	 * @return array The original messages plus those specific to the REST API V1.
 	 */
-	public function filter_service_messages( array $messages = array() )
-	{
+	public function filter_service_messages( array $messages = array() ) {
 		/** @var Tribe__REST__Messages_Interface $rest_messages */
-		$rest_messages = tribe( 'tec.rest-v1.ea-messages' );
-		$messages_array = $rest_messages->get_messages();
-		$prefixed_rest_messages_keys = array_map( array( $rest_messages, 'prefix_message_slug' ), array_keys( $messages_array ) );
-		$messages = array_merge( $messages, array_combine( $prefixed_rest_messages_keys, array_values( $messages_array ) ) );
+		$rest_messages               = tribe( 'tec.rest-v1.ea-messages' );
+		$messages_array              = $rest_messages->get_messages();
+		$prefixed_rest_messages_keys = array_map( array(
+			$rest_messages,
+			'prefix_message_slug'
+		), array_keys( $messages_array ) );
+		$messages                    = array_merge( $messages, array_combine( $prefixed_rest_messages_keys, array_values( $messages_array ) ) );
 
 		return $messages;
 	}
@@ -197,12 +198,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 * Filters the messages localized by the Event Aggregator Service to add those specific to the REST API v1.
 	 *
 	 * @param array $localized_data
+	 *
 	 * @return array
 	 */
-	public function filter_localized_data( array $localized_data = array() )
-	{
+	public function filter_localized_data( array $localized_data = array() ) {
 		/** @var Tribe__REST__Messages_Interface $rest_messages */
-		$rest_messages = tribe( 'tec.rest-v1.ea-messages' );
+		$rest_messages                 = tribe( 'tec.rest-v1.ea-messages' );
 		$localized_data['l10n']['url'] = $rest_messages->get_messages();
 
 		return $localized_data;

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -183,13 +183,10 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 */
 	public function filter_service_messages( array $messages = array() ) {
 		/** @var Tribe__REST__Messages_Interface $rest_messages */
-		$rest_messages               = tribe( 'tec.rest-v1.ea-messages' );
-		$messages_array              = $rest_messages->get_messages();
-		$prefixed_rest_messages_keys = array_map( array(
-			$rest_messages,
-			'prefix_message_slug'
-		), array_keys( $messages_array ) );
-		$messages                    = array_merge( $messages, array_combine( $prefixed_rest_messages_keys, array_values( $messages_array ) ) );
+		$rest_messages  = tribe( 'tec.rest-v1.ea-messages' );
+		$messages_array = $rest_messages->get_messages();
+		$prefixed_rest_messages_keys = array_map( array( $rest_messages, 'prefix_message_slug' ), array_keys( $messages_array ) );
+		$messages = array_merge( $messages, array_combine( $prefixed_rest_messages_keys, array_values( $messages_array ) ) );
 
 		return $messages;
 	}

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -25,6 +25,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 */
 	public function bind_implementations() {
 		tribe_singleton( 'tec.rest-v1.messages', 'Tribe__Events__REST__V1__Messages' );
+		tribe_singleton( 'tec.rest-v1.ea-messages', 'Tribe__Events__REST__V1__EA_Messages' );
 		tribe_singleton( 'tec.rest-v1.headers-base', 'Tribe__Events__REST__V1__Headers__Base' );
 		tribe_singleton( 'tec.rest-v1.settings', 'Tribe__Events__REST__V1__Settings' );
 		tribe_singleton( 'tec.rest-v1.system', 'Tribe__Events__REST__V1__System' );
@@ -40,6 +41,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	public function hook() {
 		$this->hook_headers();
 		$this->hook_settings();
+		$this->hook_messages();
 
 		/** @var Tribe__Events__REST__V1__System $system */
 		$system = tribe( 'tec.rest-v1.system' );
@@ -166,5 +168,43 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 */
 	protected function url_prefix() {
 		return $this->url_prefix;
+	}
+
+	protected function hook_messages()
+	{
+		add_filter( 'tribe_aggregator_service_messages', array( $this, 'filter_service_messages' ) );
+		add_filter( 'tribe_aggregator_localized_data', array( $this, 'filter_localized_data' ) );
+	}
+
+	/**
+	 * Filters the messages returned by the Event Aggregator Service to add those specific to the REST API v1.
+	 *
+	 * @param array $messages
+	 * @return array The original messages plus those specific to the REST API V1.
+	 */
+	public function filter_service_messages( array $messages = array() )
+	{
+		/** @var Tribe__REST__Messages_Interface $rest_messages */
+		$rest_messages = tribe( 'tec.rest-v1.ea-messages' );
+		$messages_array = $rest_messages->get_messages();
+		$prefixed_rest_messages_keys = array_map( array( $rest_messages, 'prefix_message_slug' ), array_keys( $messages_array ) );
+		$messages = array_merge( $messages, array_combine( $prefixed_rest_messages_keys, array_values( $messages_array ) ) );
+
+		return $messages;
+	}
+
+	/**
+	 * Filters the messages localized by the Event Aggregator Service to add those specific to the REST API v1.
+	 *
+	 * @param array $localized_data
+	 * @return array
+	 */
+	public function filter_localized_data( array $localized_data = array() )
+	{
+		/** @var Tribe__REST__Messages_Interface $rest_messages */
+		$rest_messages = tribe( 'tec.rest-v1.ea-messages' );
+		$localized_data['l10n']['url'] = $rest_messages->get_messages();
+
+		return $localized_data;
 	}
 }

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -3,12 +3,17 @@
 
 class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interface {
 
+	/**
+	 * @var string
+	 */
+	protected $message_prefix = 'rest-v1::';
+
 	public function __construct() {
 		$this->messages = array(
-			'missing-event-id'     => __( 'The event ID is missing from the request', 'the-events-calendar' ),
-			'event-not-found'      => __( 'The requested post ID does not exist or is not an event', 'the-events-calendar' ),
-			'event-no-venue'       => __( 'The event does not have a venue assigned', 'the-events-calendar' ),
-			'event-no-organizer'   => __( 'The event does not have an organizer assigned', 'the-events-calendar' ),
+			'missing-event-id' => __( 'The event ID is missing from the request', 'the-events-calendar' ),
+			'event-not-found' => __( 'The requested post ID does not exist or is not an event', 'the-events-calendar' ),
+			'event-no-venue' => __( 'The event does not have a venue assigned', 'the-events-calendar' ),
+			'event-no-organizer' => __( 'The event does not have an organizer assigned', 'the-events-calendar' ),
 			'event-not-accessible' => __( 'The requested event is not accessible', 'the-events-calendar' ),
 			'event-archive-bad-page' => __( "The 'page' parameter must be a positive integer greater than 1", 'the-events-calendar' ),
 			'event-archive-bad-per-page' => __( "The 'per_page' parameter must be a positive integer greater than 1", 'the-events-calendar' ),
@@ -16,8 +21,8 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 			'event-archive-bad-end-date' => __( "The 'end_date' parameter must be in a supported format", 'the-events-calendar' ),
 			'event-archive-bad-search-string' => __( "The 'search' parameter must be a string", 'the-events-calendar' ),
 			'event-archive-page-not-found' => __( 'The requested event archive page does not exist', 'the-events-calendar' ),
-			'venue-not-found'      => __( 'The requested post ID does not exist or is not an venue', 'the-events-calendar' ),
-			'organizer-not-found'  => __( 'The requested post ID does not exist or is not an organizer', 'the-events-calendar' ),
+			'venue-not-found' => __( 'The requested post ID does not exist or is not an venue', 'the-events-calendar' ),
+			'organizer-not-found' => __( 'The requested post ID does not exist or is not an organizer', 'the-events-calendar' ),
 		);
 	}
 
@@ -34,5 +39,31 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns the associative array of all the messages handled by the class.
+	 *
+	 * @return array An associative array in the `[ <slug> => <localized message> ]` format.
+	 */
+	public function get_messages(  )
+	{
+		return $this->messages;
+	}
+
+	/**
+	 * Prefixes a message slug with a common root.
+	 *
+	 * Used to uniform the slug format to the one used by the `Tribe__Events__Aggregator__Service` class.
+	 *
+	 * @see Tribe__Events__Aggregator__Service::register_messages()
+	 *
+	 * @param string $message_slug
+	 *
+	 * @return string The prefixed message slug.
+	 */
+	public function prefix_message_slug( $message_slug )
+	{
+		return $this->message_prefix . $message_slug;
 	}
 }

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -46,8 +46,7 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 	 *
 	 * @return array An associative array in the `[ <slug> => <localized message> ]` format.
 	 */
-	public function get_messages(  )
-	{
+	public function get_messages() {
 		return $this->messages;
 	}
 
@@ -62,8 +61,7 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 	 *
 	 * @return string The prefixed message slug.
 	 */
-	public function prefix_message_slug( $message_slug )
-	{
+	public function prefix_message_slug( $message_slug ) {
 		return $this->message_prefix . $message_slug;
 	}
 }

--- a/src/resources/js/aggregator-fields.js
+++ b/src/resources/js/aggregator-fields.js
@@ -369,8 +369,12 @@ tribe_aggregator.fields = {
 			import_type = $( '#' + $import_type.first().attr( 'id' ).replace( 's2id_', '' ) ).val();
 		}
 
-		if ( 'manual' === import_type && ! data.items.length ) {
-			obj.display_fetch_error( ea.l10n.no_results );
+		if ('manual' === import_type && !data.items.length) {
+			var origin = data.origin;
+			var message = 'undefined' !== ea.l10n[origin].no_results ?
+				ea.l10n[origin].no_results
+				: ea.l10n.no_results;
+			obj.display_fetch_error(message);
 			return;
 		}
 

--- a/src/resources/js/aggregator-fields.js
+++ b/src/resources/js/aggregator-fields.js
@@ -369,10 +369,10 @@ tribe_aggregator.fields = {
 			import_type = $( '#' + $import_type.first().attr( 'id' ).replace( 's2id_', '' ) ).val();
 		}
 
-		if ('manual' === import_type && !data.items.length) {
+        if ( 'manual' === import_type && !data.items.length ) {
 			var origin = data.origin;
-			var message = 'undefined' !== ea.l10n[origin].no_results ?
-				ea.l10n[origin].no_results
+			var message = 'undefined' !== ea.l10n[ origin ].no_results ?
+				ea.l10n[ origin ].no_results
 				: ea.l10n.no_results;
 			obj.display_fetch_error(message);
 			return;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/71337

Builds on: https://github.com/moderntribe/tribe-common/pull/313

This PR makes sure REST V1 messages are handled and used in 2 moments:

1. when the EA service answers the request and the response is packaged (especially errors)
2. when data is handled on the JS side