### PR TITLE
check record creation time too to mark it stalled

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -299,6 +299,12 @@ class Tribe__Events__Aggregator__Cron {
 		foreach ( $query->posts as $post ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
 
+			if ( empty( $record->meta['_tribe_aggregator_queue'] ) ) {
+				// this is incoherent, a schedule should have a queue
+				$record->set_status( Tribe__Events__Aggregator__Records::$status->failed );
+				continue;
+			}
+
 			if ( ! $record->is_schedule_time() ) {
 				$this->log( 'debug', sprintf( 'Record (%d) skipped, not scheduled time', $record->id ) );
 				continue;

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -378,8 +378,16 @@ class Tribe__Events__Aggregator__Cron {
 			return;
 		}
 
+		$cleaner = new Tribe__Events__Aggregator__Record__Queue_Cleaner();
 		foreach ( $query->posts as $post ) {
 			$record = $records->get_by_post_id( $post );
+
+			$cleaner->remove_duplicate_pending_records_for( $record );
+			$failed = $cleaner->maybe_fail_stalled_record( $record );
+
+			if ( $failed ) {
+				continue;
+			}
 
 			// Just double Check for CSV
 			if ( 'csv' === $record->origin ) {

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -792,7 +792,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 * @return boolean
 	 */
 	public function is_schedule_time() {
-		if ( true == getenv( 'TRIBE_DEBUG_OVERRIDE_SCHEDULE' ) ) {
+		if ( tribe_is_truthy( getenv( 'TRIBE_DEBUG_OVERRIDE_SCHEDULE' ) ) ) {
 			return true;
 		}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -792,6 +792,10 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 * @return boolean
 	 */
 	public function is_schedule_time() {
+		if ( true == getenv( 'TRIBE_DEBUG_OVERRIDE_SCHEDULE' ) ) {
+			return true;
+		}
+
 		// If we are not on a Schedule Type
 		if ( ! $this->is_schedule ) {
 			return false;

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -20,6 +20,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 	public $is_schedule = false;
 	public $is_manual = false;
+	public $last_wpdb_error = '';
 
 	/**
 	 * An associative array of origins and the settings they define a policy for.
@@ -218,10 +219,19 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		$post = $this->prep_post_args( $type, $args, $meta );
 
+		$this->watch_for_db_errors();
+
 		$result = wp_insert_post( $post );
 
 		if ( is_wp_error( $result ) ) {
 			$this->maybe_add_meta_via_pre_wp_44_method( $result, $post['meta_input'] );
+		}
+
+		if ( $this->db_errors_happened() ) {
+			$error_message = __( 'Something went wrong while inserting the record in the database.', 'the-events-calendar' );
+			wp_delete_post( $result );
+
+			return new WP_Error( 'db-error-during-creation', $error_message );
 		}
 
 		// After Creating the Post Load and return
@@ -397,6 +407,8 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		// Setups the post_content as the Frequency (makes it easy to fetch by frequency)
 		$post['post_content'] = $frequency->id;
 
+		$this->watch_for_db_errors();
+
 		// create schedule post
 		$schedule_id = wp_insert_post( $post );
 
@@ -406,6 +418,13 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		$this->maybe_add_meta_via_pre_wp_44_method( $schedule_id, $post['meta_input'] );
+
+
+		if ( $this->db_errors_happened() ) {
+			wp_delete_post( $schedule_id );
+
+			return tribe_error( 'core:aggregator:save-schedule-failed' );
+		}
 
 		$update_args = array(
 			'ID' => $this->post->ID,
@@ -453,14 +472,17 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		$frequency = Tribe__Events__Aggregator__Cron::instance()->get_frequency( array( 'id' => $this->meta['frequency'] ) );
 		if ( ! $frequency ) {
-			return tribe_error( 'core:aggregator:invalid-record-frequency', $meta );
+			return tribe_error( 'core:aggregator:invalid-record-frequency', $post['meta_input'] );
 		}
 
 		// Setup the post_content as the Frequency (makes it easy to fetch by frequency)
 		$post['post_content'] = $frequency->id;
 
+		$this->watch_for_db_errors();
+
 		// create schedule post
 		$child_id = wp_insert_post( $post );
+
 
 		// if the schedule creation failed, bail
 		if ( is_wp_error( $child_id ) ) {
@@ -468,6 +490,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		$this->maybe_add_meta_via_pre_wp_44_method( $child_id, $post['meta_input'] );
+
+		if ( $this->db_errors_happened() ) {
+			wp_delete_post( $child_id );
+
+			return tribe_error( 'core:aggregator:save-child-failed' );
+		}
 
 		// track the most recent child that was spawned
 		$this->update_meta( 'recent_child', $child_id );
@@ -1804,5 +1832,25 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 */
 	protected function has_import_policy_for( $origin, $setting ) {
 		return isset( $this->origin_import_policies[ $origin ] ) && in_array( $setting, $this->origin_import_policies[ $origin ] );
+	}
+
+	/**
+	 * Starts monitoring the db for errors.
+	 */
+	protected function watch_for_db_errors() {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+		$this->last_wpdb_error = $wpdb->last_error;
+
+	}
+
+	/**
+	 * @return bool Whether a db error happened during the insertion of data or not.
+	 */
+	protected function db_errors_happened() {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+
+		return $wpdb->last_error !== $this->last_wpdb_error;
 	}
 }

--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -194,6 +194,12 @@ class Tribe__Events__Aggregator__Record__Queue {
 	public function save() {
 		$this->record->update_meta( self::$activity_key, $this->activity );
 
+		/** @var Tribe__Meta__Chunker $chunker */
+		$chunker = tribe( 'chunker' );
+		// this data has the potential to be very big, so we register it for possible chunking in the db
+		$key = Tribe__Events__Aggregator__Record__Abstract::$meta_key_prefix . self::$queue_key;
+		$chunker->register_chunking_for( $this->record->post->ID, $key );
+
 		if ( empty( $this->items ) ) {
 			$this->record->delete_meta( self::$queue_key );
 		} else {

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -4,6 +4,12 @@
 class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 
 	/**
+	 * @var int The time a record is allowed to stall before havint its status set to to failed since its creation in
+	 *          seconds.
+	 */
+	protected $time_to_live = 12 * HOUR_IN_SECONDS;
+
+	/**
 	 * @var int The time a record is allowed to stall before having
 	 *          its status set to failed in seconds.
 	 */
@@ -99,11 +105,13 @@ class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 			return true;
 		}
 
+		$created = strtotime( $record->post->post_date );
 		$last_updated = strtotime( $record->post->post_modified_gmt );
-		$pending_for = time() - $last_updated;
+		$now = time();
+		$since_creation = $now - $created;
+		$pending_for = $now - $last_updated;
 
-
-		if ( $pending_for > $this->stall_limit ) {
+		if ( $pending_for > $this->stall_limit || $since_creation > $this->time_to_live ) {
 			$failed = Tribe__Events__Aggregator__Records::$status->failed;
 			wp_update_post( array( 'ID' => $id, 'post_status' => $failed ) );
 			delete_post_meta( $id, '_tribe_aggregator_queue' );

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -66,6 +66,7 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 			return;
 		}
 
+        /** @var Tribe__Events__Aggregator__Record__Queue_Processor $processor */
 		$processor = tribe( 'events-aggregator.main' )->queue_processor;
 		if ( ! $this->record_id = $processor->next_waiting_record( true ) ) {
 			return false;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -651,6 +651,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Preview handling
 			add_action( 'template_redirect', array( Tribe__Events__Revisions__Preview::instance(), 'hook' ) );
 
+			// Register all of the post types in the chunker and start the chunker
+			add_filter( 'tribe_meta_chunker_post_types', array( $this, 'filter_meta_chunker_post_types' ) );
+			tribe( 'chunker' );
+
 			// Register slug conflict notices (but test to see if tribe_notice() is indeed available, in case another plugin
 			// is hosting an earlier version of tribe-common which is already active)
 			//
@@ -5056,6 +5060,23 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public static function ecpActive( $version = '2.0.7' ) {
 			return class_exists( 'Tribe__Events__Pro__Main' ) && defined( 'Tribe__Events__Pro__Main::VERSION' ) && version_compare( Tribe__Events__Pro__Main::VERSION, $version, '>=' );
+		}
+
+		/**
+         * Filters the chunkable post types.
+         *
+		 * @param array $post_types
+		 * @return array The filtered post types
+		 */
+		public function filter_meta_chunker_post_types( array $post_types ) {
+			$post_types = array_merge( $post_types, array(
+				self::POSTTYPE,
+				self::VENUE_POST_TYPE,
+				self::ORGANIZER_POST_TYPE,
+				Tribe__Events__Aggregator__Records::$post_type,
+			) );
+
+			return $post_types;
 		}
 
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/77988

Work in progress for the ticket.

In this PR:
1. allow an env var to override schedule checks; useful to force scheduled imports to rerun using wp-cli like `export TRIBE_DEBUG_OVERRIDE_SCHEDULE=1 && wp cron event run tribe_aggregator_cron --debug`
2. adds a check on the creation time too for the records to mark records as stalled if not complete after 12 hrs

Building on https://github.com/moderntribe/tribe-common/pull/382 (Meta Chunker) now the items are stored and retrieved with the size in mind.