### PR TITLE
add taxonomy tracking in Main

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -558,6 +558,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			add_action( 'plugins_loaded', array( 'Tribe__Support', 'getInstance' ) );
 
 			add_filter( 'tribe_tracker_post_types', array( $this, 'filter_tracker_event_post_types' ) );
+			add_filter( 'tribe_tracker_taxonomies', array( $this, 'filter_tracker_event_taxonomies' ) );
 
 			if ( ! Tribe__Main::instance()->doing_ajax() ) {
 				add_action( 'current_screen', array( $this, 'init_admin_list_screen' ) );
@@ -953,12 +954,28 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @return array
 		 */
-		public function filter_tracker_event_post_types( $post_types ) {
+		public function filter_tracker_event_post_types( array $post_types ) {
 			$post_types[] = self::POSTTYPE;
 			$post_types[] = Tribe__Events__Venue::POSTTYPE;
 			$post_types[] = Tribe__Events__Organizer::POSTTYPE;
 
 			return $post_types;
+		}
+
+		/**
+		 * By default Tribe__Tracker won't track our Post Types taxonomies, so we add them here.
+		 *
+		 * @since  4.5
+		 *
+		 * @param  array $taxonomies
+		 *
+		 * @return array
+		 */
+		public function filter_tracker_event_taxonomies( array $taxonomies ) {
+			$taxonomies[] = 'post_tag';
+			$taxonomies[] = self::TAXONOMY;
+
+			return $taxonomies;
 		}
 
 		/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/74

This PR makes sure we are tracking the `post_tag` and the `tribe_events_cat` taxonomies for our post types to avoid them being overriden in imports.