### PR TITLE
Reschedule failed scheduled imports

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -10,3 +10,14 @@ settings:
     memory_limit: 1024M
 api:
     ea_license: YOUR_EA_LICENSE
+extensions:
+    commands:
+        - 'Codeception\Command\GenerateWPUnit'
+        - 'Codeception\Command\GenerateWPRestApi'
+        - 'Codeception\Command\GenerateWPRestController'
+        - 'Codeception\Command\GenerateWPRestPostTypeController'
+        - 'Codeception\Command\GenerateWPAjax'
+        - 'Codeception\Command\GenerateWPCanonical'
+        - 'Codeception\Command\GenerateWPXMLRPC'
+        - 'Codeception\Command\DbSnapshot'
+        - 'tad\Codeception\Command\SearchReplace'

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -683,6 +683,11 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		/** @var \Tribe__Events__Aggregator__API__Import $import_api */
 		$import_api  = $aggregator->api( 'import' );
+
+		if ( empty( $this->meta['import_id'] ) ) {
+			return tribe_error( 'core:aggregator:record-not-finalized' );
+		}
+
 		$import_data = $import_api->get( $this->meta['import_id'], $data );
 
 		$import_data = $this->maybe_cast_to_error( $import_data );

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1004,16 +1004,14 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		if ( empty( $status ) && $lookup_children ) {
 			$last_children_query = $this->query_child_records( array( 'posts_per_page' => 1, 'order' => 'DESC', 'order_by' => 'modified' ) );
 			if ( $last_children_query->have_posts() ) {
-				$last_children        = reset( $last_children_query->posts );
-				$last_children_status = str_replace( 'tribe-ea-', '', $last_children->post_status );
+				$last_children = reset( $last_children_query->posts );
 
-				$map                  = array(
-					'failed'  => 'error:import-failed',
-					'success' => 'success:queued',
-					'success' => 'success:queued',
+				$map = array(
+					'tribe-ea-failed'  => 'error:import-failed',
+					'tribe-ea-success' => 'success:queued',
 				);
 
-				$status = Tribe__Utils__Array::get( $map, $last_children_status, null );
+				$status = Tribe__Utils__Array::get( $map, $last_children->post_status, null );
 			}
 		}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1006,14 +1006,14 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			if ( $last_children_query->have_posts() ) {
 				$last_children        = reset( $last_children_query->posts );
 				$last_children_status = str_replace( 'tribe-ea-', '', $last_children->post_status );
+
 				$map                  = array(
 					'failed'  => 'error:import-failed',
 					'success' => 'success:queued',
 					'success' => 'success:queued',
 				);
-				if ( array_key_exists( $last_children_status, $map ) ) {
-					$status = $map[ $last_children_status ];
-				}
+
+				$status = Tribe__Utils__Array::get( $map, $last_children_status, null );
 			}
 		}
 

