### PR TITLE
64088 | Prevent Duplicate Venues After "Previewing" an Event

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3301,7 +3301,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				wp_delete_post( $venue_id );
 			}
 
-			//In some cases, one must clear the _EventVenueID before it's regenerated.
+			// In some cases, one must clear the _EventVenueID before it's regenerated.
 			if ( $delete_meta ) {
 				delete_post_meta( $event_id, '_EventVenueID' );
 			}
@@ -3333,7 +3333,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				wp_delete_post( $organizer_id );
 			}
 
-			//In some cases, one must clear the _EventOrganizerID before it's regenerated.
+			// In some cases, one must clear the _EventOrganizerID before it's regenerated.
 			if ( $delete_meta ) {
 				delete_post_meta( $event_id, '_EventOrganizerID' );
 			}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3210,7 +3210,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return;
 			}
 
-
 			foreach ( $preview_venues as $key => $venue_id ) {
 				wp_delete_post( $venue_id );
 			}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3242,14 +3242,14 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function link_preview_venue_to_event( $venue_id, $event_id ) {
 
-			$preview_venues = (array) get_post_meta( $event_id, '_previewVenues', true );
+			$preview_venues = (array) get_post_meta( $event_id, '_preview_venues', true );
 			$preview_venues[] = $venue_id;
 
 			// Remove empty and duplicate values, which can easily arise here.
 			$preview_venues = array_filter( $preview_venues );
 			$preview_venues = array_unique( $preview_venues );
 
-			update_post_meta( $event_id, '_previewVenues', array_values( $preview_venues ) );
+			update_post_meta( $event_id, '_preview_venues', array_values( $preview_venues ) );
 		}
 
 		/**
@@ -3262,7 +3262,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function link_preview_organizer_to_event( $organizer_ids, $event_id ) {
 
-			$preview_organizers = (array) get_post_meta( $event_id, '_previewOrganizers', true );
+			$preview_organizers = (array) get_post_meta( $event_id, '_preview_organizers', true );
 
 			foreach ( $organizer_ids as $key => $organizer_id ) {
 				$preview_organizers[] = $organizer_id;
@@ -3272,7 +3272,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$preview_organizers = array_filter( $preview_organizers );
 			$preview_organizers = array_unique( $preview_organizers );
 
-			update_post_meta( $event_id, '_previewOrganizers', array_values( $preview_organizers ) );
+			update_post_meta( $event_id, '_preview_organizers', array_values( $preview_organizers ) );
 		}
 
 		/**
@@ -3291,7 +3291,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return;
 			}
 
-			$preview_venues = get_post_meta( $event_id, '_previewVenues', true );
+			$preview_venues = get_post_meta( $event_id, '_preview_venues', true );
 
 			if ( ! is_array( $preview_venues ) || empty( $preview_venues ) ) {
 				return;
@@ -3323,7 +3323,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return;
 			}
 
-			$preview_organizers = get_post_meta( $event_id, '_previewOrganizers', true );
+			$preview_organizers = get_post_meta( $event_id, '_preview_organizers', true );
 
 			if ( ! is_array( $preview_organizers ) || empty( $preview_organizers ) ) {
 				return;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -660,7 +660,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// Prevent duplicate venues from being created on event preview.
-			add_action( 'tribe_events_after_view', array( $this, 'maybe_prevent_duplicate_venues' ) );
+			add_action( 'tribe_events_after_view', array( $this, 'maybe_add_preview_venues' ) );
 
 			/**
 			 * Expire notices
@@ -3154,7 +3154,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @since 4.5.1
 		 */
