### PR TITLE
Aggregator > global/source specific show-map setting fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -317,7 +317,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.4.2] TBD =
 
-
+* Fix - Ensure the global and source-specific Google Map settings for imports are respected [67228]
 
 = [4.4.1.1] 2017-01-26 =
 

--- a/src/functions/template-tags/google-map.php
+++ b/src/functions/template-tags/google-map.php
@@ -87,9 +87,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( tribe_get_option( 'embedGoogleMaps', true ) ) {
 			if ( $post_type == Tribe__Events__Main::POSTTYPE ) {
-				$output = get_post_meta( $postId, '_EventShowMap', 1 ) == 1;
+				$output = tribe_is_truthy( get_post_meta( $postId, '_EventShowMap', 1 ) );
 			} elseif ( $post_type == Tribe__Events__Main::VENUE_POST_TYPE ) {
-				$output = get_post_meta( $postId, '_VenueShowMap', 1 ) !== 'false' ? 1 : 0;
+				$output = tribe_is_truthy( get_post_meta( $postId, '_VenueShowMap', 1 ) );
 			}
 		}
 
@@ -114,9 +114,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$post_type = get_post_type( $postId );
 
 		if ( $post_type == Tribe__Events__Main::POSTTYPE ) {
-			$output = get_post_meta( $postId, '_EventShowMapLink', 1 ) == 1;
+			$output = tribe_is_truthy( get_post_meta( $postId, '_EventShowMapLink', 1 ) );
 		} elseif ( $post_type == Tribe__Events__Main::VENUE_POST_TYPE ) {
-			$output = get_post_meta( $postId, '_VenueShowMapLink', 1 ) !== 'false' ? 1 : 0;
+			$output = tribe_is_truthy( get_post_meta( $postId, '_VenueShowMapLink', 1 ) );
 		}
 
 		return apply_filters( 'tribe_show_google_map_link', $output );


### PR DESCRIPTION
Historically `'1'` was used to indicate a positive show map/map link value, though we began using `'yes'` in EA. This changes makes the editor UI tolerant of both possibilities.

https://central.tri.be/issues/67228