### PR TITLE
Minor performance enhancement (theme compat code)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -336,6 +336,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Better detection and reporting of communication failures with the Event Aggregator server
 * Tweak - Textual corrections (with thanks to @garrett-eclipse for highlighting many of these) [77196]
 * Tweak - New filter added ("tribe_events_linked_posts_dropdown_enable_creation") to facilitate more control over linked posts [80487]
+* Tweak - Improve performance of theme compatibility code [71974]
 
 = [4.5.6] 2017-06-22 =
 

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -258,7 +258,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 		public static function needs_compatibility_fix ( $theme = null ) {
 			// Defaults to current active theme
 			if ( $theme === null ) {
-				$theme = wp_get_theme()->Template;
+				$theme = get_stylesheet();
 			}
 
 			$theme_compatibility_list = apply_filters( 'tribe_themes_compatibility_fixes', self::$themes_with_compatibility_fixes );


### PR DESCRIPTION
Instead of doing `wp_get_theme()->Template` each request - which makes WordPress parse the theme header file - use `get_stylesheet()`.

:ticket: [#71974](https://central.tri.be/issues/71974)