### PR TITLE
Purge import usage count on license update

### DIFF
--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -251,7 +251,11 @@ class Tribe__Events__Aggregator {
 
 		$cache_group = $this->api( 'origins' )->cache_group;
 
-		return delete_transient( "{$cache_group}_origins" );
+		$purged = true;
+		$purged &= (bool) delete_transient( "{$cache_group}_origins" );
+		$purged &= (bool) delete_transient( "{$cache_group}_origin_limit" );
+
+		return $purged;
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/75561

Origins limit should be purged when the license string is updated.