### PR TITLE
Fix double anchor tag in tribe_get_organizer_details

### DIFF
--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -125,6 +125,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		if ( $organizer_id && $link = tribe_get_organizer_website_link() ) {
+			// $link is a full HTML string (<a>) whose components are already escaped, so we don't need create an anchor tag or escape again here
 			$details[] = '<span class="link">' . $link . '</span>';
 		}
 

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -125,7 +125,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		if ( $organizer_id && $link = tribe_get_organizer_website_link() ) {
-			$details[] = '<span class="link"> <a href="' . esc_attr( $link ) . '">' . $link . '</a> </span>';
+			$details[] = '<span class="link">' . $link . '</span>';
 		}
 
 		$html = join( '<span class="tribe-events-divider">|</span>', $details );


### PR DESCRIPTION
`tribe_get_organizer_details()` wraps the result of `tribe_get_organizer_website_link()` in an anchor tag, however `tribe_get_organizer_website_link()` already returns an anchor tag resulting in broken HTML. 

This stops `tribe_get_organizer_details()` adding the second anchor tag.

Bug originally reported here in March: https://theeventscalendar.com/support/forums/topic/single-organizer-website-link-bug/