### PR TITLE
Fix/72655 ea notices

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -329,6 +329,11 @@ class Tribe__Events__Aggregator__Cron {
 					$this->log( 'debug', sprintf( '%s — %s (%s)', $response->status, $response->message, $response->data->import_id ) );
 
 					$record->update_meta( 'last_import_status', 'success:queued' );
+				} elseif ( is_numeric( $response ) ) {
+					// it's the post ID of a rescheduled record
+					$this->log( 'debug', sprintf( 'rescheduled — %s', $response ) );
+
+					$record->update_meta( 'last_import_status', 'queued' );
 				} else {
 					$this->log( 'debug', 'Could not create Queue on Service' );
 

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -387,13 +387,13 @@ class Tribe__Events__Aggregator__Cron {
 
 			if ( ! is_wp_error( $queue ) ) {
 				/** @var Tribe__Events__Aggregator__Record__Queue $queue */
-				$this->log( 'debug', sprintf( 'Record (%d) has processed queue ', $queue->record->id ) );
+				$this->log( 'debug', sprintf( 'Record (%d) has processed queue ', $record->id ) );
 
 				if ( $queue instanceof Tribe__Events__Aggregator__Record__Queue ) {
 					$activity = $queue->activity()->get();
 				} else {
 					// if fetching or on error
-					$activity = $queue;
+					$activity = $queue->get();
 				}
 
 				foreach ( $activity as $key => $actions ) {

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -547,8 +547,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		// if the Aggregator API returns a WP_Error, set this record as failed
 		if ( is_wp_error( $response ) ) {
-			$error = $response;
-			return $this->set_status_as_failed( $error );
+			// if the error is just a reschedule set this record as pending
+			/** @var WP_Error $response */
+			if ( 'core:aggregator:http_request-limit' === $response->get_error_code() ) {
+				return $this->set_status_as_pending();
+			} else {
+				$error = $response;
+
+				return $this->set_status_as_failed( $error );
+			}
 		}
 
 		// if the Aggregator response has an unexpected format, set this record as failed

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -420,7 +420,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	/**
 	 * Creates a child record based on the import record
 	 *
-	 * @return boolean|WP_Error
+	 * @return boolean|WP_Error|Tribe__Events__Aggregator__Record__Abstract
 	 */
 	public function create_child_record() {
 		$post = array(

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -486,7 +486,11 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	/**
 	 * Queues the import on the Aggregator service
 	 *
-	 * @return mixed
+	 * @see Tribe__Events__Aggregator__API__Import::create()
+	 *
+	 * @return stdClass|WP_Error|int A response object, a `WP_Error` instance on failure or a record
+	 *                               post ID if the record had to be re-scheduled due to HTTP request
+	 *                               limit.
 	 */
 	public function queue_import( $args = array() ) {
 		$aggregator = tribe( 'events-aggregator.main' );

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -557,9 +557,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			'success:create-import' != $response->message_code
 			&& 'queued' != $response->message_code
 		) {
-			/**
-			 * @todo Allow overwriting the message
-			 */
 			$error = new WP_Error(
 				$response->message_code,
 				Tribe__Events__Aggregator__Errors::build(


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/72655

This PR fixes a glitch that, depending on run times and db access times, would either mark any re-scheduled import (due to too many HTTPS requests) to failed or eternally pending.