### PR TITLE
Fix /all/ slug for users of translation packs | #71996

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -321,6 +321,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Resolved issue where iCal exports on month view were exporting more events than intended [72133]
 * Fix - Resolved meta width issue for maps when Pro is active [69844, 72272]
 * Fix - Resolved issue where featured images were not being imported via Event Aggregator Facebook imports [72764]
+* Fix - Resolved issue where translated 'all' slugs were not respected [71996]
 * Tweak - Allow "-1" when specifying the "Month view events per day" setting [70497]
 
 = [4.4.2] 2017-02-09 =

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -93,6 +93,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public $tag_slug = 'tag';
 		public $monthSlug = 'month';
 		public $featured_slug = 'featured';
+		public $all_slug = 'featured';
 
 		/** @deprecated 4.0 */
 		public $taxRewriteSlug = 'event/category';
@@ -719,6 +720,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->daySlug                                    = sanitize_title( __( 'day', 'the-events-calendar' ) );
 			$this->todaySlug                                  = sanitize_title( __( 'today', 'the-events-calendar' ) );
 			$this->featured_slug                              = sanitize_title( _x( 'featured', 'featured events slug', 'the-events-calendar' ) );
+			$this->all_slug                                   = sanitize_title( _x( 'all', 'all events slug', 'the-events-calendar' ) );
 
 			$this->singular_venue_label                       = $this->get_venue_label_singular();
 			$this->plural_venue_label                         = $this->get_venue_label_plural();

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public $tag_slug = 'tag';
 		public $monthSlug = 'month';
 		public $featured_slug = 'featured';
-		public $all_slug = 'featured';
+		public $all_slug = 'all';
 
 		/** @deprecated 4.0 */
 		public $taxRewriteSlug = 'event/category';

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -259,7 +259,7 @@ class Tribe__Events__Rewrite extends  Tribe__Rewrite {
 			'tag' => array( 'tag', $tec->tag_slug ),
 			'tax' => array( 'category', $tec->category_slug ),
 			'page' => (array) 'page',
-			'all' => (array) 'all',
+			'all' => array( 'all', $tec->all_slug ),
 			'single' => (array) Tribe__Settings_Manager::get_option( 'singleEventSlug', 'event' ),
 			'archive' => (array) Tribe__Settings_Manager::get_option( 'eventsSlug', 'events' ),
 			'featured' => array( 'featured', $tec->featured_slug ),


### PR DESCRIPTION
Ensure that the translated version of the /all/ slug is respected.

This is in the-events-calendar rather than events-pro simply because, for whatever historic reason, most of our code that relates to this sort of permalink lives here (and it wasn't within the scope of this fix to resolve that).

https://central.tri.be/issues/71996