### PR TITLE
Call using correct syntax for an instance method | #84020

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,8 +329,9 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.5.10] TBD =
 
-* Tweak - Tweaked the Organizer e-mail address field label a bit to better accomodate Community Events [80426]
-* Fix - avoid duplicate events when importing from some iCal, GoogleCalendar and Facebook feeds in Event Aggregator [67038]
+* Fix - Avoid duplicate events when importing from some iCal, Google Calendar and Facebook feeds in Event Aggregator [67038]
+* Tweak - Moved the organizer e-mail address field label a bit to better accomodate Community Events [80426]
+* Tweak - Avoid notice-level errors while processing queues within Event Aggregator [84020]
 
 = [4.5.9] 2017-07-26 =
 

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -143,7 +143,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 			}
 		}
 
-		$queue_items = get_post_meta( $this->current_record_id, Tribe__Events__Aggregator__Records::prefix_meta( Tribe__Events__Aggregator__Record__Queue::$queue_key ), true );
+		$queue_items = get_post_meta( $this->current_record_id, Tribe__Events__Aggregator__Records::instance()->prefix_meta( Tribe__Events__Aggregator__Record__Queue::$queue_key ), true );
 
 		// We only get here if we done processing this batch
 		// Now we will check for more events on the queue


### PR DESCRIPTION
Fixes the way we call an instance method (previously being called as if it were a static method).

:ticket: [#84020](https://central.tri.be/issues/84020)