### PR TITLE
Change the class of the validator

### DIFF
--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -33,7 +33,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		tribe_singleton( 'tec.rest-v1.headers-base', 'Tribe__Events__REST__V1__Headers__Base' );
 		tribe_singleton( 'tec.rest-v1.settings', 'Tribe__Events__REST__V1__Settings' );
 		tribe_singleton( 'tec.rest-v1.system', 'Tribe__Events__REST__V1__System' );
-		tribe_singleton( 'tec.rest-v1.validator', 'Tribe__REST__Validator' );
+		tribe_singleton( 'tec.rest-v1.validator', 'Tribe__Validator__Base' );
 		tribe_singleton( 'tec.rest-v1.repository', 'Tribe__Events__REST__V1__Post_Repository' );
 
 		include_once Tribe__Events__Main::instance()->plugin_path . 'src/functions/advanced-functions/rest-v1.php';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/78582

Due to the changes made in common to use the Formatter here: https://github.com/moderntribe/tribe-common/pull/397 the REST API validator has been made a general purprse one.