### PR TITLE
Improvements to month view caching

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -316,6 +316,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.4.6] 2017-04-19 =
+
+* Fix - Enhance month view caching to minimize impact of JSON-LD generation [74656]
+
 = [4.4.5] 2017-03-23 =
 
 * Fix - Local changes to events should be preserved in accordance with the Event Import Authority setting (thanks to @bryan for reporting this one) [72876]

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -549,8 +549,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				AND $wpdb->posts.post_status IN('$post_stati')
 				ORDER BY $wpdb->posts.menu_order ASC, DATE(tribe_event_start.meta_value) ASC, TIME(tribe_event_start.meta_value) ASC;
 				",
-				$grid_start_datetime,
-				$grid_end_datetime
+				tribe_beginning_of_day( $this->first_grid_date ),
+				tribe_end_of_day( $this->final_grid_date )
 			);
 
 			$this->events_in_month = $wpdb->get_results( $events_request );

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -289,11 +289,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				return;
 			}
 
-			$grid_start_datetime = tribe_beginning_of_day( $this->first_grid_date );
-			$grid_end_datetime   = tribe_end_of_day( $this->final_grid_date );
-
 			$cache     = new Tribe__Cache();
-			$cache_key = 'events_month_jsonld_' . $grid_start_datetime . '-' . $grid_end_datetime;
+			$cache_key = $this->get_month_view_cache_key( 'events_month_jsonld' );
 			$json_ld   = $cache->get_transient( $cache_key, 'save_post' );
 
 			if ( ! $json_ld ) {
@@ -505,11 +502,8 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		protected function set_events_in_month() {
 			global $wpdb;
 
-			$grid_start_datetime = tribe_beginning_of_day( $this->first_grid_date );
-			$grid_end_datetime   = tribe_end_of_day( $this->final_grid_date );
-
 			$cache     = new Tribe__Cache();
-			$cache_key = 'events_in_month' . $grid_start_datetime . '-' . $grid_end_datetime;
+			$cache_key = $this->get_month_view_cache_key( 'events_in_month' );
 
 			// We always use the object cache if available
 			$cache_getter = 'get';
@@ -568,6 +562,19 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			// cache the found events in the object cache
 			$cache->$cache_setter( $cache_key, $this->events_in_month, $expiration, 'save_post' );
+		}
+
+		/**
+		 * Returns a string that can be used as a cache key for the current month.
+		 *
+		 * @param string $prefix
+		 *
+		 * @return string
+		 */
+		protected function get_month_view_cache_key( $prefix ) {
+			$grid_start_datetime = tribe_beginning_of_day( $this->first_grid_date );
+			$grid_end_datetime   = tribe_end_of_day( $this->final_grid_date );
+			return $prefix . '-' . $grid_start_datetime . '-' . $grid_end_datetime;
 		}
 
 		/**


### PR DESCRIPTION
If month view caching is enabled let's persistently cache both the result of the events-in-the-month query and the month's JSON LD output (in addition to the month view HTML, which is already covered).

In local testing, this reduced the total number of queries required to build month view by 90% (given a month containing 100 events). Props to @elimn for laying the groundwork here.

:ticket: [#74656](https://central.tri.be/issues/74656)