### PR TITLE
Add new hook for control over linked post dropdown UI | #80487

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -334,6 +334,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Improve compatibility with WPML in relation to event permalinks specifically (props: @dgwatkins) [81224]
 * Tweak - Better detection and reporting of communication failures with the Event Aggregator server
 * Tweak - Textual corrections (with thanks to @garrett-eclipse for highlighting many of these) [77196]
+* Tweak - New filter added ("tribe_events_linked_posts_dropdown_enable_creation") to facilitate more control over linked posts [80487]
 
 = [4.5.5] 2017-06-14 =
 

--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -897,13 +897,24 @@ class Tribe__Events__Linked_Posts {
 		$user_can_create = ( ! empty( $post_type_object->cap->create_posts ) && current_user_can( $post_type_object->cap->create_posts ) );
 		$allowed_creation = ( ! empty( $this->linked_post_types[ $post_type ]['allow_creation'] ) && $this->linked_post_types[ $post_type ]['allow_creation'] );
 
+		/**
+		 * Controls whether the UI to create new linked posts should be displayed.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $enabled
+		 * @param string $post_type
+		 * @param Tribe__Events__Linked_Posts
+		 */
+		$creation_enabled = apply_filters( 'tribe_events_linked_posts_dropdown_enable_creation', $user_can_create && $allowed_creation, $post_type, $this );
+
 		$placeholder = sprintf( esc_attr__( 'Find a %s', 'the-events-calendar' ), $singular_name );
-		if ( $user_can_create && $allowed_creation ) {
+		if ( $creation_enabled ) {
 			$placeholder = sprintf( esc_attr__( 'Create or Find %s', 'the-events-calendar' ), $singular_name );
 		}
 
 		$search_placeholder = sprintf( esc_attr__( 'Find a %s', 'the-events-calendar' ), $singular_name );
-		if ( $user_can_create && $allowed_creation ) {
+		if ( $creation_enabled ) {
 			$search_placeholder = sprintf( esc_attr__( 'Create or Find %s', 'the-events-calendar' ), $singular_name );
 		}
 
@@ -915,7 +926,7 @@ class Tribe__Events__Linked_Posts {
 				id="saved_' . esc_attr( $post_type ) . '"
 				data-placeholder="' . $placeholder . '"
 				data-search-placeholder="' . $search_placeholder . '" ' .
-				( $user_can_create && $allowed_creation ?
+				( $creation_enabled ?
 				'data-freeform
 				data-sticky-search
 				data-create-choice-template="' . __( 'Create: <b><%= term %></b>', 'the-events-calendar' ) . '"


### PR DESCRIPTION
Adds a new filter to control where the create new linked post type options are rendered as part of the linked post dropdown.

:ticket: [#80487](https://central.tri.be/issues/80487)