### PR TITLE
Dont filter WPML language switcher URL on event category archives.

### DIFF
--- a/src/Tribe/Integrations/WPML/Language_Switcher.php
+++ b/src/Tribe/Integrations/WPML/Language_Switcher.php
@@ -37,7 +37,7 @@ class Tribe__Events__Integrations__WPML__Language_Switcher {
 			return $languages;
 		}
 
-		if ( is_admin() || ! ( tribe_is_event_query() && is_archive() ) ) {
+		if ( is_admin() || ! ( tribe_is_event_query() && is_archive() && ! is_tax( 'tribe_events_cat' ) ) ) {
 			return $languages;
 		}
 


### PR DESCRIPTION
The correct URL is being generated without filtering, fixes the issue reported here:
https://wpml.org/forums/topic/update-broke-links-for-event-category-pages-the-events-calendar-plugin/