### PR TITLE
Enable month view cache by default

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -316,6 +316,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.4.5] TBD =
+
+* Tweak - Enable the month view cache by default on new installations [74867]
+
 = [4.4.4] 2017-03-08 =
 
 * Fix - Avoid unnecessarily removing a callback from an action while inside the same action (improves PolyLang compatibility - props @Chouby) [73122]

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -161,8 +161,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			// include child categories in the query, save categories for reuse
 			$this->set_queried_event_cats();
 
-
-
 			/**
 			 * Controls whether or not month view caching is enabled.
 			 *
@@ -215,7 +213,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 */
 		protected function should_enable_month_view_cache() {
 			// Respect the month view caching setting
-			if ( ! tribe_get_option( 'enable_month_view_cache', false ) ) {
+			if ( ! tribe_get_option( 'enable_month_view_cache', true ) ) {
 				return false;
 			}
 

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -191,7 +191,7 @@ $display_tab_fields = Tribe__Main::array_insert_before_key(
 			'type'            => 'checkbox_bool',
 			'label'           => __( 'Enable the Month View Cache', 'the-events-calendar' ),
 			'tooltip'         => sprintf( __( 'Check this to cache your month view HTML in transients, which can help improve calendar speed on sites with many events. <a href="%s">Read more</a>.', 'the-events-calendar' ), 'http://m.tri.be/18di' ),
-			'default'         => false,
+			'default'         => true,
 			'validation_type' => 'boolean',
 		),
 	)


### PR DESCRIPTION
For new installations/where the month view cache setting has not already been saved, default to enabling it.

https://central.tri.be/issues/74867