### PR TITLE
If the source URL for a new import lacks a scheme, add one | #76466

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -340,6 +340,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Prevent stray commas from showing up for some event venues in the Day View [85429] 
 * Tweak - Modify certain event queries to widen the window of opportunity for query caching (props @garretjohnson) [84841]
 * Tweak - Improve Event Aggregator message regarding Facebook token expiration [70376]
+* Tweak - Support importing from URLs (Event Aggregator) where the protocol hasn't been specified by defaulting to HTTP [76466]
 * Language - Improvements to various strings to improve ease of translation (props to @ramiy)
 
 = [4.5.10.1] 2017-08-16 =

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -169,7 +169,31 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		// `source` will be empty when importing .ics files
+		$original_source = $this->meta['source'];
 		$this->meta['source'] = ! empty ( $this->meta['source'] ) ? $this->meta['source'] : '';
+
+		// Intelligently prepend "http://" if the protocol is missing from the source URL
+		if ( ! empty( $this->meta['source'] && false === strpos( $this->meta['source'], '://' ) ) ) {
+			$this->meta['source'] = 'http://' . $this->meta['source'];
+		}
+
+		/**
+		 * Provides an opportunity to set or modify the source URL for an import.
+		 *
+		 * @since TBD
+		 *
+		 * @param string  $source
+		 * @param string  $original_source
+		 * @param WP_Post $record
+		 * @param array   $meta
+		 */
+		$this->meta['source'] = apply_filters(
+			'tribe_aggregator_meta_source',
+			$this->meta['source'],
+			$original_source,
+			$this->post,
+			$this->meta
+		);
 
 		// This prevents lots of isset checks for no reason
 		if ( empty( $this->meta['activity'] ) ) {


### PR DESCRIPTION
Prepend `http://` to the source URL for new imports if the scheme/protocol is missing.

* Adds a filter to allow users to unwind this or otherwise make further adjustments
* I've preferred HTTP over HTTPS here from the POV that the former probably still has wider support (and most sites with HTTPS will automatically redirect HTTP requests anyway)

No community credit needed in the changelog entry.

:ticket: [#76466](https://central.tri.be/issues/76466)