### PR TITLE
Avoid duplicated events on import

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.10] TBD =
+
+* Fix - avoid duplicate events when importing from some iCal, GoogleCalendar and Facebook feeds in Event Aggregator [67038]
+
 = [4.5.9] 2017-07-26 =
 
 * Fix - Send Aggregator callback URL with correct Scheme [83364]

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1301,10 +1301,10 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 						$venue_id = array_search( $event['Venue']['Venue'], $found_venues );
 
 						if ( ! $venue_id ) {
-							$unique_field = $this->get_unique_field( 'venue' );
+							$venue_unique_field = $this->get_unique_field( 'venue' );
 
-							if ( ! empty( $unique_field ) ) {
-								$target = $unique_field['target'];
+							if ( ! empty( $venue_unique_field ) ) {
+								$target = $venue_unique_field['target'];
 								$value  = $venue_data[ $target ];
 								$venue  = Tribe__Events__Aggregator__Event::get_post_by_meta( "_Venue{$target}", $value );
 							} else {
@@ -1427,10 +1427,10 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 						$organizer_id = array_search( $event['Organizer']['Organizer'], $found_organizers );
 
 						if ( ! $organizer_id ) {
-							$unique_field = $this->get_unique_field( 'organizer' );
+							$organizer_unique_field = $this->get_unique_field( 'organizer' );
 
-							if ( ! empty( $unique_field ) ) {
-								$target    = $unique_field['target'];
+							if ( ! empty( $organizer_unique_field ) ) {
+								$target    = $organizer_unique_field['target'];
 								$value     = $organizer_data[ $target ];
 								$organizer = Tribe__Events__Aggregator__Event::get_post_by_meta( "_Organizer{$target}", $value );
 							} else {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67038#note-14

Due to a stupid (mine) choice of var names in some instances the imported events UID might not be saved hence triggering duplicated import.
This fixes it.