### PR TITLE
Feature/72655 ea notices refine

### DIFF
--- a/src/Tribe/Aggregator/API/Import.php
+++ b/src/Tribe/Aggregator/API/Import.php
@@ -63,6 +63,19 @@ class Tribe__Events__Aggregator__API__Import extends Tribe__Events__Aggregator__
 		$response = $this->service->get_import( $import_id );
 
 		if ( is_wp_error( $response ) ) {
+
+			/** @var WP_Error $response */
+			if ( 'core:aggregator:http_request-limit' === $response->get_error_code() ) {
+				$response = (object) array(
+					'status'       => 'queued',
+					'message_code' => 'queued',
+					'message'      => tribe( 'events-aggregator.service' )->get_service_message( 'queued' ),
+					'data'         => (object) array(
+						'import_id' => $import_id
+					)
+				);
+			}
+
 			return $response;
 		}
 

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -188,10 +188,13 @@ class Tribe__Events__Aggregator__Service {
 		$response = $this->requests->get( esc_url_raw( $url ), array( 'timeout' => $timeout_in_seconds ) );
 
 		// this is not an error from the EA server, but one dealing with communication with it
+		// OR an error happened due to HTTP request rescheduling
 		if ( is_wp_error( $response ) ) {
+			/** @var WP_Error $response */
 			if ( isset( $response->errors['http_request_failed'] ) ) {
 				$response->errors['http_request_failed'][0] = __( 'Connection timed out while transferring the feed. If you are dealing with large feeds you may need to customize the tribe_aggregator_connection_timeout filter.', 'the-events-calendar' );
 			}
+
 			return $response;
 		}
 
@@ -409,7 +412,7 @@ class Tribe__Events__Aggregator__Service {
 	 * @return string
 	 */
 	public function get_service_message( $key, $args = array() ) {
-		if ( empty( $this->service_messages[ $key ] ) ) {
+		if ( ! $this->has_service_message( $key ) ) {
 			return __( 'Unknown service message', 'the-events-calendar' );
 		}
 
@@ -507,5 +510,16 @@ class Tribe__Events__Aggregator__Service {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Whether a message with the specified code is supported or not.
+	 *
+	 * @param string $code The message code
+	 *
+	 * @return bool
+	 */
+	public function has_service_message( $code ) {
+		return ! empty( $this->service_messages[ $code ] );
 	}
 }

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -196,6 +196,7 @@ class Tribe__Events__Aggregator__Service {
 		}
 
 		// whatever the EA server responds, success or error, the response from it will be a 200 as HTTP status
+		// so we check into it to see if something went wrong
 		if ( isset( $response->data ) && isset( $response->data->status ) && '404' === $response->data->status ) {
 			return tribe_error( 'core:aggregator:daily-limit-reached', (array) $response->data, array( $this->get_limit( 'import' ) ) );
 		}

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -435,9 +435,11 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 		$result = $this->handle_submit();
 
 		if ( is_wp_error( $result ) ) {
-			$result = (object) array(
+			/** @var Tribe__Events__Aggregator__Service $service */
+			$service = tribe( 'events-aggregator.service' );
+			$result  = (object) array(
 				'message_code' => $result->get_error_code(),
-				'message' => $result->get_error_message(),
+				'message'      => $service->get_service_message( $result->get_error_code() ),
 			);
 			wp_send_json_error( $result );
 		}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/72655

This PR:

* makes sure we use the localized version of EA server responses and not the English one
* marks re-scheduled imports as rescheduled in the history tab (was marked as an error)