### PR TITLE
cache the request reply to avoid hangouts

### DIFF
--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -238,7 +238,7 @@ class Tribe__Events__Aggregator__Service {
 
 		// If we have an WP_Error we return only CSV
 		if ( is_wp_error( $response ) || empty( $response->status ) ) {
-			set_transient('tribe_aggregator_origins_response', $origins, 300);
+			set_transient( 'tribe_aggregator_origins_response', $origins, 300 );
 
 			return $origins;
 		}

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -229,10 +229,17 @@ class Tribe__Events__Aggregator__Service {
 			),
 		);
 
+		$cached = get_transient( 'tribe_aggregator_origins_response' );
+		if ( ! empty( $cached ) ) {
+			return $cached;
+		}
+
 		$response = $this->get( 'origin' );
 
 		// If we have an WP_Error we return only CSV
 		if ( is_wp_error( $response ) || empty( $response->status ) ) {
+			set_transient('tribe_aggregator_origins_response', $origins, 300);
+
 			return $origins;
 		}
 


### PR DESCRIPTION
Ticket: not really

This PR adds a transient caching when trying to fetch EA origins; if our server is down or unresponsive each admin reques will hang for ~10 seconds making the admin UI unusable.
This change implements a logic like: if EA did not respond or responded "nope" keep that and try again in 5'