### PR TITLE
Change wording of non TEC site message

### DIFF
--- a/src/Tribe/REST/V1/EA_Messages.php
+++ b/src/Tribe/REST/V1/EA_Messages.php
@@ -6,7 +6,7 @@ class Tribe__Events__REST__V1__EA_Messages extends Tribe__Events__REST__V1__Mess
 
 		// TEC REST v1 messages will all have the `rest-v1:` prefix applied
 		$ea_messages = array(
-			'not-tec-rest-api-site'              => __( 'The Events Calendar is not active or is not at least version 4.5 on the requested URL.', 'the-events-calendar' ),
+			'not-tec-rest-api-site'              => __( 'Event Aggregator cannot import events from this site.', 'the-events-calendar' ),
 			'tec-rest-api-missing-origin'        => __( 'The Events Calendar is API is not providing the site origin correctly.', 'the-events-calendar' ),
 			'tec-rest-api-unsupported'           => __( 'Events could not be imported. Event Aggregator does not yet support events from that URL. We have noted your request and will review it for support in the future.', 'the-events-calendar' ),
 			'tec-rest-api-disabled'              => __( 'Events could not be imported. The Events Calendar REST API is disabled on the requested URL.', 'the-events-calendar' ),


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/71337

See PR: https://github.com/moderntribe/event-aggregator-site/pull/144

This PR changes the wording of the message reporting a site as one not exposing any information about TEC REST API as per Leah's request here: https://central.tri.be/issues/71337#note-21