### PR TITLE
Filter shortcodes before trimming excerpt

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1427,10 +1427,22 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$remove_shortcodes = apply_filters( 'tribe_events_excerpt_shortcode_removal', true );
 
 		// Get the Excerpt or content based on what is available
-		if ( has_excerpt( $post->ID ) ) {
-			$excerpt = $post->post_excerpt;
-		} else {
-			$excerpt = $post->post_content;
+		$excerpt = has_excerpt( $post->ID ) ? $post->post_excerpt : $post->post_content;
+
+		// If shortcode filter is enabled let's process them
+		if ( $allow_shortcodes ) {
+			$excerpt = do_shortcode( $excerpt );
+		}
+
+		// Remove all shortcode Content before removing HTML
+		if ( $remove_shortcodes ) {
+			$excerpt = preg_replace( '#\[.+\]#U', '', $excerpt );
+		}
+
+		// Remove "all" HTML based on what is allowed
+		$excerpt = wp_kses( $excerpt, $allowed_html );
+
+		if ( ! has_excerpt( $post->ID ) ) {
 			// We will only trim Excerpt if it comes from Post Content
 
 			/**
@@ -1450,19 +1462,6 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			// Now we actually trim it
 			$excerpt = wp_trim_words( $excerpt, $excerpt_length, $excerpt_more );
 		}
-
-		// If shortcode filter is enabled lets process them
-		if ( $allow_shortcodes ) {
-			$excerpt = do_shortcode( $excerpt );
-		}
-
-		// Remove all shortcode Content before removing HTML
-		if ( $remove_shortcodes ) {
-			$excerpt = preg_replace( '#\[.+\]#U', '', $excerpt );
-		}
-
-		// Remove "all" HTML based on what is allowed
-		$excerpt = wp_kses( $excerpt, $allowed_html );
 
 		/**
 		 * Filter the event excerpt used in various views.


### PR DESCRIPTION
Ran into an issue on one of our sites with a shortcode partially showing in an excerpt. 

<img width="1025" alt="screenshot 2017-06-01 09 45 58" src="https://cloud.githubusercontent.com/assets/1152149/26684249/68c58a40-46b4-11e7-9ad9-7a8ef8e5a2fa.png">

From looking at the `tribe_events_get_the_excerpt` function, trimming the text _after_ running the shortcodes seemed to make the most sense for this scenario. Not sure if there may be other implications I haven't seen. Tested this on our sites & the patch worked out great.