### PR TITLE
Register an 'inactive event' post type | #71509

### DIFF
--- a/src/Tribe/Inactive_Events.php
+++ b/src/Tribe/Inactive_Events.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Sets up and helps to manage inactive events.
+ */
+class Tribe__Events__Inactive_Events {
+	const POST_TYPE = 'tribe_inactive_event';
+
+	public function hook() {
+		add_action( 'init', array( $this, 'register' ), 20 );
+	}
+
+	public function register() {
+		/**
+		 * Defines the inactive event post type.
+		 *
+		 * @var array $arguments
+		 */
+		register_post_type( self::POST_TYPE, apply_filters( 'tribe_events_register_inactive_event_type_args', array(
+			'public'          => false,
+			'supports'        => get_all_post_type_supports( Tribe__Events__Main::POSTTYPE ),
+			'taxonomies'      => array( 'post_tag' ),
+			'capability_type' => array( 'tribe_event', 'tribe_events' ),
+			'map_meta_cap'    => true,
+		) ) );
+	}
+}

--- a/src/Tribe/Inactive_Events.php
+++ b/src/Tribe/Inactive_Events.php
@@ -10,6 +10,8 @@ class Tribe__Events__Inactive_Events {
 	}
 
 	public function register() {
+		$supports = array_keys( get_all_post_type_supports( Tribe__Events__Main::POSTTYPE ) );
+
 		/**
 		 * Defines the inactive event post type.
 		 *
@@ -17,7 +19,7 @@ class Tribe__Events__Inactive_Events {
 		 */
 		register_post_type( self::POST_TYPE, apply_filters( 'tribe_events_register_inactive_event_type_args', array(
 			'public'          => false,
-			'supports'        => get_all_post_type_supports( Tribe__Events__Main::POSTTYPE ),
+			'supports'        => $supports,
 			'taxonomies'      => array( 'post_tag' ),
 			'capability_type' => array( 'tribe_event', 'tribe_events' ),
 			'map_meta_cap'    => true,

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -375,7 +375,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @return void
 		 */
-		public function bind_implementations(  ) {
+		public function bind_implementations() {
 			// Front page events archive support
 			tribe_singleton( 'tec.front-page-view', 'Tribe__Events__Front_Page_View' );
 			tribe_singleton( 'tec.admin.front-page-view', 'Tribe__Events__Admin__Front_Page_View' );
@@ -395,7 +395,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Shortcodes
 			tribe_singleton( 'tec.shortcodes.event-details', 'Tribe__Events__Shortcode__Event_Details', array( 'hook' ) );
 
-			// Ignored Events
+			// Event types
+			tribe_singleton( 'tec.inactive-events', 'Tribe__Events__Inactive_Events', array( 'hook' ) );
 			tribe_singleton( 'tec.ignored-events', 'Tribe__Events__Ignored_Events', array( 'hook' ) );
 
 			// Register and start the Customizer Sections
@@ -671,6 +672,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			tribe( 'events-aggregator.main' );
 			tribe( 'tec.shortcodes.event-details' );
+			tribe( 'tec.inactive-events' );
 			tribe( 'tec.ignored-events' );
 			tribe( 'tec.iCal' );
 		}


### PR DESCRIPTION
Adds our inactive post type as required by the recurrence architecture docs. I've located it within TEC as it could potentially be useful outside of ECP.

https://central.tri.be/issues/71509