### PR TITLE
Fix/76411 get link ld

### DIFF
--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -140,4 +140,15 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 		return str_replace( $mon_thousands_sep, '', $price );
 	}
 
+	/**
+	 * Get a link to the event
+	 *
+	 * @param  int|WP_Post  $post The Post Object or ID
+	 *
+	 * @return false|string Link to the event or false
+	 */
+	protected function get_link( $post ) {
+		return tribe_get_event_link( Tribe__Main::post_id_helper( $post ) );
+	}
+
 }

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -148,7 +148,7 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	 * @return false|string Link to the event or false
 	 */
 	protected function get_link( $post ) {
-		return tribe_get_event_link( Tribe__Main::post_id_helper( $post ) );
+		return tribe_get_event_link( $post );
 	}
 
 }

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -143,6 +143,8 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	/**
 	 * Get a link to the event
 	 *
+	 * @since TBD
+	 *
 	 * @param  int|WP_Post  $post The Post Object or ID
 	 *
 	 * @return false|string Link to the event or false

--- a/src/Tribe/JSON_LD/Organizer.php
+++ b/src/Tribe/JSON_LD/Organizer.php
@@ -59,4 +59,21 @@ class Tribe__Events__JSON_LD__Organizer extends Tribe__JSON_LD__Abstract {
 		return array( $post_id => $data );
 	}
 
+	/**
+	 * Get a link to the event
+	 *
+	 * @param  int|WP_Post  $post The Post Object or ID
+	 *
+	 * @return false|string Link to the event or false
+	 */
+	protected function get_link( $post ) {
+		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			$link = tribe_get_organizer_link( $post, false );
+		} else {
+			$link = false;
+		}
+
+		return $link;
+	}
+
 }

--- a/src/Tribe/JSON_LD/Organizer.php
+++ b/src/Tribe/JSON_LD/Organizer.php
@@ -69,6 +69,7 @@ class Tribe__Events__JSON_LD__Organizer extends Tribe__JSON_LD__Abstract {
 	 * @return false|string Link to the event or false
 	 */
 	protected function get_link( $post ) {
+		// @TODO Move this logic to Pro once #33734 is handled.
 		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
 			$link = tribe_get_organizer_link( $post, false );
 		} else {

--- a/src/Tribe/JSON_LD/Organizer.php
+++ b/src/Tribe/JSON_LD/Organizer.php
@@ -62,6 +62,8 @@ class Tribe__Events__JSON_LD__Organizer extends Tribe__JSON_LD__Abstract {
 	/**
 	 * Get a link to the event
 	 *
+	 * @since TBD
+	 *
 	 * @param  int|WP_Post  $post The Post Object or ID
 	 *
 	 * @return false|string Link to the event or false

--- a/src/Tribe/JSON_LD/Venue.php
+++ b/src/Tribe/JSON_LD/Venue.php
@@ -89,6 +89,7 @@ class Tribe__Events__JSON_LD__Venue extends Tribe__JSON_LD__Abstract {
 	 * @return false|string Link to the event or false
 	 */
 	protected function get_link( $post ) {
+		// @TODO Move this logic to Pro once #33734 is handled.
 		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
 			$link = tribe_get_venue_link( $post, false );
 		} else {

--- a/src/Tribe/JSON_LD/Venue.php
+++ b/src/Tribe/JSON_LD/Venue.php
@@ -79,4 +79,21 @@ class Tribe__Events__JSON_LD__Venue extends Tribe__JSON_LD__Abstract {
 		return array( $post_id => $data );
 	}
 
+	/**
+	 * Get a link to the event
+	 *
+	 * @param  int|WP_Post  $post The Post Object or ID
+	 *
+	 * @return false|string Link to the event or false
+	 */
+	protected function get_link( $post ) {
+		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			$link = tribe_get_venue_link( $post, false );
+		} else {
+			$link = false;
+		}
+
+		return $link;
+	}
+
 }

--- a/src/Tribe/JSON_LD/Venue.php
+++ b/src/Tribe/JSON_LD/Venue.php
@@ -82,6 +82,8 @@ class Tribe__Events__JSON_LD__Venue extends Tribe__JSON_LD__Abstract {
 	/**
 	 * Get a link to the event
 	 *
+	 * @since TBD
+	 *
 	 * @param  int|WP_Post  $post The Post Object or ID
 	 *
 	 * @return false|string Link to the event or false

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -259,27 +259,46 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * Get link to a single event
 	 *
-	 * @param int $postId Optional post ID
-	 * @param bool $full_link If true outputs a complete HTML <a> link, otherwise only the URL is output
+	 * @param WP_Post|int $post_id   Optional. WP Post that this affects
+	 * @param bool        $full_link Optional. If true outputs a complete HTML <a> link, otherwise only the URL is output
 	 *
-	 * @return string
+	 * @return string|bool Link to post or false if none found
 	 */
-	function tribe_get_event_link( $postId = null, $full_link = false ) {
+	function tribe_get_event_link( $post_id = null, $full_link = false ) {
+		$post_id = Tribe__Main::post_id_helper( $post_id );
+		$url = Tribe__Events__Main::instance()->getLink( 'single', $post_id );
 
-		$url = Tribe__Events__Main::instance()->getLink( 'single', $postId );
-
-		if ( '' != get_option( 'permalink_structure' ) ) $url = trailingslashit( $url );
+		if ( '' != get_option( 'permalink_structure' ) ) {
+			$url = trailingslashit( $url );
+		}
 
 		if ( $full_link ) {
-			$title_args = array( 'post' => $postId, 'echo' => false );
-			$name = get_the_title( $postId );
+			$title_args = array( 'post' => $post_id, 'echo' => false );
+			$name       = get_the_title( $post_id );
 			$attr_title = the_title_attribute( $title_args );
-			$link = ! empty( $url ) && ! empty( $name ) ? '<a href="' . esc_url( $url ) . '" title="'.$attr_title.'"">' . $name . '</a>' : false;
+			$link       = false;
+
+			if ( ! empty( $url ) && ! empty( $name ) ) {
+				$link = sprintf(
+					'<a href="%1$s" title="%2$s"">%3$s</a>',
+					esc_url( $url ),
+					$attr_title,
+					$name
+				);
+			}
 		} else {
 			$link = $url;
 		}
 
-		return apply_filters( 'tribe_get_event_link', $link, $postId, $full_link, $url );
+		/**
+		 * Filters the permalink to events
+		 *
+		 * @param mixed  $link      The link, possibly HTML, just URL, or false
+		 * @param int    $post_id   Post ID
+		 * @param bool   $full_link Whether to output full HTML <a> link
+		 * @param string $url       The URL itself
+		 */
+		return apply_filters( 'tribe_get_event_link', $link, $post_id, $full_link, $url );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/76411

Related PR: https://github.com/moderntribe/tribe-common/pull/469

When pro isn't active the get linked post functions return the name of the organizer or venue :-/ So we should go with false here.

Took the opportunity to update tribe_get_event_link() a bit. Mostly it just needs to accept a WP_Post or ID, like everything else. But while I was adding that...