### PR TITLE
Strip single recurrence and `/all/` permalink logic from TEC (belongs in ECP)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.5.8] TBD =
 
+* Fix - Remove permalink logic for recurring events (Events Calendar PRO will implement instead) [74153]
 * Fix - Avoid type error when setting up one-time imports for Facebook URLs (our thanks to @J for flagging this!) [78664]
 
 = [4.5.7] 2017-06-28 =

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -95,6 +95,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public $tag_slug = 'tag';
 		public $monthSlug = 'month';
 		public $featured_slug = 'featured';
+
+		/**
+		 * @deprecated TBD use `Tribe__Events__Pro__Main::instance()->all_slug` instead
+		 *
+		 * @var string
+		 */
 		public $all_slug = 'all';
 
 		/** @deprecated 4.0 */

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -103,11 +103,6 @@ class Tribe__Events__Rewrite extends  Tribe__Rewrite {
 	public function generate_core_rules( Tribe__Events__Rewrite $rewrite ) {
 		$rewrite
 			// Single
-			->single( array( '(\d{4}-\d{2}-\d{2})' ), array( Tribe__Events__Main::POSTTYPE => '%1', 'eventDate' => '%2' ) )
-			->single( array( '(\d{4}-\d{2}-\d{2})', 'embed' ), array( Tribe__Events__Main::POSTTYPE => '%1', 'eventDate' => '%2', 'embed' => 1 ) )
-			->single( array( '{{ all }}' ), array( Tribe__Events__Main::POSTTYPE => '%1', 'post_type' => Tribe__Events__Main::POSTTYPE, 'eventDisplay' => 'all' ) )
-
-			->single( array( '(\d{4}-\d{2}-\d{2})', 'ical' ), array( Tribe__Events__Main::POSTTYPE => '%1', 'eventDate' => '%2', 'ical' => 1 ) )
 			->single( array( 'ical' ), array( 'ical' => 1, 'name' => '%1', 'post_type' => Tribe__Events__Main::POSTTYPE ) )
 
 			// Archive
@@ -259,7 +254,6 @@ class Tribe__Events__Rewrite extends  Tribe__Rewrite {
 			'tag' => array( 'tag', $tec->tag_slug ),
 			'tax' => array( 'category', $tec->category_slug ),
 			'page' => (array) 'page',
-			'all' => array( 'all', $tec->all_slug ),
 			'single' => (array) Tribe__Settings_Manager::get_option( 'singleEventSlug', 'event' ),
 			'archive' => (array) Tribe__Settings_Manager::get_option( 'eventsSlug', 'events' ),
 			'featured' => array( 'featured', $tec->featured_slug ),


### PR DESCRIPTION
Removes permalink logic that ought to belong in PRO.

:ticket: [#74153](https://central.tri.be/issues/74153)