### PR TITLE
#81921 Restore Functionality of $only_with_upcoming Parameter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -334,6 +334,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed Post ID not being sent to the_title filter for Organizers and Venues (props Anna L.) [85206]
 * Fix - Fixed an issue that would sometimes render Event Aggregator options invalid even with a valid license [78469]
 * Fix — Fixed an issue where the mobile.php template file would often fail to include an event's featured image [74291]
+* Fix - Restore functionality of the $only_with_upcoming parameter in the tribe_get_venues() template tag [81921]
 * Tweak - Prevent stray commas from showing up for some event venues in the List View [72289] 
 * Tweak - Modify certain event queries to widen the window of opportunity for query caching (props @garretjohnson) [84841]
 * Tweak - Improve Event Aggregator message regarding Facebook token expiration [70376]

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -568,7 +568,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				        ON p.ID = pm.post_id
 				    LEFT JOIN wp_postmeta eventDate
 				        ON p.ID=eventDate.post_id AND eventDate.meta_key='_EventStartDate'
-				WHERE p.post_type = 'tribe_events'
+				WHERE p.post_type = '%s'
 				    AND p.post_status = 'publish'
 				    AND pm.meta_key = '_EventVenueID'
 				    AND pm.meta_value > 0
@@ -576,12 +576,15 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				GROUP BY pm.meta_value
 				";
 
+			$sql       = $wpdb->prepare( $sql, array( Tribe__Events__Main::POSTTYPE ) );
 			$venue_ids = $wpdb->get_col( $sql );
 
-			$args['post__in'] = array_values( $venue_ids );
+			if ( ! empty( $venue_ids ) ) {
+				$args['post__in'] = array_values( $venue_ids );
 
-			// Ensure post__not_in isn't on the query, because when it is, post__in fails.
-			unset( $args['post__not_in'] );
+				// Ensure post__not_in isn't on the query, because when it is, post__in fails.
+				unset( $args['post__not_in'] );
+			}
 		}
 
 		$venues = get_posts( $args );

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -545,13 +545,43 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return array An array of venue post objects.
 	 */
 	function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $suppress_filters = true ) {
-		$venues = get_posts(
-			array(
-				'post_type'        => Tribe__Events__Main::VENUE_POST_TYPE,
-				'posts_per_page'   => $posts_per_page,
-				'suppress_filters' => $suppress_filters,
-			)
+		$venues    = array();
+		$venue_ids = array();
+
+		$args = array(
+			'post_type'        => Tribe__Events__Main::VENUE_POST_TYPE,
+			'posts_per_page'   => $posts_per_page,
+			'suppress_filters' => $suppress_filters,
 		);
+
+		if ( $only_with_upcoming ) {
+			global $wpdb;
+
+			$sql = "
+				SELECT DISTINCT pm.meta_value, 
+				    pm.meta_key,
+				    p.ID
+				FROM wp_postmeta pm 
+				    INNER JOIN wp_posts p 
+				        ON p.ID = pm.post_id
+				    LEFT JOIN wp_postmeta eventDate
+				        ON p.ID=eventDate.post_id AND eventDate.meta_key='_EventStartDate'
+				WHERE p.post_type = 'tribe_events'
+				    AND p.post_status = 'publish'
+				    AND pm.meta_key = '_EventVenueID'
+				    AND pm.meta_value > 0
+				    AND eventDate.meta_value > CURRENT_DATE()
+				GROUP BY pm.meta_value
+				";
+
+			$venue_ids = $wpdb->get_col( $sql );
+
+			$args['post__in'] = array_values( $venue_ids );
+
+			unset( $args['post__not_in'] );
+		}
+
+		$venues = get_posts( $args );
 
 		return $venues;
 	}

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -552,11 +552,13 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			'post_type'        => Tribe__Events__Main::VENUE_POST_TYPE,
 			'posts_per_page'   => $posts_per_page,
 			'suppress_filters' => $suppress_filters,
+			'post_status'      => 'publish'
 		);
 
-		if ( $only_with_upcoming ) {
+		if ( $only_with_upcoming ) {		
 			global $wpdb;
 
+			// Grabs all venue IDs that are associated with upcoming events.
 			$sql = "
 				SELECT DISTINCT pm.meta_value, 
 				    pm.meta_key,
@@ -578,6 +580,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 			$args['post__in'] = array_values( $venue_ids );
 
+			// Ensure post__not_in isn't on the query, because when it is, post__in fails.
 			unset( $args['post__not_in'] );
 		}
 


### PR DESCRIPTION
_Ref:_ [C#81921](http://central.tri.be/issues/81921)

### Code Review Note

After it was revealed that this is already fixed in the Full REST API bucket, we're *not* going to merge these changes. We're going to use Luca's fixes.

