### PR TITLE
Add policy control for URL import settings

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -229,8 +229,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 * @return WP_Post|WP_Error
 	 */
 	public function save( $post_id, $args = array(), $meta = array() ) {
-		global $wp_version;
-
 		if ( ! isset( $meta['type'] ) || 'schedule' !== $meta['type'] ) {
 			return tribe_error( 'core:aggregator:invalid-edit-record-type', $type );
 		}

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1045,8 +1045,8 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		//if we have no non recurring events the message may be different
 		$non_recurring = false;
 
-		$origin                   = $this->meta['origin'];
-		$show_map_setting         = 'yes' === Tribe__Events__Aggregator__Settings::instance()->default_map( $origin );
+		$origin = $this->meta['origin'];
+		$show_map_setting = tribe_is_truthy( Tribe__Events__Aggregator__Settings::instance()->default_map( $origin ) );
 		$update_authority_setting = Tribe__Events__Aggregator__Settings::instance()->default_update_authority( $origin );
 
 		$unique_inserted = array();

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -3,6 +3,7 @@
 defined( 'WPINC' ) or die;
 
 abstract class Tribe__Events__Aggregator__Record__Abstract {
+
 	/**
 	 * Meta key prefix for ea-record data
 	 *
@@ -19,6 +20,14 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 	public $is_schedule = false;
 	public $is_manual = false;
+
+	/**
+	 * An associative array of origins and the settings they define a policy for.
+	 * @var array
+	 */
+	protected $origin_import_policies = array(
+		'url' => array( 'show_map_link' )
+	);
 
 	public static $unique_id_fields = array(
 		'facebook' => array(
@@ -1036,8 +1045,9 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		//if we have no non recurring events the message may be different
 		$non_recurring = false;
 
-		$show_map_setting = Tribe__Events__Aggregator__Settings::instance()->default_map( $this->meta['origin'] );
-		$update_authority_setting = Tribe__Events__Aggregator__Settings::instance()->default_update_authority( $this->meta['origin'] );
+		$origin                   = $this->meta['origin'];
+		$show_map_setting         = 'yes' === Tribe__Events__Aggregator__Settings::instance()->default_map( $origin );
+		$update_authority_setting = Tribe__Events__Aggregator__Settings::instance()->default_update_authority( $origin );
 
 		$unique_inserted = array();
 
@@ -1074,13 +1084,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 				continue;
 			}
 
-			$import_settings = Tribe__Events__Aggregator__Settings::instance()->default_settings_import( $this->meta['origin'] );
+			$import_settings = Tribe__Events__Aggregator__Settings::instance()->default_settings_import( $origin );
 			$should_import_settings = 'yes' === $import_settings ? true : false;
 
 			if ( $show_map_setting ) {
-				$event['EventShowMap']     = $show_map_setting && $event['show_map'];
-				if ( $should_import_settings ) {
-					$event['EventShowMapLink'] = $show_map_setting && $event['show_map_link'];
+				$event['EventShowMap'] = $show_map_setting || (bool) isset( $event['show_map'] );
+				if ( $this->has_import_policy_for( $origin, 'show_map_link' ) ) {
+					$event['EventShowMapLink'] = isset( $event['show_map_link'] ) ? (bool) $event['show_map_link'] : $show_map_setting;
+				} else {
+					$event['EventShowMapLink'] = $show_map_setting;
 				}
 			}
 			unset( $event['show_map'], $event['show_map_link'] );
@@ -1463,5 +1475,17 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		return (object) array( 'post_id' => $id );
+	}
+
+	/**
+	 * Whether an origin has more granulat policies concerning an import setting or not.
+	 *
+	 * @param string $origin
+	 * @param string $setting
+	 *
+	 * @return bool
+	 */
+	protected function has_import_policy_for( $origin, $setting ) {
+		return isset( $this->origin_import_policies[ $origin ] ) && in_array( $setting, $this->origin_import_policies[ $origin ] );
 	}
 }

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1074,25 +1074,34 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 				continue;
 			}
 
+			$import_settings = Tribe__Events__Aggregator__Settings::instance()->default_settings_import( $this->meta['origin'] );
+			$should_import_settings = 'yes' === $import_settings ? true : false;
+
 			if ( $show_map_setting ) {
 				$event['EventShowMap']     = $show_map_setting && $event['show_map'];
-				$event['EventShowMapLink'] = $show_map_setting && $event['show_map_link'];
+				if ( $should_import_settings ) {
+					$event['EventShowMapLink'] = $show_map_setting && $event['show_map_link'];
+				}
 			}
 			unset( $event['show_map'], $event['show_map_link'] );
 
-			if ( isset( $event['hide_from_listings'] ) ) {
+			if ( $should_import_settings && isset( $event['hide_from_listings'] ) ) {
 				if ( $event['hide_from_listings'] == true ) {
 					$event['EventHideFromUpcoming'] = 'yes';
 				}
 				unset( $event['hide_from_listings'] );
 			}
 
-			if ( isset( $event['sticky'] ) ) {
+			if ( $should_import_settings && isset( $event['sticky'] ) ) {
 				if ( $event['sticky'] == true ) {
 					$event['EventShowInCalendar'] = 'yes';
 					$event['menu_order']          = - 1;
 				}
 				unset( $event['sticky'] );
+			}
+
+			if ( ! $should_import_settings ) {
+				unset( $event['feature_event'] );
 			}
 
 			if ( empty( $event['recurrence'] ) ) {

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -26,7 +26,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 * @var array
 	 */
 	protected $origin_import_policies = array(
-		'url' => array( 'show_map_link' )
+		'url' => array( 'show_map_link' ),
 	);
 
 	public static $unique_id_fields = array(

--- a/src/Tribe/Aggregator/Settings.php
+++ b/src/Tribe/Aggregator/Settings.php
@@ -17,7 +17,7 @@ class Tribe__Events__Aggregator__Settings {
 	/**
 	 * Static Singleton Factory Method
 	 *
-	 * @return Tribe__Events__Aggregator
+	 * @return Tribe__Events__Aggregator__Settings
 	 */
 	public static function instance() {
 		if ( ! self::$instance ) {
@@ -241,6 +241,22 @@ class Tribe__Events__Aggregator__Settings {
 				$setting = $origin_setting;
 			}
 		}
+
+		return $setting;
+	}
+
+	/**
+	 * Returns the default value for an origin regarding applicable event settings.
+	 *
+	 * Event setttings are those settings related to an event presentation like Show Google Map, Hide from Listings and so on.
+	 *
+	 * @param string $origin The origin to look up the settings for.
+	 *
+	 * @return string The option value.
+	 */
+	public function default_settings_import( $origin ) {
+		// by default do not import the event settings
+		$setting = tribe_get_option( "tribe_aggregator_default_{$origin}_import_event_settings", 'no' );
 
 		return $setting;
 	}

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -27,12 +27,12 @@ foreach ( $matches[1] as $key => $match ) {
 	$origin_categories[ $match ] = $matches[2][ $key ];
 }
 
-$show_map_options = array(
+$yes_no_options = array(
 	'no' => __( 'No', 'the-events-calendar' ),
 	'yes' => __( 'Yes', 'the-events-calendar' ),
 );
 
-$origin_show_map_options = array( '' => $use_global_settings_phrase ) + $show_map_options;
+$origin_show_map_options = array( '' => $use_global_settings_phrase ) + $yes_no_options;
 
 $change_authority = array(
 	'import-defaults-update_authority' => array(
@@ -140,7 +140,7 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'default' => 'no',
 			'can_be_empty' => true,
 			'parent_option' => Tribe__Events__Main::OPTIONNAME,
-			'options' => $show_map_options,
+			'options' => $yes_no_options,
 		),
 	);
 
@@ -392,6 +392,17 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'can_be_empty' => true,
 			'parent_option' => Tribe__Events__Main::OPTIONNAME,
 			'options' => $origin_show_map_options,
+		),
+		'tribe_aggregator_default_url_import_event_settings' => array(
+			'type' => 'dropdown',
+			'label' => esc_html__( 'Import Event Settings', 'the-events-calendar' ),
+			'tooltip' => esc_html__( "Fetch source event's settings (e.g. Show Google Maps Link or Sticky in Month View) when importing from another site using The Events Calendar.", 'the-events-calendar' ),
+			'size' => 'medium',
+			'validation_type' => 'options',
+			'default' => 'no',
+			'can_be_empty' => true,
+			'parent_option' => Tribe__Events__Main::OPTIONNAME,
+			'options' => $yes_no_options,
 		),
 	);
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/72911

This PR adds an option field to control whether an event presentation settings should be imported or not alongside its content when importing from the Other URL source.