### PR TITLE
Enable month view and day view titles to be translated separately

### DIFF
--- a/src/functions/template-tags/loop.php
+++ b/src/functions/template-tags/loop.php
@@ -159,7 +159,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( tribe_is_month() ) {
 			$title = sprintf(
-				esc_html__( '%1$s for %2$s', 'the-events-calendar' ),
+				esc_html_x( '%1$s for %2$s', 'month view', 'the-events-calendar' ),
 				$events_label_plural,
 				date_i18n( tribe_get_date_option( 'monthAndYearFormat', 'F Y' ), strtotime( tribe_get_month_view_date() ) )
 			);
@@ -168,7 +168,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		// day view title
 		if ( tribe_is_day() ) {
 			$title = sprintf(
-				esc_html__( '%1$s for %2$s', 'the-events-calendar' ),
+				esc_html_x( '%1$s for %2$s', 'day_view', 'the-events-calendar' ),
 				$events_label_plural,
 				date_i18n( tribe_get_date_format( true ), strtotime( $wp_query->get( 'start_date' ) ) )
 			);


### PR DESCRIPTION
Month and day view title strings were the same which doesn't work in some languages.

https://central.tri.be/issues/70068
https://central.tri.be/issues/68999