### PR TITLE
Update Query.php to allow 60s query caching

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -285,7 +285,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 								? $query->get( 'eventDate' )
 								: date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT );
 							if ( ! $query->tribe_is_past ) {
-								$query->set( 'start_date', ( '' != $query->get( 'eventDate' ) ? tribe_beginning_of_day( $event_date ) : tribe_format_date( current_time( 'timestamp' ), true, 'Y-m-d H:i:s' ) ) );
+								$query->set( 'start_date', ( '' != $query->get( 'eventDate' ) ? tribe_beginning_of_day( $event_date ) : tribe_format_date( current_time( 'timestamp' ), true, 'Y-m-d H:i:00' ) ) );
 								$query->set( 'end_date', '' );
 								$query->set( 'order', self::set_order( 'ASC', $query ) );
 							} else {


### PR DESCRIPTION
By including the seconds string in the default list query mysql has a difficult/impossible time caching the query results, because the query changes every second. By replacing `H:i:s` with `H:i:00` mysql can cache the query for 60s, which results in events being displayed with the same precision, since events do not use seconds, and better performance out of the box.