### PR TITLE
Change field initialization for pre-5.6 compatibility | #79208

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -326,6 +326,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.2.1] 2017-05-19 =
+
+* Fix - Prevent fatal errors occuring in PHP 5.5 and earlier [79208]
+
 = [4.5.2] 2017-05-17 =
 
 * Fix - Correct REST API reference URL (our thanks to Lindsey for flagging this) [78658]

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -5,6 +5,7 @@ class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 
 	/**
 	 * Default is 12hrs.
+	 *
 	 * @var int The time a record is allowed to stall before havint its status set to to failed since its creation in
 	 *          seconds.
 	 */

--- a/src/Tribe/Aggregator/Record/Queue_Cleaner.php
+++ b/src/Tribe/Aggregator/Record/Queue_Cleaner.php
@@ -4,10 +4,11 @@
 class Tribe__Events__Aggregator__Record__Queue_Cleaner {
 
 	/**
+	 * Default is 12hrs.
 	 * @var int The time a record is allowed to stall before havint its status set to to failed since its creation in
 	 *          seconds.
 	 */
-	protected $time_to_live = 12 * HOUR_IN_SECONDS;
+	protected $time_to_live = 43200; // For pre-PHP 5.6 compat, we do not define as 12 * HOUR_IN_SECONDS
 
 	/**
 	 * @var int The time a record is allowed to stall before having


### PR DESCRIPTION
Initialize the `$time_to_live` property in a way that is compatible with PHP 5.5 and earlier.

:ticket: [#79208](https://central.tri.be/issues/79208)