### PR TITLE
Altered tribe_events_get_the_excerpt() to set the global $post prior …

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -331,6 +331,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 * Fix - Avoid Event Aggregator previews or scheduled imports being marked as failures [84259]
 * Fix - Fixed start and end date limit parsing for events archive in the REST API code [78375]
+* Fix - Fixed issue with `tribe_events_get_the_excerpt()` returning a read more link that sometimes pointed to the current page [70473]
 * Fix - Fixed Post ID not being sent to the_title filter for Organizers and Venues (props Anna L.) [85206]
 * Tweak - Modify certain event queries to widen the window of opportunity for query caching (props @garretjohnson) [84841]
 * Tweak - Improve Event Aggregator message regarding Facebook token expiration [70376]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1444,7 +1444,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( ! has_excerpt( $post->ID ) ) {
 			// Temporarily alter the global post in preparation for our filters.
-			$global_post = $GLOBALS['post'];
+			$global_post     = $GLOBALS['post'];
 			$GLOBALS['post'] = $post;
 
 			// We will only trim Excerpt if it comes from Post Content

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1443,6 +1443,10 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$excerpt = wp_kses( $excerpt, $allowed_html );
 
 		if ( ! has_excerpt( $post->ID ) ) {
+			// Temporarily alter the global post in preparation for our filters.
+			$global_post = $GLOBALS['post'];
+			$GLOBALS['post'] = $post;
+
 			// We will only trim Excerpt if it comes from Post Content
 
 			/**
@@ -1461,6 +1465,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 			// Now we actually trim it
 			$excerpt = wp_trim_words( $excerpt, $excerpt_length, $excerpt_more );
+
+			// Original post is back in action!
+			$GLOBALS['post'] = $global_post;
 		}
 
 		/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/70473

Fixed issue with `tribe_events_get_the_excerpt()` returning a read more link that pointed to the current page when used inside of the inline event shortcode.