### PR TITLE
WPML compatibility: support translated event slugs | #73478

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.6.1] TBD =
 
+* Fix - Restore support for translated events category slugs when WPML is active [73478]
 * Fix - Improve handling of shortcodes within event view excerpts (props: @awbauer) [81226]
 * Fix - Improve compatibility with WPML in relation to event permalinks specifically (props: @dgwatkins) [81224]
 * Tweak - Better detection and reporting of communication failures with the Event Aggregator server

--- a/src/Tribe/Integrations/WPML/Category_Translation.php
+++ b/src/Tribe/Integrations/WPML/Category_Translation.php
@@ -72,4 +72,43 @@ class Tribe__Events__Integrations__WPML__Category_Translation {
 
 		return $slug;
 	}
+
+	/**
+	 * Supplies an array containing all translated forms of the events category slug.
+	 *
+	 * The default (English) slug will not be containied in the resulting array.
+	 * Example: [ 'categorie', 'kategorie', 'categoria' ] // French, German, Italian
+	 *
+	 * @return array
+	 */
+	public function get_translated_base_slugs() {
+		/** @var SitePress $sitepress */
+		global $sitepress;
+
+		$translations     = array();
+		$tax_sync_options = $sitepress->get_setting( 'taxonomies_sync_option' );
+		$should_translate = ! empty( $tax_sync_options[ Tribe__Events__Main::TAXONOMY ] );
+
+		// If the event category slug shouldn't be translated, return an empty list
+		if ( ! $should_translate ) {
+			return array();
+		}
+
+		// Determine the translated form of the category slug for each active locale
+		foreach ( Tribe__Events__Integrations__WPML__Utils::get_active_locales() as $lang ) {
+			$slugs = Tribe__Events__Integrations__WPML__Utils::get_wpml_i18n_strings( array( 'category' ), $lang );
+
+			// We expect an array of arrays with at least one element to come back
+			if ( empty( $slugs[0] ) ) {
+				continue;
+			}
+
+			// Following the strategy used elsewhere, use the final translation if there are multiple
+			$translations[] = end( $slugs[0] );
+		}
+
+		$translations = array_map( 'urldecode', $translations );
+		$translations = array_map( 'remove_accents', $translations );
+		return array_unique( $translations );
+	}
 }

--- a/src/Tribe/Integrations/WPML/Rewrites.php
+++ b/src/Tribe/Integrations/WPML/Rewrites.php
@@ -148,4 +148,26 @@ class Tribe__Events__Integrations__WPML__Rewrites {
 	protected function is_organizer_rule( $candidate_rule ) {
 		return preg_match( '/^' . $this->organizer_slug . '/', $candidate_rule );
 	}
+
+	/**
+	 * Adds translated versions of the events category base slug to the rewrite rules.
+	 *
+	 * @param array  $bases
+	 * @param string $method
+	 *
+	 * @return array
+	 */
+	public function filter_tax_base_slug( $bases, $method ) {
+		// We only want to make changes if there is a tax key and if the method is 'regex'
+		if ( ! isset( $bases['tax'] ) || 'regex' !== $method ) {
+			return $bases;
+		}
+
+		// Fetch translated versions of the event category slug and append them
+		$category_translation = Tribe__Events__Integrations__WPML__Category_Translation::instance();
+		$translated_slugs = $category_translation->get_translated_base_slugs();
+		$bases['tax'] = array_merge( $bases['tax'], $translated_slugs );
+
+		return $bases;
+	}
 }

--- a/src/Tribe/Integrations/WPML/Utils.php
+++ b/src/Tribe/Integrations/WPML/Utils.php
@@ -114,7 +114,7 @@ class Tribe__Events__Integrations__WPML__Utils {
 	/**
 	 * Returns an array of currently active locales (other than English).
 	 *
-	 * Example: [ 'fr_fr', 'de_de', 'it_it' ]
+	 * Example: [ 'fr_FR', 'de_DE', 'it_IT' ]
 	 *
 	 * @return array
 	 */

--- a/src/Tribe/Integrations/WPML/Utils.php
+++ b/src/Tribe/Integrations/WPML/Utils.php
@@ -110,4 +110,27 @@ class Tribe__Events__Integrations__WPML__Utils {
 
 		return array_combine( wp_list_pluck( $results, 'language' ), wp_list_pluck( $results, 'value' ) );
 	}
+
+	/**
+	 * Returns an array of currently active locales (other than English).
+	 *
+	 * Example: [ 'fr_fr', 'de_de', 'it_it' ]
+	 *
+	 * @return array
+	 */
+	public static function get_active_locales() {
+		global $sitepress;
+
+		$locales = array();
+		$languages = $sitepress->get_active_languages();
+		unset( $languages['en'] );
+
+		foreach ( $languages as $language_definition ) {
+			if ( isset( $language_definition['default_locale'] ) ) {
+				$locales[] = $language_definition['default_locale'];
+			}
+		}
+
+		return $locales;
+	}
 }

--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -60,6 +60,7 @@ class Tribe__Events__Integrations__WPML__WPML {
 
 		$rewrites = Tribe__Events__Integrations__WPML__Rewrites::instance();
 		add_filter( 'rewrite_rules_array', array( $rewrites, 'filter_rewrite_rules_array' ), 20, 1 );
+		add_filter( 'tribe_events_rewrite_i18n_slugs_raw', array( $rewrites, 'filter_tax_base_slug' ), 10, 2 );
 
 		$permalinks = Tribe__Events__Integrations__WPML__Permalinks::instance();
 		add_filter( 'post_type_link', array( $permalinks, 'filter_post_type_link' ), 20, 2 );


### PR DESCRIPTION
If WPML is active it attempts to translate the events category base slug: let's ensure we update the permalink rules accordingly to support this.

:ticket: [#73478](https://central.tri.be/issues/73478)