### PR TITLE
Respect settings preventing local changes being overriden when the ev…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -318,9 +318,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.4.5] TBD =
 
+* Fix - Local changes to events should be preserved in accordance with the Event Import Authority setting [72876]
 * Tweak - Enable the month view cache by default on new installations [74867]
-* Fix - External links to Google maps changed from http to https [74930]
-* Fix - Links to WordPress.org changed from http to https [72273]
+* Tweak - External links to Google maps changed from http to https [74930]
+* Tweak - Links to WordPress.org changed from http to https [72273]
 
 = [4.4.4] 2017-03-08 =
 

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -252,7 +252,19 @@ class Tribe__Events__Aggregator__Event {
 				continue;
 			}
 
-			$event[ $field ] = $post_meta[ $field ];
+			// If the field name contains a leading underscore we need to strip it (or the field will not save)
+			$field_name = trim( $field, '_' );
+			$event[ $field_name ] = $post_meta[ $field ];
+		}
+
+		// The start date needs to be adjusted from a MySQL style datetime string to just the date
+		if ( isset( $modified['_EventStartDate'] ) ) {
+			$event['EventStartDate'] = Tribe__Date_Utils::dateOnly( $event['EventStartDate'] );
+		}
+
+		// The end date needs to be adjusted from a MySQL style datetime string to just the date
+		if ( isset( $modified['_EventEndDate'] ) ) {
+			$event['EventEndDate'] = Tribe__Date_Utils::dateOnly( $event['EventEndDate'] );
 		}
 
 		return $event;


### PR DESCRIPTION
* Make it so that local changes to various fields including venues, organizers and categories are not overridden upon updates (when the change authority is `preserve_updates`)
* Make it so the event start/end dates don't reset to the Unix epoch in the same circumstances

[#72876](https://central.tri.be/issues/72876)