### PR TITLE
Make the update confirmation message easier to translate

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -326,6 +326,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.3] TBD =
+
+* Fix - Made it easier to translate the update confirmation message (our thanks to safu9 for highlighting this) [79729]
+
 = [4.5.2.1] 2017-05-19 =
 
 * Fix - Prevent fatal errors occuring in PHP 5.5 and earlier [79208]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1705,10 +1705,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$messages[ self::POSTTYPE ] = array(
 				0  => '', // Unused. Messages start at index 1.
 				1  => sprintf(
-					esc_html__( '%1$s updated. %2$sView %3$s', 'the-events-calendar' ),
+					esc_html__( '%1$s updated. %2$sView %1$s%3$s', 'the-events-calendar' ),
 					esc_html( $this->singular_event_label ),
 					'<a href="' . esc_url( get_permalink( $post_ID ) ) . '">',
-					esc_html( $this->singular_event_label ) . '</a>'
+					'</a>'
 				),
 				2  => esc_html__( 'Custom field updated.', 'the-events-calendar' ),
 				3  => esc_html__( 'Custom field deleted.', 'the-events-calendar' ),


### PR DESCRIPTION
Keep markup and translatable elements separate.

:ticket: [#79729](https://central.tri.be/issues/79729)