### PR TITLE
Use `get_page_template()` not `locate_template()`

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 					add_action( 'loop_start', array( __CLASS__, 'setup_ecp_template' ) );
 				}
 
-				$template = locate_template( tribe_get_option( 'tribeEventsTemplate', 'default' ) == 'default' ? 'page.php' : tribe_get_option( 'tribeEventsTemplate', 'default' ) );
+				$template = tribe_get_option( 'tribeEventsTemplate', 'default' ) == 'default' ? get_page_template() : locate_template( tribe_get_option( 'tribeEventsTemplate', 'default' ) );
 
 				if ( $template == '' ) {
 					$template = get_index_template();


### PR DESCRIPTION
Using `locate_template()` effectively bypasses all of the normal template hierarchy filters that are normally made available to developers at this stage when loading a page. This PR ensures developers can still hook into those filters by using the same function that WordPress core uses in [**wp-includes/template-loader.php**](https://github.com/WordPress/WordPress/blob/master/wp-includes/template-loader.php#L56).

Full disclosure: I haven't tested this. A user was having difficulty with your plugin, and I noticed this issue when I was diving into your code. A workaround was possible for his particular issue, but I figured I would still bring this to your attention.