-		public function add_preview_venues() {
+		public function maybe_add_preview_venues() {
 
 			if ( ! is_singular( self::POSTTYPE ) ) {
 				return;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3043,19 +3043,19 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		/**
 		 * Publishes associated venue/organizer when an event is published
 		 *
-		 * @param int     $postID , the post ID
-		 * @param WP_Post $post   , the post object
+		 * @param int     $post_id The post ID.
+		 * @param WP_Post $post    The post object.
 		 *
 		 */
-		public function publishAssociatedTypes( $postID, $post ) {
+		public function publishAssociatedTypes( $post_id, $post ) {
 
 			// don't need to save the venue or organizer meta when we are just publishing
 			remove_action( 'save_post_' . self::VENUE_POST_TYPE, array( $this, 'save_venue_data' ), 16, 2 );
 			remove_action( 'save_post_' . self::ORGANIZER_POST_TYPE, array( $this, 'save_organizer_data' ), 16, 2 );
 
 			// Remove any "preview" venues and organizers (duplicates) attached to this event.
-			$this->remove_preview_venues( $postID, true );
-			$this->remove_preview_organizers( $postID, true );
+			$this->remove_preview_venues( $post_id, true );
+			$this->remove_preview_organizers( $post_id, true );
 
 			// save venue and organizer info on first pass
 			if ( isset( $post->post_status ) && $post->post_status == 'publish' ) {

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -229,10 +229,18 @@ class Tribe__Events__Venue {
 	 * @param array  $data The venue data.
 	 * @param string $post_type Venue Post Type
 	 * @param string $post_status The intended post status.
+	 * @param int|null $event_id The ID of the linked event
 	 *
 	 * @return mixed
 	 */
-	public function save( $id, $data, $post_type, $post_status ) {
+	public function save( $id, $data, $post_type, $post_status, $event_id ) {
+
+// print '<pre>';
+// print '<h1>DATA</h1>';
+// var_dump( $data );
+// print '</pre><hr>'
+
+// die;
 		if ( isset( $data['VenueID'] ) && $data['VenueID'] > 0 ) {
 			if ( count( $data ) == 1 ) {
 				// Only an ID was passed and we should do nothing.
@@ -253,7 +261,7 @@ class Tribe__Events__Venue {
 			unset( $data['VenueID'] );
 		}
 
-		return $this->create( $data, $post_status );
+		return $this->create( $data, $post_status, $event_id );
 	}
 
 	/**
@@ -304,24 +312,37 @@ class Tribe__Events__Venue {
 	/**
 	 * Creates a new venue
 	 *
-	 * @param array  $data        The venue data.
-	 * @param string $post_status the intended post status.
+	 * @param array    $data        The venue data.
+	 * @param string   $post_status the intended post status.
+	 * @param int|null $event_id    The event ID.
 	 *
 	 * @return int
 	 */
-	public function create( $data, $post_status = 'publish' ) {
+	public function create( $data, $post_status = 'publish', $event_id = 0 ) {
 
 		if ( ( isset( $data['Venue'] ) && $data['Venue'] ) || $this->has_venue_data( $data ) ) {
 			$title   = isset( $data['Venue'] ) ? $data['Venue'] : esc_html__( 'Unnamed Venue', 'the-events-calendar' );
 			$content = isset( $data['Description'] ) ? $data['Description'] : '';
 			$slug    = sanitize_title( $title );
 
+			// // Get the event origin; it may be useful for preventing duplicates.
+			// $event_origin = get_post_meta( $event_id, '_EventOrigin', true );
+
+			// // Determine if we're in a context where some extra work is required to prevent
+			// // duplicate venues after "previewing" the parent event.
+			// $prevent_duplicates = 'draft' === $post_status && $event_id && 'events-calendar' === $event_origin;
+
+			// // When publishing the parent event, check for and remove "preview" venues.
+			// if ( 'publish' === $post_status && 'events-calendar' === $event_origin ) {
+			// 	Tribe__Events__Main::instance()->remove_preview_venues( $event_id, true );
+			// }
+
 			$postdata = array(
-				'post_title'  => $title,
+				'post_title'   => $title,
 				'post_content' => $content,
-				'post_name'   => $slug,
-				'post_type'   => self::POSTTYPE,
-				'post_status' => $post_status,
+				'post_name'    => $slug,
+				'post_type'    => self::POSTTYPE,
+				'post_status'  => $post_status,
 			);
 
 			$venue_id = wp_insert_post( $postdata, true );
@@ -331,8 +352,22 @@ class Tribe__Events__Venue {
 			$data['ShowMapLink'] = isset( $data['ShowMapLink'] ) ? $data['ShowMapLink'] : 'true';
 
 			if ( ! is_wp_error( $venue_id ) ) {
+
 				$this->save_meta( $venue_id, $data );
+
 				do_action( 'tribe_events_venue_created', $venue_id, $data );
+
+				// Helps prevent duplicate venues when events are previewd.
+				// if ( $prevent_duplicates ) {
+
+				// 	$preview_venues   = (array) get_post_meta( $event_id, '_previewVenues', true );
+				// 	$preview_venues[] = $venue_id;
+
+				// 	// Remove empty values, which can easily arise here.
+				// 	$preview_venues = array_filter( $preview_venues );
+
+				// 	update_post_meta( $event_id, '_previewVenues', array_values( $preview_venues ) );
+				// }
 
 				return $venue_id;
 			}

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -229,18 +229,10 @@ class Tribe__Events__Venue {
 	 * @param array  $data The venue data.
 	 * @param string $post_type Venue Post Type
 	 * @param string $post_status The intended post status.
-	 * @param int|null $event_id The ID of the linked event
 	 *
 	 * @return mixed
 	 */
-	public function save( $id, $data, $post_type, $post_status, $event_id ) {
-
-// print '<pre>';
-// print '<h1>DATA</h1>';
-// var_dump( $data );
-// print '</pre><hr>'
-
-// die;
+	public function save( $id, $data, $post_type, $post_status ) {
 		if ( isset( $data['VenueID'] ) && $data['VenueID'] > 0 ) {
 			if ( count( $data ) == 1 ) {
 				// Only an ID was passed and we should do nothing.
@@ -261,7 +253,7 @@ class Tribe__Events__Venue {
 			unset( $data['VenueID'] );
 		}
 
-		return $this->create( $data, $post_status, $event_id );
+		return $this->create( $data, $post_status );
 	}
 
 	/**
@@ -312,37 +304,24 @@ class Tribe__Events__Venue {
 	/**
 	 * Creates a new venue
 	 *
-	 * @param array    $data        The venue data.
-	 * @param string   $post_status the intended post status.
-	 * @param int|null $event_id    The event ID.
+	 * @param array  $data        The venue data.
+	 * @param string $post_status the intended post status.
 	 *
 	 * @return int
 	 */
-	public function create( $data, $post_status = 'publish', $event_id = 0 ) {
+	public function create( $data, $post_status = 'publish' ) {
 
 		if ( ( isset( $data['Venue'] ) && $data['Venue'] ) || $this->has_venue_data( $data ) ) {
 			$title   = isset( $data['Venue'] ) ? $data['Venue'] : esc_html__( 'Unnamed Venue', 'the-events-calendar' );
 			$content = isset( $data['Description'] ) ? $data['Description'] : '';
 			$slug    = sanitize_title( $title );
 
-			// // Get the event origin; it may be useful for preventing duplicates.
-			// $event_origin = get_post_meta( $event_id, '_EventOrigin', true );
-
-			// // Determine if we're in a context where some extra work is required to prevent
-			// // duplicate venues after "previewing" the parent event.
-			// $prevent_duplicates = 'draft' === $post_status && $event_id && 'events-calendar' === $event_origin;
-
-			// // When publishing the parent event, check for and remove "preview" venues.
-			// if ( 'publish' === $post_status && 'events-calendar' === $event_origin ) {
-			// 	Tribe__Events__Main::instance()->remove_preview_venues( $event_id, true );
-			// }
-
 			$postdata = array(
-				'post_title'   => $title,
+				'post_title'  => $title,
 				'post_content' => $content,
-				'post_name'    => $slug,
-				'post_type'    => self::POSTTYPE,
-				'post_status'  => $post_status,
+				'post_name'   => $slug,
+				'post_type'   => self::POSTTYPE,
+				'post_status' => $post_status,
 			);
 
 			$venue_id = wp_insert_post( $postdata, true );
@@ -352,22 +331,8 @@ class Tribe__Events__Venue {
 			$data['ShowMapLink'] = isset( $data['ShowMapLink'] ) ? $data['ShowMapLink'] : 'true';
 
 			if ( ! is_wp_error( $venue_id ) ) {
-
 				$this->save_meta( $venue_id, $data );
-
 				do_action( 'tribe_events_venue_created', $venue_id, $data );
-
-				// Helps prevent duplicate venues when events are previewd.
-				// if ( $prevent_duplicates ) {
-
-				// 	$preview_venues   = (array) get_post_meta( $event_id, '_previewVenues', true );
-				// 	$preview_venues[] = $venue_id;
-
-				// 	// Remove empty values, which can easily arise here.
-				// 	$preview_venues = array_filter( $preview_venues );
-
-				// 	update_post_meta( $event_id, '_previewVenues', array_values( $preview_venues ) );
-				// }
 
 				return $venue_id;
 			}


### PR DESCRIPTION
_Ref:_ [C#64088](https://central.tri.be/issues/64088)

---

This one has been pretty challenging for me, but I say with caution that I _think_ I have implemented a solution here that:
- Reliably prevents duplicate venues from existing after "Previewing" an Event.
- Doesn't require reworking the whole way venues/linked posts are saved.

What I spent a lot of time untangling here was the following problem:
- When "previewing" an event, it's saved as a draft.
- This fact was useful to me at first—by watching for the transition of an event's post status from _draft_ to _publish_, for example, I was able to capture "duplicate" venues from when the event was previewed and delete those duplicate venues.
- *But*, an event's being a draft is totally arbitrary. There's nothing about the post status that tells you if the event is a draft because it was "previewed", saved as a draft, imported via Aggregator or CSV as a draft, published then reverted to draft, etc.
- And so my first solution failed in all of the above use cases.

This current solution uses what seem a weird method: it takes much of the code I had in place for the first method to link "preview"/duplicate venues to events, and then flush those duplicates on the publishing of the event. 

But it only does this linking of duplicates to events when explicitly previewing an event. I'm using the front-end hook `tribe_events_after_view` to do this, which might be weird or even outright not acceptable, but in my rudimentary testing thus far, this solution has worked very in all of the normative cases and edge cases alike. By using a front-end hook instead of wrangling with back-end options, I'm able to use the Core function `is_preview`, which was a huge boon for (hopefully-) solving this problem.

I'm flagging Gustavo for code review on this one at his request.