### PR TITLE
Register TEC with Tribe__Dependency

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -139,6 +139,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public $pluginName;
 
 		public $displaying;
+		public $plugin_file;
 		public $plugin_dir;
 		public $plugin_path;
 		public $plugin_url;
@@ -252,7 +253,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Initializes plugin variables and sets up WordPress hooks/actions.
 		 */
 		protected function __construct() {
-			$this->pluginPath = $this->plugin_path = trailingslashit( dirname( dirname( dirname( __FILE__ ) ) ) );
+			$this->plugin_file = THE_EVENTS_CALENDAR_PLUGIN_FILE;
+			$this->pluginPath = $this->plugin_path = trailingslashit( dirname( $this->plugin_file ) );
 			$this->pluginDir  = $this->plugin_dir = trailingslashit( basename( $this->plugin_path ) );
 			$this->pluginUrl  = $this->plugin_url = plugins_url( $this->plugin_dir );
 
@@ -330,6 +332,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$this->loadLibraries();
 				$this->addHooks();
 				$this->maybe_load_tickets_framework();
+				$this->register_active_plugin();
 			} else {
 				// Either PHP or WordPress version is inadequate so we simply return an error.
 				add_action( 'admin_head', array( $this, 'notSupportedError' ) );
@@ -439,6 +442,19 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			require_once $this->plugin_path . 'vendor/tickets/event-tickets.php';
 			Tribe__Tickets__Main::instance()->plugins_loaded();
+		}
+
+		/**
+		 * Registers this plugin as being active for other tribe plugins and extensions
+		 */
+		protected function register_active_plugin() {
+			if ( class_exists( 'Tribe__Dependency' ) ) {
+				Tribe__Dependency::instance()->add_active_plugin(
+					__CLASS__,
+					self::VERSION,
+					$this->plugin_file
+				);
+			}
 		}
 
 		/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -253,7 +253,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Initializes plugin variables and sets up WordPress hooks/actions.
 		 */
 		protected function __construct() {
-			$this->plugin_file = THE_EVENTS_CALENDAR_PLUGIN_FILE;
+			$this->plugin_file = TRIBE_EVENTS_FILE;
 			$this->pluginPath = $this->plugin_path = trailingslashit( dirname( $this->plugin_file ) );
 			$this->pluginDir  = $this->plugin_dir = trailingslashit( basename( $this->plugin_path ) );
 			$this->pluginUrl  = $this->plugin_url = plugins_url( $this->plugin_dir );

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -27,7 +27,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'THE_EVENTS_CALENDAR_PLUGIN_FILE', __FILE__ );
+define( 'TRIBE_EVENTS_FILE', __FILE__ );
 
 // the main plugin class
 require_once dirname( __FILE__ ) . '/src/Tribe/Main.php';

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -27,6 +27,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+define( 'THE_EVENTS_CALENDAR_PLUGIN_FILE', __FILE__ );
 
 // the main plugin class
 require_once dirname( __FILE__ ) . '/src/Tribe/Main.php';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/69583

We now have a plugin file constant like we do in our other plugins, and like our plugins this one will now register itself `Tribe__Dependency`. 

I rebased the changes in `feature/66657-register-plugins` to the MR's code. That branch was meant to be submitted a few MR's back, but slipped through the cracks. 