### PR TITLE
Allow for negative numbers for "Month view events per day" setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -321,6 +321,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Resolved issue where iCal exports on month view were exporting more events than intended [72133]
 * Fix - Resolved meta width issue for maps when Pro is active [69844]
 * Fix - Resolved issue where featured images were not being imported via Event Aggregator Facebook imports [72764]
+* Tweak - Allow "-1" when specifying the "Month view events per day" setting [70497]
 
 = [4.4.2] 2017-02-09 =
 

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -182,8 +182,8 @@ $display_tab_fields = Tribe__Main::array_insert_before_key(
 		'monthEventAmount'                   => array(
 			'type'            => 'text',
 			'label'           => __( 'Month view events per day', 'the-events-calendar' ),
-			'tooltip'         => sprintf( __( 'Change the default 3 events per day in month view. Please note there may be performance issues if you set this too high. <a href="%s">Read more</a>.', 'the-events-calendar' ), 'http://m.tri.be/rh' ),
-			'validation_type' => 'positive_int',
+			'tooltip'         => sprintf( __( 'Change the default 3 events per day in month view. To impose no limit, you may specify -1. Please note there may be performance issues if you allow too many events per day. <a href="%s">Read more</a>.', 'the-events-calendar' ), 'http://m.tri.be/rh' ),
+			'validation_type' => 'int',
 			'size'            => 'small',
 			'default'         => '3',
 		),


### PR DESCRIPTION
I know this allows for values less than -1, but I'm not concerned on that front.

Requires: https://github.com/moderntribe/tribe-common/pull/333

See: https://central.tri.be/issues/70497