### PR TITLE
Replace MONTH_IN_SECONDS with 30 * DAY_IN_SECONDS

### DIFF
--- a/src/Tribe/Aggregator/Settings.php
+++ b/src/Tribe/Aggregator/Settings.php
@@ -269,35 +269,35 @@ class Tribe__Events__Aggregator__Settings {
 	 */
 	public function get_url_import_range_options( $title = true ) {
 		$options = array(
-			DAY_IN_SECONDS       => array(
+			DAY_IN_SECONDS          => array(
 				'title' => __( '24 hours', 'the-events-calendar' ),
 				'range' => __( '24 hours', 'the-events-calendar' ),
 			),
-			3 * DAY_IN_SECONDS   => array(
+			3 * DAY_IN_SECONDS      => array(
 				'title' => __( '72 hours', 'the-events-calendar' ),
 				'range' => __( '72 hours', 'the-events-calendar' ),
 			),
-			WEEK_IN_SECONDS      => array(
+			WEEK_IN_SECONDS         => array(
 				'title' => __( 'One week', 'the-events-calendar' ),
 				'range' => __( 'a week', 'the-events-calendar' ),
 			),
-			2 * WEEK_IN_SECONDS  => array(
+			2 * WEEK_IN_SECONDS     => array(
 				'title' => __( 'Two weeks', 'the-events-calendar' ),
 				'range' => __( 'two weeks', 'the-events-calendar' ),
 			),
-			3 * WEEK_IN_SECONDS  => array(
+			3 * WEEK_IN_SECONDS     => array(
 				'title' => __( 'Three weeks', 'the-events-calendar' ),
 				'range' => __( 'three weeks', 'the-events-calendar' ),
 			),
-			MONTH_IN_SECONDS     => array(
+			30 * DAY_IN_SECONDS     => array(
 				'title' => __( 'One month', 'the-events-calendar' ),
 				'range' => __( 'a month', 'the-events-calendar' ),
 			),
-			2 * MONTH_IN_SECONDS => array(
+			2 * 30 * DAY_IN_SECONDS => array(
 				'title' => __( 'Two months', 'the-events-calendar' ),
 				'range' => __( 'two months', 'the-events-calendar' ),
 			),
-			3 * MONTH_IN_SECONDS => array(
+			3 * 30 * DAY_IN_SECONDS => array(
 				'title' => __( 'Three months', 'the-events-calendar' ),
 				'range' => __( 'three months', 'the-events-calendar' ),
 			),

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -147,7 +147,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 				break;
 			case 'url':
 				$now = time();
-				$range = tribe_get_option( 'tribe_aggregator_default_url_import_range', 3 * MONTH_IN_SECONDS );
+				$range = tribe_get_option( 'tribe_aggregator_default_url_import_range', 3 * 30 * DAY_IN_SECONDS );
 				$start = ! empty( $meta['start'] ) ? $this->to_timestamp( $meta['start'], $now ) : $now;
 				$end = ! empty( $meta['end'] ) ? $this->to_timestamp( $meta['end'], $now + $range ) : $now + $range;
 
@@ -157,7 +157,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 				 * @param int   $max_range The duration in seconds of the cap.
 				 * @param array $meta      The meta for this import request.
 				 */
-				$max_range = apply_filters( 'tribe_aggregator_url_import_range_cap', 3 * MONTH_IN_SECONDS, $meta );
+				$max_range = apply_filters( 'tribe_aggregator_url_import_range_cap', 3 * 30 * DAY_IN_SECONDS, $meta );
 
 				// but soft-cap the range to start + cap at the most
 				$end = min( $end, $start + $max_range );

--- a/src/admin-views/aggregator/origins/url.php
+++ b/src/admin-views/aggregator/origins/url.php
@@ -83,7 +83,7 @@ $field->label       = __( 'URL:', 'the-events-calendar' );
 $field->placeholder = __( 'example.com/', 'the-events-calendar' );
 $field->help        = __( 'Enter the url for the calendar, website, or event you would like to import. Event Aggregator will attempt to import events at that location.', 'the-events-calendar' );
 
-$range_option = tribe_get_option( 'tribe_aggregator_default_url_import_range', MONTH_IN_SECONDS );
+$range_option = tribe_get_option( 'tribe_aggregator_default_url_import_range', 30 * DAY_IN_SECONDS );
 $range_strings = tribe( 'events-aggregator.settings' )->get_url_import_range_options( false );
 $range_string = $range_strings[ $range_option ];
 $range_message = esc_html( sprintf( __( 'Event Aggregator will try to fetch events starting in %s from the current date or the specified date;', 'the-events-calendar' ), $range_string ) );

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -400,7 +400,7 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'tooltip' => esc_html__( 'When importing from a website that uses The Events Calendar, the REST API will attempt to fetch events this far in the future. That website\'s hosting resources may impact the success of imports. Selecting a shorter time period may improve results.', 'the-events-calendar' ) . ' ' . sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_attr( 'https://theeventscalendar.com/knowledgebase/other-url-import-errors-in-event-aggregator' ), esc_html( 'Learn more.' ) ),
 			'size' => 'medium',
 			'validation_type' => 'options',
-			'default' => MONTH_IN_SECONDS,
+			'default' => 30 * DAY_IN_SECONDS,
 			'can_be_empty' => false,
 			'parent_option' => Tribe__Events__Main::OPTIONNAME,
 			'options' => tribe( 'events-aggregator.settings' )->get_url_import_range_options( true ),


### PR DESCRIPTION
`MONTH_IN_SECONDS` is not available on versions prior to 4.4 of WP