### PR TITLE
Add the no-results message for feeds

### DIFF
--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -515,6 +515,7 @@ class Tribe__Events__Aggregator__Service {
 			'success:import-complete' => __( 'Import is complete', 'the-events-calendar' ),
 			'success:queued' => __( 'Import queued', 'the-events-calendar' ),
 			'error:invalid-other-url' => __( 'Events could not be imported. The URL provided could not be reached.', 'the-events-calendar' ),
+			'error:empty-results' => __( 'The requested source does not have any upcoming and published events matching the search criteria.', 'the-events-calendar' ),
 		);
 
 		/**

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -515,7 +515,7 @@ class Tribe__Events__Aggregator__Service {
 			'success:import-complete' => __( 'Import is complete', 'the-events-calendar' ),
 			'success:queued' => __( 'Import queued', 'the-events-calendar' ),
 			'error:invalid-other-url' => __( 'Events could not be imported. The URL provided could not be reached.', 'the-events-calendar' ),
-			'error:empty-results' => __( 'The requested source does not have any upcoming and published events matching the search criteria.', 'the-events-calendar' ),
+			'error:no-results' => __( 'The requested source does not have any upcoming and published events matching the search criteria.', 'the-events-calendar' ),
 		);
 
 		/**


### PR DESCRIPTION
Ticket (contetxt): https://central.tri.be/issues/72634

This PR adds support for the `no-results` message when a fetch from a feed is successful but simply yields no results; this could happen when using keywords or dates or whatever.

This avoids the client hanging up on an empty events array after receiving the response.