### PR TITLE
Resolve EA Facebook image import problem caused by object vs array bug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -318,6 +318,8 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.4.3] unreleased =
 
+* Fix - Resolved issue where featured images were not being imported via Event Aggregator Facebook imports [72764]
+
 = [4.4.2] 2017-02-09 =
 
 * Fix - Ensure the global and source-specific Google Map settings for imports are respected [67228]

--- a/src/Tribe/Aggregator/API/Image.php
+++ b/src/Tribe/Aggregator/API/Image.php
@@ -71,9 +71,7 @@ class Tribe__Events__Aggregator__API__Image extends Tribe__Events__Aggregator__A
 		$headers = wp_remote_retrieve_headers( $response );
 		$body = wp_remote_retrieve_body( $response );
 
-
-
-		$is_invalid_image = empty( $headers->{'content-type'} ) && empty( $headers->{'content-disposition'} ) ;
+		$is_invalid_image = empty( $headers['content-type'] ) && empty( $headers['content-disposition'] ) ;
 
 		// Baild if we don't have Content type or Disposition
 		if ( $is_invalid_image ) {
@@ -81,7 +79,7 @@ class Tribe__Events__Aggregator__API__Image extends Tribe__Events__Aggregator__A
 		}
 
 		// if the response isn't an image then we need to bail
-		if ( ! preg_match( '/image/', $headers->{'content-type'} ) ) {
+		if ( ! preg_match( '/image/', $headers['content-type'] ) ) {
 			/**
 			 * @todo  See a way for Tribe__Errors to handle overwriting
 			 */
@@ -89,7 +87,7 @@ class Tribe__Events__Aggregator__API__Image extends Tribe__Events__Aggregator__A
 		}
 
 		// Fetch the Extension (it's safe because it comes from our service)
-		$extension = str_replace( 'image/', '', $headers->{'content-type'} );
+		$extension = str_replace( 'image/', '', $headers['content-type'] );
 
 		// Removed Query String
 		if ( false !== strpos( $extension, '?' ) ) {
@@ -98,7 +96,7 @@ class Tribe__Events__Aggregator__API__Image extends Tribe__Events__Aggregator__A
 		}
 
 		if (
-			preg_match( '/filename="([^"]+)"/', $headers->{'content-disposition'}, $matches )
+			preg_match( '/filename="([^"]+)"/', $headers['content-disposition'], $matches )
 			&& ! empty( $matches[1] )
 		) {
 			$filename = $matches[1];


### PR DESCRIPTION
`wp_remote_retrieve_headers()` returns an array of headers, not an object

See: https://central.tri.be/issues/72764