--- a/tests/_data/classes/Tribe__Events__Aggregator__Record__Scheduled_Test.php
+++ b/tests/_data/classes/Tribe__Events__Aggregator__Record__Scheduled_Test.php
@@ -1,0 +1,18 @@
+<?php
+
+class Tribe__Events__Aggregator__Record__Scheduled_Test extends Tribe__Events__Aggregator__Record__Abstract {
+
+	/**
+	 * @var bool
+	 */
+	public $is_schedule = true;
+
+	/**
+	 * Public facing Label for this Origin
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return 'test';
+	}
+}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tribe\Events\Aggregator\Record;
+
+include_once( codecept_data_dir( 'classes/Tribe__Events__Aggregator__Record__Scheduled_Test.php' ) );
+
+use Tribe__Events__Aggregator__Record__Abstract as Base;
+use Tribe__Events__Aggregator__Record__Scheduled_Test as Record;
+use Tribe__Events__Aggregator__Records as Records;
+
+class AbstractTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * Builds a simulation of a scheduled record.
+	 *
+	 * @param string $frequency_id  A supported scheduled frequency string among ("on_demand", "daily", "weekly", "monthly")
+	 * @param string $modified      A `strtotime` compatible string to indicate when the scheduled record was last modified
+	 * @param int    $schedule_day  The day of the week the import should happen at; defaults to 1 (Monday)
+	 * @param string $schedule_time The time of the day the import should happen at in 'H:i:s' format; defaults to 9am
+	 *
+	 * @return \Tribe__Events__Aggregator__Record__Scheduled_Test
+	 */
+	private function make_scheduled_record_instance( $frequency_id = 'weekly', $modified = 'now', $schedule_day = 1, $schedule_time = '09:00:00' ) {
+		$supported_frequencies = [
+			'on_demand' => 0,
+			'daily'     => 1 * DAY_IN_SECONDS,
+			'weekly'    => 7 * DAY_IN_SECONDS,
+			'monthly'   => 30 * DAY_IN_SECONDS,
+		];
+
+		if ( ! array_key_exists( $frequency_id, $supported_frequencies ) ) {
+			$frequencies = implode( ', ', $supported_frequencies );
+			throw new \InvalidArgumentException( "Frequency id should be one among [{$frequencies}]" );
+		}
+
+		$modified = strtotime( $modified );
+
+		if ( 0 >= $modified ) {
+			throw new \InvalidArgumentException( 'Modified should be a string parseable by the strtotime function' );
+		}
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_type'   => Records::$post_type,
+			'post_status' => Records::$status->schedule,
+			'post_date'   => date( 'Y-m-d H:i:s', $modified ),
+		] );
+
+		$record = new Record();
+		$record->set_post( $post );
+		$record->frequency             = (object) [
+			'id'       => $frequency_id,
+			'interval' => $supported_frequencies[ $frequency_id ],
+		];
+		$record->meta['schedule_day']  = $schedule_day;
+		$record->meta['schedule_time'] = $schedule_time;
+
+		return $record;
+	}
+
+	/**
+	 * It should mark a scheduled record that failed on last run as in schedule time
+	 *
+	 * @test
+	 */
+	public function should_mark_a_scheduled_record_that_failed_on_last_run_as_in_schedule_time() {
+		$scheduled_record                             = $this->make_scheduled_record_instance( 'weekly', '-1 hour' );
+		$scheduled_record->meta['last_import_status'] = 'success:hurray';
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+
+		$scheduled_record->meta['last_import_status'] = 'error:something-happened';
+
+		$this->assertTrue( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should not mark a failed record on demand as in schedule time
+	 *
+	 * @test
+	 */
+	public function should_not_mark_a_failed_record_on_demand_as_in_schedule_time() {
+		$scheduled_record                             = $this->make_scheduled_record_instance( 'on_demand', '-1 hour' );
+		$scheduled_record->meta['last_import_status'] = 'success:hurray';
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+
+		$scheduled_record->meta['last_import_status'] = 'error:something-happened';
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should look up children records if last_import_status meta is not set to find last imoprt status
+	 *
+	 * @test
+	 */
+	public function should_look_up_children_records_if_last_import_status_meta_is_not_set_to_find_last_imoprt_status() {
+		$scheduled_record = $this->make_scheduled_record_instance( 'weekly', '-1 hour' );
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+
+		$this->add_failed_children_to( $scheduled_record, '-1 hour' );
+
+		$this->assertTrue( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should not mark scheduled record with successful last children and no last_import_status as in schedule
+	 *
+	 * @test
+	 */
+	public function should_not_mark_scheduled_record_with_successful_last_children_and_no_last_import_status_as_in_schedule() {
+		$scheduled_record = $this->make_scheduled_record_instance( 'weekly', '-1 hour' );
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+
+		$this->add_successful_children_to( $scheduled_record, '-1 hour' );
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should mark a scheduled import that has no children and no last import status as in schedule if in schedule
+	 *
+	 * @test
+	 */
+	public function should_mark_a_scheduled_import_that_has_no_children_and_no_last_import_status_as_in_schedule_if_in_schedule() {
+		$scheduled_record = $this->make_scheduled_record_instance( 'daily', '-1 week' );
+
+		$this->assertTrue( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should use last_import_status over last children post status to determine status
+	 *
+	 * @test
+	 */
+	public function should_use_last_import_status_over_last_children_post_status_to_determine_status() {
+		$scheduled_record = $this->make_scheduled_record_instance( 'weekly', '-1 hour' );
+
+		$scheduled_record->meta['last_import_status'] = 'error::something-happened';
+
+		$this->add_successful_children_to( $scheduled_record );
+
+		$this->assertTrue( $scheduled_record->is_schedule_time() );
+
+		$scheduled_record->meta['last_import_status'] = 'success::hurray';
+
+		$this->add_failed_children_to( $scheduled_record );
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * It should use the most recent children import to determine the status if last_import_status is not set
+	 *
+	 * @test
+	 */
+	public function should_use_the_most_recent_children_import_to_determine_the_status_if_last_import_status_is_not_set() {
+		$scheduled_record = $this->make_scheduled_record_instance( 'weekly', '-1 hour' );
+
+		$this->add_successful_children_to( $scheduled_record );
+		$this->add_successful_children_to( $scheduled_record );
+		$last = $this->add_failed_children_to( $scheduled_record );
+
+		$this->assertTrue( $scheduled_record->is_schedule_time() );
+
+		wp_delete_post( $last, true );
+
+		$this->assertFalse( $scheduled_record->is_schedule_time() );
+	}
+
+	/**
+	 * Attaches a failed children import record to the specified scheduled record.
+	 *
+	 * @param Base   $scheduled_record
+	 * @param string $modified
+	 *
+	 * @return int The children record post ID.
+	 */
+	protected function add_failed_children_to( $scheduled_record, $modified = 'now' ) {
+		$modified = strtotime( $modified );
+
+		if ( 0 >= $modified ) {
+			throw new \InvalidArgumentException( 'Modified should be a string parseable by the strtotime function' );
+		}
+
+		return $this->factory()->post->create( [
+			'post_type'   => Records::$post_type,
+			'post_parent' => $scheduled_record->post->id,
+			'post_status' => Records::$status->failed,
+			'post_date'   => date( 'Y-m-d H:i:s', $modified ),
+		] );
+	}
+
+	/**
+	 * Attaches a successful children import record to the specified scheduled record.
+	 *
+	 * @param Base   $scheduled_record
+	 * @param string $modified
+	 *
+	 * @return int The children record post ID.
+	 */
+	protected function add_successful_children_to( Base $scheduled_record, $modified = 'now' ) {
+		$modified = strtotime( $modified );
+
+		if ( 0 >= $modified ) {
+			throw new \InvalidArgumentException( 'Modified should be a string parseable by the strtotime function' );
+		}
+
+		return $this->factory()->post->create( [
+			'post_type'   => Records::$post_type,
+			'post_parent' => $scheduled_record->post->id,
+			'post_status' => Records::$status->success,
+			'post_date'   => date( 'Y-m-d H:i:s', $modified ),
+		] );
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/81639

This PR modifies the way EA Client detects if a scheduled import is in schedule or not to allow failed, not on-demand, scheduled imports to be rescheduled before their frequency.
While testing the ticket in question with the database attached to the ticket I noticed that yes, we would now pick up correct imports but a weekly import that failed 4 days ago would be given another chance to run in 3 days (a week); this modifications tries to address this issue putting in code the following reasoning:

* do this once a week...
* ...but keep trying until if it fails, do not wait the next week

Furthermore the code tries some fallback strategies to handle some incoherent records found in the db:

* missing `last_import_status` meta
* incoherent children records

and the like.