### PR TITLE
Start/end hour and minute require special handling | #72876

### DIFF
--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -263,7 +263,6 @@ class Tribe__Events__Aggregator__Event {
 			$event['EventStartDate'] = date( Tribe__Date_Utils::DBDATEFORMAT, $start_datetime );
 			$event['EventStartHour'] = date( 'H', $start_datetime );
 			$event['EventStartMinute'] = date( 'i', $start_datetime );
-			
 		}
 
 		// The end date needs to be adjusted from a MySQL style datetime string to just the date

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -259,12 +259,19 @@ class Tribe__Events__Aggregator__Event {
 
 		// The start date needs to be adjusted from a MySQL style datetime string to just the date
 		if ( isset( $modified['_EventStartDate'] ) ) {
-			$event['EventStartDate'] = Tribe__Date_Utils::dateOnly( $event['EventStartDate'] );
+			$start_datetime = strtotime( $event['EventStartDate'] );
+			$event['EventStartDate'] = date( Tribe__Date_Utils::DBDATEFORMAT, $start_datetime );
+			$event['EventStartHour'] = date( 'H', $start_datetime );
+			$event['EventStartMinute'] = date( 'i', $start_datetime );
+			
 		}
 
 		// The end date needs to be adjusted from a MySQL style datetime string to just the date
 		if ( isset( $modified['_EventEndDate'] ) ) {
-			$event['EventEndDate'] = Tribe__Date_Utils::dateOnly( $event['EventEndDate'] );
+			$end_datetime = strtotime( $event['EventEndDate'] );
+			$event['EventEndDate'] = date( Tribe__Date_Utils::DBDATEFORMAT, $end_datetime );
+			$event['EventEndHour'] = date( 'H', $end_datetime );
+			$event['EventEndMinute'] = date( 'i', $end_datetime );
 		}
 
 		return $event;


### PR DESCRIPTION
Resolves Nico's finding in [#72876 (note 12)](https://central.tri.be/issues/72876#note-12) - we explicitly need to set the start and end _hour_ and _minute_ values if we want to preserve them, in addition to the date itself.