### PR TITLE
Added translation option for 'Location' meta box title

### DIFF
--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -198,7 +198,7 @@ class Tribe__Events__Venue {
 
 	public function meta_box_title( $title, $post_type ) {
 		if ( self::POSTTYPE === $post_type ) {
-			return 'Location';
+			return _x( 'Location', 'Metabox title', 'the-events-calendar' );
 		}
 
 		return $title;


### PR DESCRIPTION
The meta box title "Location" when creating / editing an event was not translated.