### PR TITLE
Don't call remove_action in a function hooked to the same action

### DIFF
--- a/src/Tribe/Meta/Save.php
+++ b/src/Tribe/Meta/Save.php
@@ -109,9 +109,6 @@ class Tribe__Events__Meta__Save {
 			return false;
 		}
 
-		// Remove this hook to avoid an infinite loop, because saveEventMeta calls wp_update_post when the post is set to always show in calendar
-		remove_action( 'save_post', array( Tribe__Events__Main::instance(), 'addEventMeta' ), 15 );
-
 		$_POST['Organizer'] = isset( $_POST['organizer'] ) ? stripslashes_deep( $_POST['organizer'] ) : null;
 		$_POST['Venue']     = isset( $_POST['venue'] ) ? stripslashes_deep( $_POST['venue'] ) : null;
 

--- a/src/Tribe/Meta/Save.php
+++ b/src/Tribe/Meta/Save.php
@@ -120,9 +120,6 @@ class Tribe__Events__Meta__Save {
 
 		Tribe__Events__API::saveEventMeta( $this->post_id, $_POST, $this->post );
 
-		// Add this hook back in
-		add_action( 'save_post_' . Tribe__Events__Main::POSTTYPE, array( Tribe__Events__Main::instance(), 'addEventMeta' ), 15, 2 );
-
 		return true;
 	}
 

--- a/src/admin-views/widget-admin-list.php
+++ b/src/admin-views/widget-admin-list.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 <p>
 	<input id="<?php echo esc_attr( $this->get_field_id( 'featured_events_only' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'featured_events_only' ) ); ?>" type="checkbox" <?php checked( $instance['featured_events_only'], 1 ); ?> value="1" />
-	<label for="<?php echo esc_attr( $this->get_field_id( 'featured_events_only' ) ); ?>"><?php echo esc_html_x( 'Limit to featured events only', 'events list widget setting', 'tribe-events-calendar-pro' ); ?></label>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'featured_events_only' ) ); ?>"><?php echo esc_html_x( 'Limit to featured events only', 'events list widget setting', 'the-events-calendar' ); ?></label>
 </p>
 <p>
 	<?php $jsonld_enable = ( isset( $instance['jsonld_enable'] ) && $instance['jsonld_enable'] ) || false === $this->updated; ?>


### PR DESCRIPTION
This is a follow up of #753.

The goal of this PR was to avoid calling remove_action on 'save_post' while already running this action. The PR was merged in develop branch for the 4.3 main release. But the function was refactored in parallel in the 4.2.x branch and it looks like the merge lost the main purpose of #753, i.e removing the call to remove_action. 