### PR TITLE
Add support for CRUD operations for Categories and Tags

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1159,16 +1159,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "1.21.6",
+            "version": "1.21.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "08be090b552f3b1c89220cd37c64d014ce50c7a6"
+                "reference": "6643bbb185d509029d8f9be19f904da92b17391b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/08be090b552f3b1c89220cd37c64d014ce50c7a6",
-                "reference": "08be090b552f3b1c89220cd37c64d014ce50c7a6",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/6643bbb185d509029d8f9be19f904da92b17391b",
+                "reference": "6643bbb185d509029d8f9be19f904da92b17391b",
                 "shasum": ""
             },
             "require": {
@@ -1216,7 +1216,7 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2017-07-06T12:44:35+00:00"
+            "time": "2017-07-14T15:55:34+00:00"
         },
         {
             "name": "lucatume/wp-browser-commons",
@@ -1698,22 +1698,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/46f7e8bb075036c92695b15a1ddb6971c751e585",
+                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -1739,24 +1739,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-07-15T11:38:20+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -1786,7 +1786,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3231,16 +3231,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "3a4435e79a8401746e8525e98039199d0924b4e5"
+                "reference": "8079a6b3668ef15cdbf73a4c7d31081abb8bb5f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/3a4435e79a8401746e8525e98039199d0924b4e5",
-                "reference": "3a4435e79a8401746e8525e98039199d0924b4e5",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/8079a6b3668ef15cdbf73a4c7d31081abb8bb5f0",
+                "reference": "8079a6b3668ef15cdbf73a4c7d31081abb8bb5f0",
                 "shasum": ""
             },
             "require": {
@@ -3284,11 +3284,11 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-24T09:29:48+00:00"
+            "time": "2017-07-12T13:03:20+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -3350,7 +3350,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -3419,7 +3419,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -3472,7 +3472,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -3528,16 +3528,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "986a633c92220ecb22ad06820a1df126c7a4f9eb"
+                "reference": "761e51a86f35f5b3e213e9b7f554fd91f9bffae4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/986a633c92220ecb22ad06820a1df126c7a4f9eb",
-                "reference": "986a633c92220ecb22ad06820a1df126c7a4f9eb",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/761e51a86f35f5b3e213e9b7f554fd91f9bffae4",
+                "reference": "761e51a86f35f5b3e213e9b7f554fd91f9bffae4",
                 "shasum": ""
             },
             "require": {
@@ -3594,11 +3594,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-20T14:01:46+00:00"
+            "time": "2017-07-17T14:07:10+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
@@ -3654,7 +3654,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -3717,16 +3717,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.24",
+            "version": "v2.8.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b8c9c18eacc525c980d27c7a2c8fd1e09e0ed4c7"
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8c9c18eacc525c980d27c7a2c8fd1e09e0ed4c7",
-                "reference": "b8c9c18eacc525c980d27c7a2c8fd1e09e0ed4c7",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/714b1036010c354ae2b25d7f9ca27e14e265e9f2",
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2",
                 "shasum": ""
             },
             "require": {
@@ -3762,11 +3762,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-20T23:27:56+00:00"
+            "time": "2017-07-11T07:12:11+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -3874,7 +3874,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.24",
+            "version": "v2.8.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -3923,7 +3923,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -3988,7 +3988,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/Tribe/REST/Interfaces/Post_Repository.php
+++ b/src/Tribe/REST/Interfaces/Post_Repository.php
@@ -43,4 +43,17 @@ interface Tribe__Events__REST__Interfaces__Post_Repository {
 	 * @since TBD
 	 */
 	public function prepare_terms_data( array $terms_data, $taxonomy );
+
+	/**
+	 * Prepares a single term data for the response.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $term_data
+	 * @param string $taxonomy
+	 * @param string $namespace
+	 *
+	 * @return array
+	 */
+	public function prepare_term_data( $term_data, $taxonomy, $namespace );
 }

--- a/src/Tribe/REST/V1/Endpoints/Single_Category.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Category.php
@@ -46,43 +46,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	}
 
 	/**
-	 * Handles DELETE requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_Error|WP_REST_Response An array containing the data of the trashed post on
-	 *                                   success or a WP_Error instance on failure.
-	 */
-	public function delete( WP_REST_Request $request ) {
-		// TODO: Implement delete() method.
-	}
-
-	/**
-	 * Returns the content of the `args` array that should be used to register the endpoint
-	 * with the `register_rest_route` function.
-	 *
-	 * @since TBD
-	 *
-	 * @return array
-	 */
-	public function DELETE_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can delete content of this type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can delete or not.
-	 */
-	public function can_delete() {
-		// TODO: Implement can_delete() method.
-	}
-
-	/**
 	 * Returns an array in the format used by Swagger 2.0.
 	 *
 	 * While the structure must conform to that used by v2.0 of Swagger the structure can be that of a full document
@@ -97,7 +60,75 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	 * @return array An array description of a Swagger supported component.
 	 */
 	public function get_documentation() {
-		return array();
+		$GET_defaults = $DELETE_defaults = array( 'in' => 'query', 'default' => '', 'type' => 'string' );
+		$POST_defaults = array( 'in' => 'body', 'default' => '', 'type' => 'string' );
+		$post_args = array_merge( $this->READ_args(), $this->CREATE_args() );
+
+		return array(
+			'get'  => array(
+				'parameters' => $this->swaggerize_args( $this->READ_args(), $GET_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Returns the data of the event category with the specified term ID', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'The event category term ID is missing.', 'the-events-calendar' ),
+					),
+					'404' => array(
+						'description' => __( 'An event category with the specified term ID does not exist.', 'the-events-calendar' ),
+					),
+				),
+			),
+			'post' => array(
+				'parameters' => $this->swaggerize_args( $post_args, $POST_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Returns the data of the updated event category', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'201' => array(
+						'description' => __( 'Returns the data of the created event category', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'A required parameter is missing or an input parameter is in the wrong format', 'the-events-calendar' ),
+					),
+					'403' => array(
+						'description' => __( 'The user is not authorized to create event categories', 'the-events-calendar' ),
+					),
+				),
+			),
+			'delete'  => array(
+				'parameters' => $this->swaggerize_args( $this->DELETE_args(), $DELETE_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Deletes an event category and returns its data', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'The event category term ID is missing or does not exist.', 'the-events-calendar' ),
+					),
+					'403' => array(
+						'description' => __( 'The current user cannot delete the event category with the specified term ID.', 'the-events-calendar' ),
+					),
+					'410' => array(
+						'description' => __( 'The event category with the specified term ID has been deleted already.', 'the-events-calendar' ),
+					),
+					'500' => array(
+						'description' => __( 'The event category with the specified term ID could not be deleted.', 'the-events-calendar' ),
+					),
+				),
+			),
+		);
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Single_Category.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Category.php
@@ -9,20 +9,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	Tribe__Documentation__Swagger__Provider_Interface {
 
 	/**
-	 * Handles POST requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 * @param bool            $return_id Whether the created post ID should be returned or the full response object.
-	 *
-	 * @return WP_Error|WP_REST_Response|int An array containing the data on success or a WP_Error instance on failure.
-	 */
-	public function create( WP_REST_Request $request, $return_id = false ) {
-		// TODO: Implement create() method.
-	}
-
-	/**
 	 * Returns the content of the `args` array that should be used to register the endpoint
 	 * with the `register_rest_route` function.
 	 *
@@ -31,18 +17,32 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	 * @return array
 	 */
 	public function CREATE_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can create content of the specified type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can post or not.
-	 */
-	public function can_create() {
-		// TODO: Implement can_create() method.
+		return array(
+			'name'             => array(
+				'required'          => true,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event category name', 'the-events-calendar' ),
+			),
+			'description'             => array(
+				'required'          => false,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event category description', 'the-events-calendar' ),
+			),
+			'slug'             => array(
+				'required'          => false,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event category slug', 'the-events-calendar' ),
+			),
+			'parent'             => array(
+				'required'          => false,
+				'validate_callback' => array( $this->validator, 'is_event_category' ),
+				'type'              => 'integer',
+				'description'       => __( 'The event category slug', 'the-events-calendar' ),
+			),
+		);
 	}
 
 	/**
@@ -118,43 +118,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 				'validate_callback' => array( $this->validator, 'is_event_category' ),
 			),
 		);
-	}
-
-	/**
-	 * Handles UPDATE requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_Error|WP_REST_Response An array containing the data of the updated post on
-	 *                                   success or a WP_Error instance on failure.
-	 */
-	public function update( WP_REST_Request $request ) {
-		// TODO: Implement update() method.
-	}
-
-	/**
-	 * Returns the content of the `args` array that should be used to register the endpoint
-	 * with the `register_rest_route` function.
-	 *
-	 * @since TBD
-	 *
-	 * @return array
-	 */
-	public function EDIT_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can update content of this type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can update or not.
-	 */
-	public function can_edit() {
-		// TODO: Implement can_edit() method.
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -358,6 +358,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	}
 
 	/**
+	 * Whether the current user can create content of the specified type or not.
+	 *
 	 * @return bool Whether the current user can post or not.
 	 */
 	public function can_create() {
@@ -424,6 +426,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	/**
 	 * Whether the current user can delete posts of the type managed by the endpoint or not.
 	 *
+	 * @since TBD
+	 *
 	 * @return bool
 	 */
 	public function can_delete() {
@@ -485,6 +489,10 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	}
 
 	/**
+	 * Whether the current user can update content of this type or not.
+	 *
+	 * @since TBD
+	 *
 	 * @return bool Whether the current user can update or not.
 	 */
 	public function can_edit() {

--- a/src/Tribe/REST/V1/Endpoints/Single_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Organizer.php
@@ -282,6 +282,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 	}
 
 	/**
+	 * Whether the current user can create content of the specified type or not.
+	 *
 	 * @return bool Whether the current user can post or not.
 	 */
 	public function can_create() {
@@ -405,6 +407,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 	/**
 	 * Whether the current user can delete posts of the type managed by the endpoint or not.
 	 *
+	 * @since TBD
+	 *
 	 * @return bool
 	 */
 	public function can_delete() {
@@ -455,6 +459,10 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 	}
 
 	/**
+	 * Whether the current user can update content of this type or not.
+	 *
+	 * @since TBD
+	 *
 	 * @return bool Whether the current user can update or not.
 	 */
 	public function can_edit() {

--- a/src/Tribe/REST/V1/Endpoints/Single_Tag.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Tag.php
@@ -40,43 +40,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	}
 
 	/**
-	 * Handles DELETE requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_Error|WP_REST_Response An array containing the data of the trashed post on
-	 *                                   success or a WP_Error instance on failure.
-	 */
-	public function delete( WP_REST_Request $request ) {
-		// TODO: Implement delete() method.
-	}
-
-	/**
-	 * Returns the content of the `args` array that should be used to register the endpoint
-	 * with the `register_rest_route` function.
-	 *
-	 * @since TBD
-	 *
-	 * @return array
-	 */
-	public function DELETE_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can delete content of this type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can delete or not.
-	 */
-	public function can_delete() {
-		// TODO: Implement can_delete() method.
-	}
-
-	/**
 	 * Returns an array in the format used by Swagger 2.0.
 	 *
 	 * While the structure must conform to that used by v2.0 of Swagger the structure can be that of a full document
@@ -91,7 +54,75 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	 * @return array An array description of a Swagger supported component.
 	 */
 	public function get_documentation() {
-		return array();
+		$GET_defaults = $DELETE_defaults = array( 'in' => 'query', 'default' => '', 'type' => 'string' );
+		$POST_defaults = array( 'in' => 'body', 'default' => '', 'type' => 'string' );
+		$post_args = array_merge( $this->READ_args(), $this->CREATE_args() );
+
+		return array(
+			'get'  => array(
+				'parameters' => $this->swaggerize_args( $this->READ_args(), $GET_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Returns the data of the event tag with the specified term ID', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'The event tag term ID is missing.', 'the-events-calendar' ),
+					),
+					'404' => array(
+						'description' => __( 'An event tag with the specified term ID does not exist.', 'the-events-calendar' ),
+					),
+				),
+			),
+			'post' => array(
+				'parameters' => $this->swaggerize_args( $post_args, $POST_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Returns the data of the updated event tag', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'201' => array(
+						'description' => __( 'Returns the data of the created event tag', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'A required parameter is missing or an input parameter is in the wrong format', 'the-events-calendar' ),
+					),
+					'403' => array(
+						'description' => __( 'The user is not authorized to create event tags', 'the-events-calendar' ),
+					),
+				),
+			),
+			'delete'  => array(
+				'parameters' => $this->swaggerize_args( $this->DELETE_args(), $DELETE_defaults ),
+				'responses'  => array(
+					'200' => array(
+						'description' => __( 'Deletes an event tag and returns its data', 'the-event-calendar' ),
+						'schema'      => array(
+							'$ref' => '#/definitions/Term',
+						),
+					),
+					'400' => array(
+						'description' => __( 'The event tag term ID is missing or does not exist.', 'the-events-calendar' ),
+					),
+					'403' => array(
+						'description' => __( 'The current user cannot delete the event tag with the specified term ID.', 'the-events-calendar' ),
+					),
+					'410' => array(
+						'description' => __( 'The event tag with the specified term ID has been deleted already.', 'the-events-calendar' ),
+					),
+					'500' => array(
+						'description' => __( 'The event tag with the specified term ID could not be deleted.', 'the-events-calendar' ),
+					),
+				),
+			),
+		);
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Single_Tag.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Tag.php
@@ -9,20 +9,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	Tribe__Documentation__Swagger__Provider_Interface {
 
 	/**
-	 * Handles POST requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 * @param bool            $return_id Whether the created post ID should be returned or the full response object.
-	 *
-	 * @return WP_Error|WP_REST_Response|int An array containing the data on success or a WP_Error instance on failure.
-	 */
-	public function create( WP_REST_Request $request, $return_id = false ) {
-		// TODO: Implement create() method.
-	}
-
-	/**
 	 * Returns the content of the `args` array that should be used to register the endpoint
 	 * with the `register_rest_route` function.
 	 *
@@ -31,18 +17,26 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	 * @return array
 	 */
 	public function CREATE_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can create content of the specified type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can post or not.
-	 */
-	public function can_create() {
-		// TODO: Implement can_create() method.
+		return array(
+			'name'             => array(
+				'required'          => true,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event tag name', 'the-events-calendar' ),
+			),
+			'description'             => array(
+				'required'          => false,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event tag description', 'the-events-calendar' ),
+			),
+			'slug'             => array(
+				'required'          => false,
+				'validate_callback' => array( $this->validator, 'is_string' ),
+				'type'              => 'string',
+				'description'       => __( 'The event tag slug', 'the-events-calendar' ),
+			),
+		);
 	}
 
 	/**
@@ -118,43 +112,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 				'validate_callback' => array( $this->validator, 'is_post_tag' ),
 			),
 		);
-	}
-
-	/**
-	 * Handles UPDATE requests on the endpoint.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @return WP_Error|WP_REST_Response An array containing the data of the updated post on
-	 *                                   success or a WP_Error instance on failure.
-	 */
-	public function update( WP_REST_Request $request ) {
-		// TODO: Implement update() method.
-	}
-
-	/**
-	 * Returns the content of the `args` array that should be used to register the endpoint
-	 * with the `register_rest_route` function.
-	 *
-	 * @since TBD
-	 *
-	 * @return array
-	 */
-	public function EDIT_args() {
-		return array();
-	}
-
-	/**
-	 * Whether the current user can update content of this type or not.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether the current user can update or not.
-	 */
-	public function can_edit() {
-		// TODO: Implement can_edit() method.
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Single_Tag.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-class Tribe__Events__REST__V1__Endpoints__Single_Category
+class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	extends Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	implements Tribe__REST__Endpoints__READ_Endpoint_Interface,
 	Tribe__REST__Endpoints__CREATE_Endpoint_Interface,
@@ -113,9 +113,9 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 			'id' => array(
 				'in'                => 'path',
 				'type'              => 'integer',
-				'description'       => __( 'the event category term ID', 'the-events-calendar' ),
+				'description'       => __( 'the event tag term ID', 'the-events-calendar' ),
 				'required'          => true,
-				'validate_callback' => array( $this->validator, 'is_event_category' ),
+				'validate_callback' => array( $this->validator, 'is_post_tag' ),
 			),
 		);
 	}
@@ -165,7 +165,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	 * @return string
 	 */
 	public function get_taxonomy() {
-		return Tribe__Events__Main::TAXONOMY;
+		return 'post_tag';
 	}
 
 	/**
@@ -176,6 +176,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Category
 	 * @return string
 	 */
 	protected function get_term_namespace() {
-		return 'categories';
+		return 'tags';
 	}
 }

--- a/src/Tribe/REST/V1/Endpoints/Single_Tag.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Tag.php
@@ -18,19 +18,19 @@ class Tribe__Events__REST__V1__Endpoints__Single_Tag
 	 */
 	public function CREATE_args() {
 		return array(
-			'name'             => array(
+			'name'        => array(
 				'required'          => true,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',
 				'description'       => __( 'The event tag name', 'the-events-calendar' ),
 			),
-			'description'             => array(
+			'description' => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',
 				'description'       => __( 'The event tag description', 'the-events-calendar' ),
 			),
-			'slug'             => array(
+			'slug'        => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',

--- a/src/Tribe/REST/V1/Endpoints/Single_Venue.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Venue.php
@@ -445,6 +445,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Venue
 	/**
 	 * Whether the current user can delete posts of the type managed by the endpoint or not.
 	 *
+	 * @since TBD
+	 *
 	 * @return bool
 	 */
 	public function can_delete() {
@@ -495,6 +497,10 @@ class Tribe__Events__REST__V1__Endpoints__Single_Venue
 	}
 
 	/**
+	 * Whether the current user can update content of this type or not.
+	 *
+	 * @since TBD
+	 *
 	 * @return bool Whether the current user can update or not.
 	 */
 	public function can_edit() {

--- a/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
@@ -75,4 +75,84 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	 * @return string
 	 */
 	abstract protected function get_term_namespace();
+
+	/**
+	 * Handles POST requests on the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request
+	 * @param bool            $return_id Whether the created post ID should be returned or the full response object.
+	 *
+	 * @return WP_Error|WP_REST_Response|int An array containing the data on success or a WP_Error instance on failure.
+	 */
+	public function create( WP_REST_Request $request, $return_id = false ) {
+		$term_response = $this->terms_controller->create_item( $request );
+
+		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
+
+		$term_response->set_data( $data );
+
+		return $term_response;
+	}
+
+	/**
+	 * Whether the current user can create content of the specified type or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the current user can post or not.
+	 */
+	public function can_create() {
+		$cap = get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->edit_posts;
+
+		return current_user_can( $cap );
+	}
+
+	/**
+	 * Whether the current user can update content of this type or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the current user can update or not.
+	 */
+	public function can_edit() {
+		return $this->can_create();
+	}
+
+	/**
+	 * Handles UPDATE requests on the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response An array containing the data of the updated post on
+	 *                                   success or a WP_Error instance on failure.
+	 */
+	public function update( WP_REST_Request $request ) {
+		$term_response = $this->terms_controller->update_item( $request );
+
+		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
+
+		$term_response->set_data( $data );
+
+		return $term_response;
+	}
+
+	/**
+	 * Returns the content of the `args` array that should be used to register the endpoint
+	 * with the `register_rest_route` function.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function EDIT_args() {
+		// when editing the only required argument is the ID ('id')
+		$create_args = $this->CREATE_args();
+		array_walk( $create_args, array( $this, 'unrequire_arg' ) );
+
+		return array_merge( $this->READ_args(), $create_args );
+	}
 }

--- a/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
@@ -1,4 +1,5 @@
 <?php
+
 abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	extends Tribe__Events__REST__V1__Endpoints__Base {
 
@@ -34,8 +35,8 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 		WP_REST_Terms_Controller $terms_controller
 	) {
 		parent::__construct( $messages );
-		$this->repository = $repository;
-		$this->validator = $validator;
+		$this->repository       = $repository;
+		$this->validator        = $validator;
 		$this->terms_controller = $terms_controller;
 	}
 
@@ -59,6 +60,10 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	 */
 	public function get( WP_REST_Request $request ) {
 		$term_response = $this->terms_controller->get_item( $request );
+
+		if ( is_wp_error( $term_response ) ) {
+			return $term_response;
+		}
 
 		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
 
@@ -88,6 +93,10 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	 */
 	public function create( WP_REST_Request $request, $return_id = false ) {
 		$term_response = $this->terms_controller->create_item( $request );
+
+		if ( is_wp_error( $term_response ) ) {
+			return $term_response;
+		}
 
 		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
 
@@ -133,6 +142,10 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 	public function update( WP_REST_Request $request ) {
 		$term_response = $this->terms_controller->update_item( $request );
 
+		if ( is_wp_error( $term_response ) ) {
+			return $term_response;
+		}
+
 		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
 
 		$term_response->set_data( $data );
@@ -154,5 +167,66 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 		array_walk( $create_args, array( $this, 'unrequire_arg' ) );
 
 		return array_merge( $this->READ_args(), $create_args );
+	}
+
+	/**
+	 * Returns the content of the `args` array that should be used to register the endpoint
+	 * with the `register_rest_route` function.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function DELETE_args() {
+		return $this->READ_args();
+	}
+
+	/**
+	 * Whether the current user can delete content of this type or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the current user can delete or not.
+	 */
+	public function can_delete() {
+		return $this->can_create();
+	}
+
+	/**
+	 * Handles DELETE requests on the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response An array containing the data of the trashed post on
+	 *                                   success or a WP_Error instance on failure.
+	 */
+	public function delete( WP_REST_Request $request ) {
+		/**
+		 * Filters whether term deletion is supported in TEC REST API or not.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $support_deletion
+		 */
+		$support_deletion = apply_filters( 'tribe_events_rest_term_allow_delete', true );
+
+		if ( $support_deletion ) {
+			$request['force'] = true;
+		}
+
+		$term_response = $this->terms_controller->delete_item( $request );
+
+		if ( is_wp_error( $term_response ) ) {
+			return $term_response;
+		}
+
+		$term_data = $term_response->get_data();
+		$data      = $this->repository->prepare_term_data( $term_data['previous'], $this->get_taxonomy(), $this->get_term_namespace() );
+
+		$term_response->set_data( $data );
+
+		return $term_response;
 	}
 }

--- a/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
@@ -97,8 +97,13 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
 		if ( is_wp_error( $term_response ) ) {
 			return $term_response;
 		}
+		$term_data = $term_response->get_data();
 
-		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
+		if ( $return_id ) {
+			return $term_data['id'];
+		}
+
+		$data = $this->repository->prepare_term_data( $term_data, $this->get_taxonomy(), $this->get_term_namespace() );
 
 		$term_response->set_data( $data );
 

--- a/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Single_Base.php
@@ -1,0 +1,78 @@
+<?php
+abstract class Tribe__Events__REST__V1__Endpoints__Term_Single_Base
+	extends Tribe__Events__REST__V1__Endpoints__Base {
+
+	/**
+	 * @var \Tribe__Events__REST__Interfaces__Post_Repository
+	 */
+	protected $repository;
+
+	/**
+	 * @var \Tribe__Events__Validator__Interface
+	 */
+	protected $validator;
+
+	/**
+	 * @var \WP_REST_Terms_Controller
+	 */
+	protected $terms_controller;
+
+	/**
+	 * Tribe__Events__REST__V1__Endpoints__Term_Single_Base constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__REST__Messages_Interface                  $messages
+	 * @param \Tribe__Events__REST__Interfaces__Post_Repository $repository
+	 * @param \Tribe__Events__Validator__Interface              $validator
+	 * @param \WP_REST_Terms_Controller                         $terms_controller
+	 */
+	public function __construct(
+		Tribe__REST__Messages_Interface $messages,
+		Tribe__Events__REST__Interfaces__Post_Repository $repository,
+		Tribe__Events__Validator__Interface $validator,
+		WP_REST_Terms_Controller $terms_controller
+	) {
+		parent::__construct( $messages );
+		$this->repository = $repository;
+		$this->validator = $validator;
+		$this->terms_controller = $terms_controller;
+	}
+
+	/**
+	 * Returns the taxonomy of the terms handled by the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	abstract public function get_taxonomy();
+
+	/**
+	 * Handles GET requests on the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
+	 */
+	public function get( WP_REST_Request $request ) {
+		$term_response = $this->terms_controller->get_item( $request );
+
+		$data = $this->repository->prepare_term_data( $term_response->get_data(), $this->get_taxonomy(), $this->get_term_namespace() );
+
+		$term_response->set_data( $data );
+
+		return $term_response;
+	}
+
+	/**
+	 * Returns the term namespace used by the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	abstract protected function get_term_namespace();
+}

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -535,6 +535,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'callback' => array( $archive_endpoint, 'get' ),
 						'args'     => $archive_endpoint->READ_args(),
 					),
+					array(
+						'methods'             => WP_REST_Server::CREATABLE,
+						'args'                => $single_endpoint->CREATE_args(),
+						'permission_callback' => array( $single_endpoint, 'can_create' ),
+						'callback'            => array( $single_endpoint, 'create' ),
+					),
 				)
 			);
 
@@ -546,6 +552,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'methods'  => WP_REST_Server::READABLE,
 						'callback' => array( $single_endpoint, 'get' ),
 						'args'     => $single_endpoint->READ_args(),
+					),
+					array(
+						'methods'             => WP_REST_Server::EDITABLE,
+						'args'                => $single_endpoint->EDIT_args(),
+						'permission_callback' => array( $single_endpoint, 'can_edit' ),
+						'callback'            => array( $single_endpoint, 'update' ),
 					),
 				)
 			);
@@ -585,6 +597,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'callback' => array( $archive_endpoint, 'get' ),
 						'args'     => $archive_endpoint->READ_args(),
 					),
+					array(
+						'methods'             => WP_REST_Server::CREATABLE,
+						'args'                => $single_endpoint->CREATE_args(),
+						'permission_callback' => array( $single_endpoint, 'can_create' ),
+						'callback'            => array( $single_endpoint, 'create' ),
+					),
 				)
 			);
 
@@ -596,6 +614,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'methods'  => WP_REST_Server::READABLE,
 						'callback' => array( $single_endpoint, 'get' ),
 						'args'     => $single_endpoint->READ_args(),
+					),
+					array(
+						'methods'             => WP_REST_Server::EDITABLE,
+						'args'                => $single_endpoint->EDIT_args(),
+						'permission_callback' => array( $single_endpoint, 'can_edit' ),
+						'callback'            => array( $single_endpoint, 'update' ),
 					),
 				)
 			);

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -559,6 +559,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'permission_callback' => array( $single_endpoint, 'can_edit' ),
 						'callback'            => array( $single_endpoint, 'update' ),
 					),
+					array(
+						'methods'             => WP_REST_Server::DELETABLE,
+						'args'                => $single_endpoint->DELETE_args(),
+						'permission_callback' => array( $single_endpoint, 'can_delete' ),
+						'callback'            => array( $single_endpoint, 'delete' ),
+					),
 				)
 			);
 		}
@@ -620,6 +626,12 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 						'args'                => $single_endpoint->EDIT_args(),
 						'permission_callback' => array( $single_endpoint, 'can_edit' ),
 						'callback'            => array( $single_endpoint, 'update' ),
+					),
+					array(
+						'methods'             => WP_REST_Server::DELETABLE,
+						'args'                => $single_endpoint->DELETE_args(),
+						'permission_callback' => array( $single_endpoint, 'can_delete' ),
+						'callback'            => array( $single_endpoint, 'delete' ),
 					),
 				)
 			);

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -57,6 +57,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		}
 
 		add_action( 'rest_api_init', array( $this, 'register_endpoints' ) );
+		add_filter( 'tribe_events_register_event_cat_type_args', array( $this, 'filter_taxonomy_args' ) );
 	}
 
 	/**
@@ -518,6 +519,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		$validator        = tribe( 'tec.rest-v1.validator' );
 		$terms_controller = new WP_REST_Terms_Controller( Tribe__Events__Main::TAXONOMY );
 		$archive_endpoint = new Tribe__Events__REST__V1__Endpoints__Archive_Category( $messages, $post_repository, $validator, $terms_controller );
+		$single_endpoint  = new Tribe__Events__REST__V1__Endpoints__Single_Category( $messages, $post_repository, $validator, $terms_controller );
 
 		tribe_singleton( 'tec.rest-v1.endpoints.archive-category', $archive_endpoint );
 
@@ -535,10 +537,23 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 					),
 				)
 			);
+
+			register_rest_route(
+				$namespace,
+				'/categories/(?P<id>\\d+)',
+				array(
+					array(
+						'methods'  => WP_REST_Server::READABLE,
+						'callback' => array( $single_endpoint, 'get' ),
+						'args'     => $single_endpoint->READ_args(),
+					),
+				)
+			);
 		}
 
 		$documentation_endpoint = tribe( 'tec.rest-v1.endpoints.documentation' );
 		$documentation_endpoint->register_documentation_provider( '/categories', $archive_endpoint );
+		$documentation_endpoint->register_documentation_provider( '/categories/{id}', $single_endpoint );
 	}
 
 	/**
@@ -554,6 +569,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		$validator        = tribe( 'tec.rest-v1.validator' );
 		$terms_controller = new WP_REST_Terms_Controller( 'post_tag' );
 		$archive_endpoint = new Tribe__Events__REST__V1__Endpoints__Archive_Tag( $messages, $post_repository, $validator, $terms_controller );
+		$single_endpoint = new Tribe__Events__REST__V1__Endpoints__Single_Tag( $messages, $post_repository, $validator, $terms_controller );
 
 		tribe_singleton( 'tec.rest-v1.endpoints.archive-category', $archive_endpoint );
 
@@ -572,9 +588,36 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 				)
 			);
 
+			register_rest_route(
+				$namespace,
+				'/tags/(?P<id>\\d+)',
+				array(
+					array(
+						'methods'  => WP_REST_Server::READABLE,
+						'callback' => array( $single_endpoint, 'get' ),
+						'args'     => $single_endpoint->READ_args(),
+					),
+				)
+			);
 		}
 
 		$documentation_endpoint = tribe( 'tec.rest-v1.endpoints.documentation' );
 		$documentation_endpoint->register_documentation_provider( '/tags', $archive_endpoint );
+		$documentation_endpoint->register_documentation_provider( '/tags/{id}', $single_endpoint );
+	}
+
+	/**
+	 * Filters the event category taxonomy registration arguments to make it show in REST API requests.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $taxonomy_args
+	 *
+	 * @return array
+	 */
+	public function filter_taxonomy_args( array $taxonomy_args ) {
+		$taxonomy_args['show_in_rest'] = true;
+
+		return $taxonomy_args;
 	}
 }

--- a/tests/_support/Helper/TribeDb.php
+++ b/tests/_support/Helper/TribeDb.php
@@ -225,11 +225,11 @@ class TribeDb extends \Codeception\Module {
 
 		$tax_input = [];
 		if ( isset( $overrides['categories'] ) ) {
-			$tax_input['tribe_events_cat'] = $overrides['categories'];
+			$tax_input['tribe_events_cat'] = (array)$overrides['categories'];
 			unset( $overrides['categories'] );
 		}
 		if ( isset( $overrides['tags'] ) ) {
-			$tax_input['post_tag'] = $overrides['tags'];
+			$tax_input['post_tag'] = (array)$overrides['tags'];
 			unset( $overrides['tags'] );
 		}
 
@@ -254,7 +254,7 @@ class TribeDb extends \Codeception\Module {
 
 		unset( $overrides['when'], $overrides['duration'], $overrides['utc_offset'] );
 
-		$id = uniqid();
+		$id = uniqid( mt_rand( 1, 999 ), true );
 		$defaults = [
 			'post_type'  => 'tribe_events',
 			'post_title' => "Event {$id}",

--- a/tests/_support/Helper/TribeDb.php
+++ b/tests/_support/Helper/TribeDb.php
@@ -225,11 +225,11 @@ class TribeDb extends \Codeception\Module {
 
 		$tax_input = [];
 		if ( isset( $overrides['categories'] ) ) {
-			$tax_input['tribe_events_cat'] = (array)$overrides['categories'];
+			$tax_input['tribe_events_cat'] = (array) $overrides['categories'];
 			unset( $overrides['categories'] );
 		}
 		if ( isset( $overrides['tags'] ) ) {
-			$tax_input['post_tag'] = (array)$overrides['tags'];
+			$tax_input['post_tag'] = (array) $overrides['tags'];
 			unset( $overrides['tags'] );
 		}
 

--- a/tests/restv1/CategoryDeletionCest.php
+++ b/tests/restv1/CategoryDeletionCest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+use Tribe__Events__Main as Main;
+
+class CategoryDeletionCest extends BaseRestCest {
+
+	/**
+	 * It should allow deleting an event category
+	 *
+	 * @test
+	 */
+	public function should_allow_deleting_an_event_category( Tester $I ) {
+		list( $parent ) = $I->haveTermInDatabase( 'foo-parent', Main::TAXONOMY );
+		list( $id ) = $I->haveTermInDatabase( 'foo', Main::TAXONOMY, [
+			'count'       => 3,
+			'parent'      => $parent,
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+		$link = get_term_link( $id, Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendDELETE( $this->categories_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 3,
+			'parent'      => $parent,
+			'description' => 'Term description',
+			'url'         => $link,
+			'slug'        => 'foo-bar',
+			'taxonomy'    => Main::TAXONOMY,
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->categories_url . "/{$id}",
+				'collection' => $this->categories_url,
+				'up'         => $this->categories_url . "/{$parent}",
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot delete event category
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_delete_event_category( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendDELETE( $this->categories_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if term ID parameter is bad
+	 *
+	 * @test
+	 * @example [23]
+	 * @example ["23"]
+	 */
+	public function should_return_bad_request_if_term_id_parameter_is_bad( Tester $I, Example $example ) {
+		$I->haveTermInDatabase( 'foo', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendDELETE( $this->categories_url . "/{$example[0]}" );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/CategoryInsertionCest.php
+++ b/tests/restv1/CategoryInsertionCest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+use Tribe__Events__Main as Main;
+
+class CategoryInsertionCest extends BaseRestCest {
+
+	/**
+	 * It should allow inserting an event category
+	 *
+	 * @test
+	 */
+	public function should_allow_inserting_an_event_category( Tester $I ) {
+		list( $parent ) = $I->haveTermInDatabase( 'foo-parent', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendPOST( $this->categories_url, [
+			'parent'      => $parent,
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 201 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 0,
+			'parent'      => $parent,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, Main::TAXONOMY ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => Main::TAXONOMY,
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->categories_url . "/{$id}",
+				'collection' => $this->categories_url,
+				'up'         => $this->categories_url . "/{$parent}",
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot insert terms
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_insert_terms( Tester $I ) {
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendPOST( $this->categories_url, [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if passing bad request parameters
+	 *
+	 * @test
+	 * @example ["name", ""]
+	 * @example ["description", ""]
+	 * @example ["slug", ""]
+	 * @example ["parent", ""]
+	 * @example ["parent", "2389"]
+	 * @example ["parent", "foo"]
+	 */
+	public function should_return_bad_request_if_passing_bad_request_parameters( Tester $I, Example $example ) {
+		$I->generate_nonce_for_role( 'editor' );
+		$params = [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		];
+		$I->sendPOST( $this->categories_url, array_merge( $params, [ $example[0] => $example[1] ] ) );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/CategoryUpdateCest.php
+++ b/tests/restv1/CategoryUpdateCest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+use Tribe__Events__Main as Main;
+
+class CategoryUpdateCest extends BaseRestCest {
+
+	/**
+	 * It should allow updating an event category
+	 *
+	 * @test
+	 */
+	public function should_allow_updating_an_event_category( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', Main::TAXONOMY );
+
+		list( $parent ) = $I->haveTermInDatabase( 'foo-parent', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendPOST( $this->categories_url . "/{$id}", [
+			'parent'      => $parent,
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 0,
+			'parent'      => $parent,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, Main::TAXONOMY ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => Main::TAXONOMY,
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->categories_url . "/{$id}",
+				'collection' => $this->categories_url,
+				'up'         => $this->categories_url . "/{$parent}",
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot update terms
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_update_terms( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendPOST( $this->categories_url . "/{$id}", [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if passing bad request parameters
+	 *
+	 * @test
+	 * @example ["name", ""]
+	 * @example ["description", ""]
+	 * @example ["slug", ""]
+	 * @example ["parent", ""]
+	 * @example ["parent", "2389"]
+	 * @example ["parent", "foo"]
+	 */
+	public function should_return_bad_request_if_passing_bad_request_parameters( Tester $I, Example $example ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', Main::TAXONOMY );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$params = [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		];
+		$I->sendPOST( $this->categories_url . "/{$id}", array_merge( $params, [ $example[0] => $example[1] ] ) );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/SingleCategoryCest.php
+++ b/tests/restv1/SingleCategoryCest.php
@@ -27,6 +27,7 @@ class SingleCategoryCest extends BaseRestCest {
 		$I->seeResponseIsJson();
 		$expected = [
 			'id'          => $id,
+			'name'        => 'foo',
 			'count'       => 2,
 			'description' => 'Term description',
 			'url'         => get_term_link( $id, Main::TAXONOMY ),
@@ -37,7 +38,7 @@ class SingleCategoryCest extends BaseRestCest {
 			'urls'        => [
 				'self'       => $url,
 				'collection' => $this->categories_url,
-				'up'     => $this->categories_url . "/{$parent}",
+				'up'         => $this->categories_url . "/{$parent}",
 			],
 		];
 		foreach ( $expected as $key => $value ) {

--- a/tests/restv1/SingleCategoryCest.php
+++ b/tests/restv1/SingleCategoryCest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+use Tribe__Events__Main as Main;
+
+class SingleCategoryCest extends BaseRestCest {
+
+	/**
+	 * It should allow getting a single category term
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_a_single_category_term( Tester $I ) {
+		list( $parent ) = $I->haveTermInDatabase( 'foo-parent', Main::TAXONOMY );
+		list( $id ) = $I->haveTermInDatabase( 'foo', Main::TAXONOMY, [
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+			'parent'      => $parent,
+			'count'       => 2,
+		] );
+
+		$url = $this->categories_url . "/{$id}";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$expected = [
+			'id'          => $id,
+			'count'       => 2,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, Main::TAXONOMY ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => Main::TAXONOMY,
+			'parent'      => $parent,
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $url,
+				'collection' => $this->categories_url,
+				'up'     => $this->categories_url . "/{$parent}",
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return bad request if trying to get non existing single category term
+	 *
+	 * @test
+	 */
+	public function should_return_bad_request_if_trying_to_get_non_existing_single_category_term( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', 'foo-tax' );
+
+		$I->sendGET( $this->categories_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$url = $this->categories_url . "/2389";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return 404 if supplying not int values for single category term
+	 *
+	 * @test
+	 * @example ["foo"]
+	 * @example ["foo bar"]
+	 * @example [""]
+	 */
+	public function should_return_404_if_supplying_not_int_values_for_single_category_term( Tester $I, Example $example ) {
+		$url = $this->categories_url . "/{$example[0]}";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 404 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/SingleTagCest.php
+++ b/tests/restv1/SingleTagCest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+
+class SingleTagCest extends BaseRestCest {
+
+	/**
+	 * It should allow getting a single tag term
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_a_single_tag_term( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', 'post_tag', [
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+			'count'       => 2,
+		] );
+
+		$url = $this->tags_url . "/{$id}";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$expected = [
+			'id'          => $id,
+			'count'       => 2,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, 'post_tag' ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => 'post_tag',
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $url,
+				'collection' => $this->tags_url,
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return bad request if trying to get non existing single tag term
+	 *
+	 * @test
+	 */
+	public function should_return_bad_request_if_trying_to_get_non_existing_single_tag_term( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', 'foo-tax' );
+
+		$I->sendGET( $this->tags_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+
+		$url = $this->tags_url . "/2389";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return 404 if supplying not int values for single tag term
+	 *
+	 * @test
+	 * @example ["foo"]
+	 * @example ["foo bar"]
+	 * @example [""]
+	 */
+	public function should_return_404_if_supplying_not_int_values_for_single_tag_term( Tester $I, Example $example ) {
+		$url = $this->tags_url . "/{$example[0]}";
+		$I->sendGET( $url );
+
+		$I->seeResponseCodeIs( 404 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/SingleTagCest.php
+++ b/tests/restv1/SingleTagCest.php
@@ -24,6 +24,7 @@ class SingleTagCest extends BaseRestCest {
 		$I->seeResponseIsJson();
 		$expected = [
 			'id'          => $id,
+			'name'        => 'foo',
 			'count'       => 2,
 			'description' => 'Term description',
 			'url'         => get_term_link( $id, 'post_tag' ),

--- a/tests/restv1/TagDeletionCest.php
+++ b/tests/restv1/TagDeletionCest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+use Tribe__Events__Main as Main;
+
+class TagDeletionCest extends BaseRestCest {
+
+	/**
+	 * It should allow deleting an event tag
+	 *
+	 * @test
+	 */
+	public function should_allow_deleting_an_event_tag( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', 'post_tag', [
+			'count'       => 3,
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+		$link = get_term_link( $id, 'post_tag' );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendDELETE( $this->tags_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 3,
+			'description' => 'Term description',
+			'url'         => $link,
+			'slug'        => 'foo-bar',
+			'taxonomy'    => 'post_tag',
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->tags_url . "/{$id}",
+				'collection' => $this->tags_url,
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot delete event tag
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_delete_event_tag( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'foo', 'post_tag' );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendDELETE( $this->tags_url . "/{$id}" );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if term ID parameter is bad
+	 *
+	 * @test
+	 * @example [23]
+	 * @example ["23"]
+	 */
+	public function should_return_bad_request_if_term_id_parameter_is_bad( Tester $I, Example $example ) {
+		$I->haveTermInDatabase( 'foo', 'post_tag' );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendDELETE( $this->tags_url . "/{$example[0]}" );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/TagInsertionCest.php
+++ b/tests/restv1/TagInsertionCest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+
+class TagInsertionCest extends BaseRestCest {
+
+	/**
+	 * It should allow inserting an event tag
+	 *
+	 * @test
+	 */
+	public function should_allow_inserting_an_event_tag( Tester $I ) {
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendPOST( $this->tags_url, [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 201 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 0,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, 'post_tag' ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => 'post_tag',
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->tags_url . "/{$id}",
+				'collection' => $this->tags_url,
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot insert terms
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_insert_terms( Tester $I ) {
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendPOST( $this->tags_url, [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if passing bad request parameters
+	 *
+	 * @test
+	 * @example ["name", ""]
+	 * @example ["description", ""]
+	 * @example ["slug", ""]
+	 */
+	public function should_return_bad_request_if_passing_bad_request_parameters( Tester $I, Example $example ) {
+		$I->generate_nonce_for_role( 'editor' );
+		$params = [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		];
+		$I->sendPOST( $this->tags_url, array_merge( $params, [ $example[0] => $example[1] ] ) );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}

--- a/tests/restv1/TagUpdateCest.php
+++ b/tests/restv1/TagUpdateCest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Codeception\Example;
+use Step\Restv1\RestGuy as Tester;
+
+class TagUpdateCest extends BaseRestCest {
+
+	/**
+	 * It should allow updating an event tag
+	 *
+	 * @test
+	 */
+	public function should_allow_updating_an_event_tag( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', 'post_tag' );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$I->sendPOST( $this->tags_url . "/{$id}", [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->assertArrayHasKey( 'id', $response );
+
+		$id       = $response['id'];
+		$expected = [
+			'id'          => $id,
+			'name'        => 'foo',
+			'count'       => 0,
+			'description' => 'Term description',
+			'url'         => get_term_link( $id, 'post_tag' ),
+			'slug'        => 'foo-bar',
+			'taxonomy'    => 'post_tag',
+			'meta'        => [],
+			'urls'        => [
+				'self'       => $this->tags_url . "/{$id}",
+				'collection' => $this->tags_url,
+			],
+		];
+		foreach ( $expected as $key => $value ) {
+			$I->seeResponseContainsJson( [ $key => $value ] );
+		}
+	}
+
+	/**
+	 * It should return 403 if user cannot update terms
+	 *
+	 * @test
+	 */
+	public function should_return_403_if_user_cannot_update_terms( Tester $I ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', 'post_tag' );
+
+		$I->generate_nonce_for_role( 'subscriber' );
+		$I->sendPOST( $this->tags_url . "/{$id}", [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		] );
+
+		$I->seeResponseCodeIs( 403 );
+		$I->seeResponseIsJson();
+	}
+
+	/**
+	 * It should return bad request if passing bad request parameters
+	 *
+	 * @test
+	 * @example ["name", ""]
+	 * @example ["description", ""]
+	 * @example ["slug", ""]
+	 */
+	public function should_return_bad_request_if_passing_bad_request_parameters( Tester $I, Example $example ) {
+		list( $id ) = $I->haveTermInDatabase( 'old-foo', 'post_tag' );
+
+		$I->generate_nonce_for_role( 'editor' );
+		$params = [
+			'name'        => 'foo',
+			'description' => 'Term description',
+			'slug'        => 'foo-bar',
+		];
+		$I->sendPOST( $this->tags_url . "/{$id}", array_merge( $params, [ $example[0] => $example[1] ] ) );
+
+		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseIsJson();
+	}
+}


### PR DESCRIPTION
Ticket:  https://central.tri.be/issues/82414

Based on: https://github.com/moderntribe/tribe-common/pull/452

This PR adds the code and the tests to fully support CRUD operations for event Categories and Tags.