### PR TITLE
Return a wp_error if the expected JSON response was non-JSON or malformed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.6.1] TBD =
 
+* Tweak - Better detection and reporting of communication failures with the Event Aggregator server
 * Tweak - Textual corrections (with thanks to @garrett-eclipse for highlighting many of these) [77196]
 
 = [4.5.5] 2017-06-14 =


### PR DESCRIPTION
Adds a safeguard in case decoding the JSON response fails (following reports in the forum indicating we're trying to use the property of a non-object - which is coming back from this method).