### PR TITLE
Fix/79344 get record erorrs

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -299,6 +299,10 @@ class Tribe__Events__Aggregator__Cron {
 		foreach ( $query->posts as $post ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
 
+			if ( tribe_is_error( $record ) ) {
+				continue;
+			}
+
 			if ( empty( $record->meta['_tribe_aggregator_queue'] ) ) {
 				// this is incoherent, a schedule should have a queue
 				$record->set_status( Tribe__Events__Aggregator__Records::$status->failed );
@@ -387,6 +391,10 @@ class Tribe__Events__Aggregator__Cron {
 		$cleaner = new Tribe__Events__Aggregator__Record__Queue_Cleaner();
 		foreach ( $query->posts as $post ) {
 			$record = $records->get_by_post_id( $post );
+
+			if ( tribe_is_error( $record ) ) {
+				continue;
+			}
 
 			$cleaner->remove_duplicate_pending_records_for( $record );
 			$failed = $cleaner->maybe_fail_stalled_record( $record );
@@ -491,7 +499,7 @@ class Tribe__Events__Aggregator__Cron {
 		foreach ( $query->posts as $post ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
 
-			if ( ! $record ) {
+			if ( tribe_is_error( $record ) ) {
 				$this->log( 'debug', sprintf( 'Record (%d) skipped, original post non-existent', $post->id ) );
 				continue;
 			}

--- a/src/Tribe/Aggregator/Meta_Box.php
+++ b/src/Tribe/Aggregator/Meta_Box.php
@@ -29,7 +29,7 @@ class Tribe__Events__Aggregator__Meta_Box {
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_event_id( $post_id );
 		$origin = get_post_meta( $post_id, Tribe__Events__Aggregator__Event::$origin_key, true );
 
-		if ( is_wp_error( $record ) && ! $origin ) {
+		if ( tribe_is_error( $record ) && ! $origin ) {
 			return;
 		}
 
@@ -53,7 +53,7 @@ class Tribe__Events__Aggregator__Meta_Box {
 		$source = null;
 		$origin = null;
 
-		if ( is_wp_error( $record ) ) {
+		if ( tribe_is_error( $record ) ) {
 			$last_import = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$updated_key, true );
 			$source = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$source_key, true );
 			$origin = get_post_meta( $event_id, Tribe__Events__Aggregator__Event::$origin_key, true );

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -979,7 +979,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		$parent_record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $this->post->post_parent );
 
-		if ( tribe_is_error( $record ) ) {
+		if ( tribe_is_error( $parent_record ) ) {
 			return;
 		}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -369,7 +369,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	/**
 	 * Creates a schedule record based on the import record
 	 *
-	 * @return boolean|WP_Error
+	 * @return boolean|Tribe_Error
 	 */
 	public function create_schedule_record() {
 		$post = array(
@@ -419,7 +419,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		$this->maybe_add_meta_via_pre_wp_44_method( $schedule_id, $post['meta_input'] );
 
-
 		if ( $this->db_errors_happened() ) {
 			wp_delete_post( $schedule_id );
 
@@ -447,7 +446,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	/**
 	 * Creates a child record based on the import record
 	 *
-	 * @return boolean|WP_Error|Tribe__Events__Aggregator__Record__Abstract
+	 * @return boolean|Tribe_Error|Tribe__Events__Aggregator__Record__Abstract
 	 */
 	public function create_child_record() {
 		$post = array(
@@ -482,7 +481,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		// create schedule post
 		$child_id = wp_insert_post( $post );
-
 
 		// if the schedule creation failed, bail
 		if ( is_wp_error( $child_id ) ) {
@@ -980,6 +978,11 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		$parent_record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $this->post->post_parent );
+
+		if ( tribe_is_error( $record ) ) {
+			return;
+		}
+
 		$parent_record->update_meta( 'source_name', $source_name );
 	}
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -157,8 +157,6 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 			$data = $this->meta;
 		}
 
-		$record = Tribe__Events__Aggregator__Records::instance()->get_by_import_id( $data['import_id'] );
-
 		if ( empty( $data['column_map'] ) ) {
 			return tribe_error( 'core:aggregator:missing-csv-column-map' );
 		}

--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -453,6 +453,10 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 	public function column_source( $post ) {
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
 
+		if ( tribe_is_error( $record ) ) {
+			return '';
+		}
+
 		if ( 'scheduled' !== $this->tab->get_slug() ) {
 			$html[] = $this->get_status_icon( $record );
 		}
@@ -508,6 +512,10 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 	public function column_imported( $post ) {
 		$html = array();
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
+
+		if ( tribe_is_error( $record ) ) {
+			return '';
+		}
 
 		if ( 'scheduled' === $this->tab->get_slug() ) {
 			$last_import_error = $record->get_last_import_status( 'error' );
@@ -565,12 +573,21 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		$html = array();
 
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post );
+
+		if ( tribe_is_error( $record ) ) {
+			return '';
+		}
+
 		$last_imported = $record->get_child_record_by_status( 'success', 1 );
 
 		// is this the scheduled import page?
 		if ( $last_imported && $last_imported->have_posts() ) {
 			// Fetches the Record Object
 			$last_imported = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $last_imported->post->ID );
+
+			if ( tribe_is_error( $last_imported ) ) {
+				return '';
+			}
 
 			$html[] = '<div class="tribe-ea-total">' . number_format_i18n( $record->get_event_count( 'created' ) ) . ' ' . esc_html__( 'all time', 'the-events-calendar' ) . '</div>';
 

--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -209,7 +209,8 @@ class Tribe__Events__Aggregator__Record__Queue {
 		// If we have a parent also update that
 		if ( ! empty( $this->record->post->post_parent ) ) {
 			$parent = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $this->record->post->post_parent );
-			if ( isset( $parent->meta[ self::$activity_key ] ) ) {
+
+			if ( ! tribe_is_error( $parent ) && isset( $parent->meta[ self::$activity_key ] ) ) {
 				$activity = $parent->meta[ self::$activity_key ];
 
 				if ( $activity instanceof Tribe__Events__Aggregator__Record__Activity ) {

--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -375,7 +375,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param int $post_id WP Post ID of record
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
 	 */
 	public function get_by_post_id( $post ) {
 		$post = get_post( $post );
@@ -404,7 +404,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param int $import_id Aggregator import id
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
 	 */
 	public function get_by_import_id( $import_id ) {
 		$args = array(
@@ -438,7 +438,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param  int $event_id   Post ID for the Event
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
 	 */
 	public function get_by_event_id( $event_id ) {
 		$event = get_post( $event_id );

--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -375,7 +375,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param int $post_id WP Post ID of record
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|Tribe__Error
+	 * @return Tribe__Events__Aggregator__Record__Abstract|Tribe__Error|null
 	 */
 	public function get_by_post_id( $post ) {
 		$post = get_post( $post );

--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -375,7 +375,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param int $post_id WP Post ID of record
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|Tribe__Error
 	 */
 	public function get_by_post_id( $post ) {
 		$post = get_post( $post );
@@ -404,7 +404,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param int $import_id Aggregator import id
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|Tribe__Error
 	 */
 	public function get_by_import_id( $import_id ) {
 		$args = array(
@@ -438,7 +438,7 @@ class Tribe__Events__Aggregator__Records {
 	 *
 	 * @param  int $event_id   Post ID for the Event
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|WP_Error|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract|Tribe__Error
 	 */
 	public function get_by_event_id( $event_id ) {
 		$event = get_post( $event_id );
@@ -569,7 +569,7 @@ class Tribe__Events__Aggregator__Records {
 		$record = $this->get_by_import_id( $import_id );
 
 		// We received an Invalid Import ID
-		if ( is_wp_error( $record ) ) {
+		if ( tribe_is_error( $record ) ) {
 			return wp_send_json_error();
 		}
 
@@ -597,6 +597,10 @@ class Tribe__Events__Aggregator__Records {
 	 */
 	public function add_record_to_event( $id, $record_id, $origin ) {
 		$record = $this->get_by_post_id( $record_id );
+
+		if ( tribe_is_error( $record ) ) {
+			return;
+		}
 
 		// Set the event origin
 		update_post_meta( $id, '_EventOrigin', Tribe__Events__Aggregator__Event::$event_origin );

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -181,7 +181,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_import_id( $data['import_id'] );
 
-		if ( is_wp_error( $record ) ) {
+		if ( tribe_is_error( $record ) ) {
 			$this->messages['error'][] = $record->get_error_message();
 			return $this->messages;
 		}
@@ -464,7 +464,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_import_id( $import_id );
 
-		if ( is_wp_error( $record ) ) {
+		if ( tribe_is_error( $record ) ) {
 			wp_send_json_error( $record );
 		}
 
@@ -484,7 +484,10 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 			if ( ! empty( $record->post->post_parent ) ) {
 				$parent_record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record->post->post_parent );
-				$parent_record->update_meta( 'source_name', $result->data->source_name );
+
+				if ( tribe_is_error( $parent_record ) ) {
+					$parent_record->update_meta( 'source_name', $result->data->source_name );
+				}
 			}
 		}
 

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -267,7 +267,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		foreach ( $records as $record_id ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
 
-			if ( is_wp_error( $record ) ) {
+			if ( tribe_is_error( $record ) ) {
 				$errors[ $record_id ] = $record;
 				continue;
 			}
@@ -300,7 +300,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 		foreach ( $records as $record_id ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $record_id );
 
-			if ( is_wp_error( $record ) ) {
+			if ( tribe_is_error( $record ) ) {
 				$errors[ $record_id ] = $record;
 				continue;
 			}

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -320,7 +320,7 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 		public function action_column_contents( $column, $post ) {
 			$record = Tribe__Events__Aggregator__Records::instance()->get_by_event_id( $post );
 
-			if ( is_wp_error( $record ) ) {
+			if ( tribe_is_error( $record ) ) {
 				return false;
 			}
 

--- a/src/admin-views/aggregator/tabs/edit.php
+++ b/src/admin-views/aggregator/tabs/edit.php
@@ -2,7 +2,11 @@
 $record = new stdClass;
 
 if ( ! empty( $_GET['id'] ) ) {
-	$record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( (int) $_GET['id'] );
+	$get_record = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( (int) $_GET['id'] );
+
+	if ( ! tribe_is_error( $get_record ) ) {
+		$record = $get_record;
+	}
 }
 
 $aggregator_action = 'edit';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/79344

 A customer had some records in her database with a blank origin. This is showing errors in many places because our Aggregator Records get methods all can return a Tribe_Error, or in some cases null. We need to properly check if this is happening whenever we call these.