### PR TITLE
Use the correct var name and double check the var before usage

### DIFF
--- a/src/Tribe/Asset/Events_Css.php
+++ b/src/Tribe/Asset/Events_Css.php
@@ -52,7 +52,7 @@ class Tribe__Events__Asset__Events_Css extends Tribe__Events__Asset__Abstract_As
 				if ( $user_stylesheet_url ) {
 					// wp_get_theme() is safe because it has cache
 					$theme = wp_get_theme();
-					wp_enqueue_style( $name, $user_stylesheet_url, array(), $current_theme->get( 'Version' ) );
+					wp_enqueue_style( $name, $user_stylesheet_url, array(), isset( $theme ) ? $theme->get( 'Version' ) : Tribe__Events__Main::VERSION );
 				}
 			} else {
 


### PR DESCRIPTION
See: https://wordpress.org/support/topic/fatal-error-in-4-4-1/