### PR TITLE
Fix scheduled imports not running

### DIFF
--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -303,12 +303,6 @@ class Tribe__Events__Aggregator__Cron {
 				continue;
 			}
 
-//			if ( empty( $record->meta['_tribe_aggregator_queue'] ) ) {
-//				// this is incoherent, a schedule should have a queue
-//				$record->set_status( Tribe__Events__Aggregator__Records::$status->failed );
-//				continue;
-//			}
-
 			if ( ! $record->is_schedule_time() ) {
 				$this->log( 'debug', sprintf( 'Record (%d) skipped, not scheduled time', $record->id ) );
 				continue;

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -303,11 +303,11 @@ class Tribe__Events__Aggregator__Cron {
 				continue;
 			}
 
-			if ( empty( $record->meta['_tribe_aggregator_queue'] ) ) {
-				// this is incoherent, a schedule should have a queue
-				$record->set_status( Tribe__Events__Aggregator__Records::$status->failed );
-				continue;
-			}
+//			if ( empty( $record->meta['_tribe_aggregator_queue'] ) ) {
+//				// this is incoherent, a schedule should have a queue
+//				$record->set_status( Tribe__Events__Aggregator__Records::$status->failed );
+//				continue;
+//			}
 
 			if ( ! $record->is_schedule_time() ) {
 				$this->log( 'debug', sprintf( 'Record (%d) skipped, not scheduled time', $record->id ) );

--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -128,6 +128,11 @@ class Tribe__Events__Aggregator__Record__Queue {
 	}
 
 	public function load_queue() {
+		if ( empty( $this->record->meta[ self::$queue_key ] ) ) {
+			$this->is_fetching = false;
+			$this->items = array();
+		}
+
 		$this->items = $this->record->meta[ self::$queue_key ];
 
 		if ( 'fetch' === $this->items ) {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/79587

This PR removes an over-zealous inconsistency check I have added (so yes: this issue is completely my fault) to allow scheduled imports to run free again.