### PR TITLE
Avoid category and tag override during import

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -374,6 +374,8 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		 * @param int $event_id The event post ID
 		 * @param array $args An array of arguments supported by the `wp_get_object_terms` function.
 		 *
+		 * @since 4.5
+		 *
 		 * @see wp_get_object_terms()
 		 *
 		 * @return array An associative array of terms in the [ <taxonomy> => [ <term_1>, <term_2>, ...], ...] format.

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -371,6 +371,24 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 		}
 
 		/**
+		 * @param int $event_id The event post ID
+		 * @param array $args An array of arguments supported by the `wp_get_object_terms` function.
+		 *
+		 * @see wp_get_object_terms()
+		 *
+		 * @return array An associative array of terms in the [ <taxonomy> => [ <term_1>, <term_2>, ...], ...] format.
+		 */
+		public static function get_event_terms( $event_id, array $args = [] ) {
+			$terms = array();
+			foreach ( get_post_taxonomies( $event_id ) as $taxonomy ) {
+				$tax_terms = wp_get_object_terms( $event_id, $taxonomy, $args );
+				$terms[ $taxonomy ] = $tax_terms;
+			}
+
+			return $terms;
+		}
+
+		/**
 		 * Saves the event organizer information passed via an event
 		 *
 		 * @param array   $data        The organizer data.

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -343,10 +343,8 @@ class Tribe__Events__Aggregator__Event {
 			if ( ! isset( $modified[ $taxonomy ] ) ) {
 				continue;
 			}
-			$tax_key = isset( $taxonomy_map[ $taxonomy ] ) ?
-				$taxonomy_map[ $taxonomy ]
-				: $taxonomy;
 
+			$tax_key = Tribe__Utils__Array::get( $taxonomy, $taxonomy_map, $taxonomy );
 			$data[ $tax_key ] = $post_terms[ $taxonomy ];
 		}
 

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -271,6 +271,7 @@ class Tribe__Events__Aggregator__Event {
 
 		$post = get_post( $data['ID'] );
 		$post_meta = Tribe__Events__API::get_and_flatten_event_meta( $data['ID'] );
+		$post_terms = Tribe__Events__API::get_event_terms( $data['ID'], array( 'fields' => 'ids' ) );
 
 		if ( empty( $post_meta[ Tribe__Tracker::$field_key ] ) ) {
 			$modified = array();
@@ -331,6 +332,22 @@ class Tribe__Events__Aggregator__Event {
 			}
 
 			$data[ $field ] = $post_meta[ $field ];
+		}
+
+		// reset any modified taxonomy terms
+		$taxonomy_map = array(
+			'post_tag'	 => 'tags',
+			Tribe__Events__Main::TAXONOMY => 'categories',
+		);
+		foreach ( $post_terms as $taxonomy => $terms ) {
+			if ( ! isset( $modified[ $taxonomy ] ) ) {
+				continue;
+			}
+			$tax_key = isset( $taxonomy_map[ $taxonomy ] ) ?
+				$taxonomy_map[ $taxonomy ]
+				: $taxonomy;
+
+			$data[ $tax_key ] = $post_terms[ $taxonomy ];
 		}
 
 		return $data;

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -344,7 +344,7 @@ class Tribe__Events__Aggregator__Event {
 				continue;
 			}
 
-			$tax_key = Tribe__Utils__Array::get( $taxonomy, $taxonomy_map, $taxonomy );
+			$tax_key = Tribe__Utils__Array::get( $taxonomy_map, $taxonomy, $taxonomy );
 			$data[ $tax_key ] = $post_terms[ $taxonomy ];
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/74264

This PR taps into the `Tribe_Tracker` class to avoid resetting an imported event local changes pertaining tags and categories to the imported data.