### PR TITLE
Show when no upcoming events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -321,6 +321,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Ensure the global and source-specific Google Map settings for imports are respected [67228]
 * Tweak - Add filters for template tag functions related to dates: `tribe_get_start_time`, `tribe_get_end_time`, `tribe_get_start_date` and `tribe_get_end_date` [67759]
 * Fix - Prevent PHP 5.2 Strict mode from throwing notices due to usage of `is_a` [72812]
+* Fix - Ensure the events list widget's show/hide if there are upcoming events setting is respected [72965]
 
 = [4.4.1.1] 2017-01-26 =
 

--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -65,8 +65,6 @@ class Tribe__Events__List_Widget extends WP_Widget {
 	public function widget_output( $args, $instance, $template_name = 'widgets/list-widget' ) {
 		global $wp_query, $tribe_ecp, $post;
 
-		$no_upcoming_events = true;
-
 		$instance = wp_parse_args(
 			$instance, array(
 				'limit' => self::$limit,
@@ -85,6 +83,10 @@ class Tribe__Events__List_Widget extends WP_Widget {
 		 */
 		extract( $args, EXTR_SKIP );
 		extract( $instance, EXTR_SKIP );
+
+		if ( ! isset( $no_upcoming_events ) ) {
+			$no_upcoming_events = true;
+		}
 
 		// Temporarily unset the tribe bar params so they don't apply
 		$hold_tribe_bar_args = array();


### PR DESCRIPTION
Ensure the show/hide if no upcoming events configuration of the events list widget is respected.

https://central.tri.be/issues/72965