### PR TITLE
New hook to control inclusion/exclusion of year

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -326,6 +326,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.2] TBD =
+
+* Tweak - Make the inclusion or exclusion of the year (within the event schedule string) filterable [78070]
+
 = [4.5.1] 2017-05-04 =
 
 * Fix - Prevented errors on EA import screen that happened in exotic circumstance. Thanks @kathryn for reporting this! [75787]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -958,7 +958,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * @return mixed|void
 	 */
-	function tribe_events_event_schedule_details( $event = null, $before = '', $after = '' ) {
+	function tribe_events_( $event = null, $before = '', $after = '' ) {
 		if ( is_null( $event ) ) {
 			global $post;
 			$event = $post;
@@ -994,8 +994,23 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		$format = $date_with_year_format;
 
-		// if it starts and ends in the current year then there is no need to display the year
-		if ( tribe_get_start_date( $event, false, 'Y' ) === date( 'Y' ) && tribe_get_end_date( $event, false, 'Y' ) === date( 'Y' ) ) {
+		/**
+		 * If a yearless date format should be preferred.
+		 *
+		 * By default, this will be true if the event starts and ends in the current year.
+		 *
+		 * @param bool    $use_yearless_format
+		 * @param WP_Post $event
+		 */
+		$use_yearless_format = apply_filters( 'tribe_events_event_schedule_details_use_yearless_format',
+			(
+					tribe_get_start_date( $event, false, 'Y' ) === date_i18n( 'Y' )
+					&& tribe_get_end_date( $event, false, 'Y' ) === date_i18n( 'Y' )
+			),
+			$event
+		);
+
+		if ( $use_yearless_format ) {
 			$format = $date_without_year_format;
 		}
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -958,7 +958,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * @return mixed|void
 	 */
-	function tribe_events_( $event = null, $before = '', $after = '' ) {
+	function tribe_events_event_schedule_details( $event = null, $before = '', $after = '' ) {
 		if ( is_null( $event ) ) {
 			global $post;
 			$event = $post;

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1004,8 +1004,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		$use_yearless_format = apply_filters( 'tribe_events_event_schedule_details_use_yearless_format',
 			(
-					tribe_get_start_date( $event, false, 'Y' ) === date_i18n( 'Y' )
-					&& tribe_get_end_date( $event, false, 'Y' ) === date_i18n( 'Y' )
+				tribe_get_start_date( $event, false, 'Y' ) === date_i18n( 'Y' )
+				&& tribe_get_end_date( $event, false, 'Y' ) === date_i18n( 'Y' )
 			),
 			$event
 		);


### PR DESCRIPTION
Following user feedback, makes it easier to exercise control over the inclusion or exclusion of the year in the event schedule details string.

:ticket: [#78070](https://central.tri.be/issues/78070)