### PR TITLE
Cast error responses to WP_Error

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.8.1] TBD =
+
+* Fix - Fixed an issue where failed EA Imports would hang for a long time before failing [83344]
+
 = [4.5.8] 2017-07-13 =
 
 * Fix - Remove permalink logic for recurring events (Events Calendar PRO will implement instead) [74153]

--- a/src/Tribe/Aggregator/API/Import.php
+++ b/src/Tribe/Aggregator/API/Import.php
@@ -85,7 +85,7 @@ class Tribe__Events__Aggregator__API__Import extends Tribe__Events__Aggregator__
 		// let's try to use the localized version of the message if available
 		if ( ! empty( $response->message_code ) ) {
 			$default = ! empty( $response->message ) ? $response->message : $this->service->get_unknown_message();
-			$response->message = $this->service->get_service_message( $response->message_code, $default );
+			$response->message = $this->service->get_service_message( $response->message_code, array(), $default );
 		}
 
 		if ( 'success_import-complete' !== $response->message_code ) {

--- a/src/Tribe/Aggregator/API/Import.php
+++ b/src/Tribe/Aggregator/API/Import.php
@@ -60,7 +60,7 @@ class Tribe__Events__Aggregator__API__Import extends Tribe__Events__Aggregator__
 	 *
 	 * @param string $import_id Event Aggregator import id
 	 *
-	 * @return stdClass|WP_Error
+	 * @return stdClass|WP_Error A class containing the service response or a WP_Error if the service could not be reached.
 	 */
 	public function get( $import_id, $data = array() ) {
 		$response = $this->service->get_import( $import_id, $data );

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1839,6 +1839,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	}
 
 	/**
+	 * Cast error responses from the Service to WP_Errors to ease processing down the line.
+	 *
+	 * If a response is a WP_Error already or is not an error response then it will not be modified.
+	 *
+	 * @since TBD
+	 *
 	 * @param WP_Error|object $import_data
 	 *
 	 * @return array|\WP_Error

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -634,8 +634,9 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	}
 
 	public function get_import_data() {
+		/** @var \Tribe__Events__Aggregator $aggregator */
 		$aggregator = tribe( 'events-aggregator.main' );
-		$data = array();
+		$data       = array();
 
 		// For now only apply this to the URL type
 		if ( 'url' === $this->type ) {
@@ -645,7 +646,13 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			);
 		}
 
-		return $aggregator->api( 'import' )->get( $this->meta['import_id'], $data );
+		/** @var \Tribe__Events__Aggregator__API__Import $import_api */
+		$import_api  = $aggregator->api( 'import' );
+		$import_data = $import_api->get( $this->meta['import_id'], $data );
+
+		$import_data = $this->maybe_cast_to_error( $import_data );
+
+		return $import_data;
 	}
 
 	public function delete( $force = false ) {
@@ -1829,5 +1836,28 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		global $wpdb;
 
 		return $wpdb->last_error !== $this->last_wpdb_error;
+	}
+
+	/**
+	 * @param WP_Error|object $import_data
+	 *
+	 * @return array|\WP_Error
+	 */
+	protected function maybe_cast_to_error( $import_data ) {
+		if ( is_wp_error( $import_data ) ) {
+			return $import_data;
+		}
+
+		if ( ! empty( $import_data->status ) && 'error' === $import_data->status ) {
+			$import_data = (array) $import_data;
+			$code        = Tribe__Utils__Array::get( $import_data, 'message_code', 'error:import-failed' );
+			/** @var \Tribe__Events__Aggregator__Service $service */
+			$service     = tribe( 'events-aggregator.service' );
+			$message     = Tribe__Utils__Array::get( $import_data, 'message', $service->get_service_message( 'error:import-failed' ) );
+			$data        = Tribe__Utils__Array::get( $import_data, 'data', array() );
+			$import_data = new WP_Error( $code, $message, $data );
+		}
+
+		return $import_data;
 	}
 }

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -169,18 +169,32 @@ class Tribe__Events__Aggregator__Service {
 			if ( isset( $response->errors['http_request_failed'] ) ) {
 				$response->errors['http_request_failed'][0] = __( 'Connection timed out while transferring the feed. If you are dealing with large feeds you may need to customize the tribe_aggregator_connection_timeout filter.', 'the-events-calendar' );
 			}
+
 			return $response;
 		}
 
-		if (
-			(
-				isset( $response->data )
-				&& isset( $response->data->status )
-				&& '404' === $response->data->status
-			)
-		     || '200' != wp_remote_retrieve_response_code( $response )
-		) {
-			return new WP_Error( 'core:aggregator:daily-limit-reached', esc_html__( 'There may be an issue with the Event Aggregator server. Please try your import again later.', 'the-events-calendar' ) );
+		if ( 403 == wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error(
+				'core:aggregator:request-denied',
+				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.',
+					'the-events-calendar' )
+			);
+		}
+
+		// we know it is not a 404 or 403 at this point
+		if ( 200 != wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error(
+				'core:aggregator:bad-response',
+				esc_html__( 'There may be an issue with the Event Aggregator server. Please try your import again later.',
+					'the-events-calendar' )
+			);
+		}
+
+		if ( isset( $response->data ) && isset( $response->data->status ) && '404' === $response->data->status ) {
+			return new WP_Error(
+				'core:aggregator:daily-limit-reached',
+				esc_html__( 'There may be an issue with the Event Aggregator server. Please try your import again later.', 'the-events-calendar' )
+			);
 		}
 
 		// if the response is not an image, let's json decode the body

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -172,7 +172,14 @@ class Tribe__Events__Aggregator__Service {
 			return $response;
 		}
 
-		if ( isset( $response->data ) && isset( $response->data->status ) && '404' === $response->data->status ) {
+		if (
+			(
+				isset( $response->data )
+				&& isset( $response->data->status )
+				&& '404' === $response->data->status
+			)
+		     || '200' != wp_remote_retrieve_response_code( $response )
+		) {
 			return new WP_Error( 'core:aggregator:daily-limit-reached', esc_html__( 'There may be an issue with the Event Aggregator server. Please try your import again later.', 'the-events-calendar' ) );
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/83344

This PR follows up the research work done by @borkweb (https://tribe.slack.com/archives/C1SMDBJQ7/p1500615585145005) to make sure we cast error responses coming from the service to proper WP_Errors.
Using the EA Mocker it observable that, without this, error responses would be queued and try to fetch forever.