### PR TITLE
Attach wp_localize_script to the correct handle, jQuery is unsafe.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.4.1] TBD =
+
+* Fix - Resolve JavaScript error when jQuery was been de-registered [71369]
+
 = [4.4.0.1] 2017-01-09 =
 
 * Fix - Adds safety check to ensure a smooth activation process when earlier versions of Tribe Common are active

--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -48,7 +48,7 @@ class Tribe__Events__Linked_Posts {
 	}
 
 	public function enqueue_scripts() {
-		wp_localize_script( 'jquery', 'tribe_events_linked_posts', $this->get_post_type_container_data() );
+		wp_localize_script( 'tribe-events-admin', 'tribe_events_linked_posts', $this->get_post_type_container_data() );
 	}
 
 	/**


### PR DESCRIPTION
_Ref:_ [C#71369](https://central.tri.be/issues/71369)