### PR TITLE
Avoid overwriting FB Venues and Organizers when they have the same name

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -334,6 +334,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Add a safety check in isOrganizer() function (our thanks to Kevin for flagging this!) [81645]
 * Fix - Avoid EA Client hanging when no events are found while attempting an import from a Facebook source [82713]
 * Fix - Improve compatibility of The Events Calendar when operating with WPML from within a subdirectory (props: @dgwatkins) [81998]
+* Fix - Avoid overwriting Venues and Organizers when importing FB events with similarly named Venues and Organizers [75370]
 
 = [4.5.7] 2017-06-28 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -329,7 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.5.9] TBD =
 
-* ...
+* Fix - Avoid overwriting Venues and Organizers when importing FB events with similarly named Venues and Organizers [75370]
 
 = [4.5.8] 2017-07-13 =
 
@@ -338,7 +338,6 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Add a safety check in isOrganizer() function (our thanks to Kevin for flagging this!) [81645]
 * Fix - Avoid EA Client hanging when no events are found while attempting an import from a Facebook source [82713]
 * Fix - Improve compatibility of The Events Calendar when operating with WPML from within a subdirectory (props: @dgwatkins) [81998]
-* Fix - Avoid overwriting Venues and Organizers when importing FB events with similarly named Venues and Organizers [75370]
 
 = [4.5.7] 2017-06-28 =
 

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -221,7 +221,7 @@ class Tribe__Events__Aggregator__Event {
 	 *
 	 * @return bool|WP_Post
 	 */
-	public static function get_post_by_meta( $key = 'global_id', $value = null ) {
+	public static function get_post_by_meta( $key, $value = null ) {
 		if ( null === $value ) {
 			return false;
 		}
@@ -234,7 +234,6 @@ class Tribe__Events__Aggregator__Event {
 		if ( isset( $keys[ $key ] ) ) {
 			$key = $keys[ $key ];
 		}
-
 
 		global $wpdb;
 

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -222,7 +222,7 @@ class Tribe__Events__Aggregator__Event {
 	 * @return bool|WP_Post
 	 */
 	public static function get_post_by_meta( $key = 'global_id', $value = null ) {
-		if ( is_null( $value ) ) {
+		if ( null === $value ) {
 			return false;
 		}
 
@@ -231,11 +231,10 @@ class Tribe__Events__Aggregator__Event {
 			'global_id_lineage' => self::$global_id_lineage_key,
 		);
 
-		if ( ! isset( $keys[ $key ] ) ) {
-			return false;
+		if ( isset( $keys[ $key ] ) ) {
+			$key = $keys[ $key ];
 		}
 
-		$key = $keys[ $key ];
 
 		global $wpdb;
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -59,6 +59,34 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	);
 
 	/**
+	 * @var array
+	 */
+	public static $unique_venue_id_fields = array(
+		'facebook' => array(
+			'source' => 'facebook_id',
+			'target' => 'VenueFacebookID',
+		),
+		'meetup'   => array(
+			'source' => 'meetup_id',
+			'target' => 'VenueMeetupID',
+		),
+	);
+
+	/**
+	 * @var array
+	 */
+	public static $unique_organizer_id_fields = array(
+		'facebook' => array(
+			'source' => 'facebook_id',
+			'target' => 'OrganizerFacebookID',
+		),
+		'meetup'   => array(
+			'source' => 'meetup_id',
+			'target' => 'OrganizerMeetupID',
+		),
+	);
+
+	/**
 	 * Holds the event count temporarily while event counts (comment_count) is being updated
 	 *
 	 * @var int

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -94,6 +94,13 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	private $temp_event_count = 0;
 
 	/**
+	 * The import record origin.
+	 *
+	 * @var string
+	 */
+	protected $origin;
+
+	/**
 	 * Setup all the hooks and filters
 	 *
 	 * @return void

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1739,12 +1739,32 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		return $selected;
 	}
 
-	protected function get_unique_field() {
-		if ( ! isset( self::$unique_id_fields[ $this->meta['origin'] ] ) ) {
-			return null;
+	/**
+	 * Gets the unique field map for the current origin and the specified post type.
+	 *
+	 * @param string $for
+	 *
+	 * @return array|null
+	 */
+	protected function get_unique_field( $for = null ) {
+		$fields = self::$unique_id_fields;
+
+		switch ( $for ) {
+			case 'venue':
+				$fields = self::$unique_venue_id_fields;
+				break;
+			case 'organizer':
+				$fields = self::$unique_organizer_id_fields;
+				break;
+			default:
+				break;
 		}
 
-		return self::$unique_id_fields[ $this->meta['origin'] ];
+		if ( ! isset( $fields[ $this->meta['origin'] ] ) ) {
+			return NULL;
+		}
+
+		return $fields [ $this->meta['origin'] ];
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1781,10 +1781,10 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		if ( ! isset( $fields[ $this->meta['origin'] ] ) ) {
-			return NULL;
+			return null;
 		}
 
-		return $fields [ $this->meta['origin'] ];
+		return $fields[ $this->meta['origin'] ];
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1292,8 +1292,17 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 						}
 					} else {
 						$venue_id = array_search( $event['Venue']['Venue'], $found_venues );
+
 						if ( ! $venue_id ) {
-							$venue = get_page_by_title( $event['Venue']['Venue'], 'OBJECT', Tribe__Events__Venue::POSTTYPE );
+							$unique_field = $this->get_unique_field( 'venue' );
+
+							if ( ! empty( $unique_field ) ) {
+								$target = $unique_field['target'];
+								$value  = $venue_data[ $target ];
+								$venue  = Tribe__Events__Aggregator__Event::get_post_by_meta( "_Venue{$target}", $value );
+							} else {
+								$venue = get_page_by_title( $event['Venue']['Venue'], 'OBJECT', Tribe__Events__Venue::POSTTYPE );
+							}
 
 							if ( $venue ) {
 								$venue_id = $venue->ID;
@@ -1409,11 +1418,22 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 						}
 					} else {
 						$organizer_id = array_search( $event['Organizer']['Organizer'], $found_organizers );
-						if ( ! $organizer_id ) {
-							$organizer = get_page_by_title( $event['Organizer']['Organizer'], 'OBJECT', Tribe__Events__Organizer::POSTTYPE );
 
+						if ( ! $organizer_id ) {
+							$unique_field = $this->get_unique_field( 'organizer' );
+
+							if ( ! empty( $unique_field ) ) {
+								$target    = $unique_field['target'];
+								$value     = $organizer_data[ $target ];
+								$organizer = Tribe__Events__Aggregator__Event::get_post_by_meta( "_Organizer{$target}", $value );
+							} else {
+								$organizer = get_page_by_title( $event['Organizer']['Organizer'], 'OBJECT', Tribe__Events__Organizer::POSTTYPE );
+							}
+						}
+
+						if ( ! $organizer_id ) {
 							if ( $organizer ) {
-								$organizer_id = $organizer->ID;
+								$organizer_id                      = $organizer->ID;
 								$found_organizers[ $organizer_id ] = $event['Organizer']['Organizer'];
 							}
 						}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/75370

This PR uses, in the case of FB and Meetup origins, the ID provided by the origin to look for duplicates and avoid false positives while doing so.
What was happening in the ticket is that `Venue Foo` with a FB ID of `12345` and `Venue Foo` with a FB ID of `678910` would, incorrectly, be matched as same.