### PR TITLE
remove rest api settings

### DIFF
--- a/src/Tribe/REST/V1/Settings.php
+++ b/src/Tribe/REST/V1/Settings.php
@@ -44,28 +44,6 @@ class Tribe__Events__REST__V1__Settings {
 	 * @return array
 	 */
 	protected function add_fields( array $fields = array() ) {
-		$option = Tribe__Events__REST__V1__System::get_disable_option_name();
-
-		$additional_fields = array(
-			'rest-v1-api-start' => array(
-				'type' => 'html',
-				'html' => '<h3>' . esc_html__( 'The Events Calendar REST API', 'the-events-calendar' ) . '</h3>',
-			),
-
-			'rest-v1-api-info-box' => array(
-				'type' => 'html',
-				'html' => '<p>' . __( 'The Events Calendar implements its own REST API that applications and websites can use to get events published on your site; you can disable it by unchecking this option.', 'the-events-calendar' ) . '</p>',
-			),
-
-			$option => array(
-				'type'            => 'checkbox_bool',
-				'label'           => esc_html__( 'Disable The Events Calendar REST API', 'the-events-calendar' ),
-				'tooltip'         =>  __( 'By checking this box you will disable The Events Calendar REST API; you can re-enable it later.', 'the-events-calendar' ),
-				'validation_type' => 'boolean',
-				'parent_option'   => Tribe__Events__Main::OPTIONNAME,
-			),
-		);
-
-		return array_merge( (array) $fields, $additional_fields );
+		return $fields;
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/72911

Remove the option to disable the REST API but leave the Settings structure in place as we might need it