### PR TITLE
Broken translation

### DIFF
--- a/src/functions/template-tags/loop.php
+++ b/src/functions/template-tags/loop.php
@@ -159,7 +159,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( tribe_is_month() ) {
 			$title = sprintf(
-				esc_html_x( '%1$s for %2$s', 'month view', 'the-events-calendar' ),
+				esc_html__( '%1$s for %2$s', 'the-events-calendar' ),
 				$events_label_plural,
 				date_i18n( tribe_get_date_option( 'monthAndYearFormat', 'F Y' ), strtotime( tribe_get_month_view_date() ) )
 			);
@@ -168,7 +168,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		// day view title
 		if ( tribe_is_day() ) {
 			$title = sprintf(
-				esc_html_x( '%1$s for %2$s', 'day_view', 'the-events-calendar' ),
+				esc_html__( '%1$s for %2$s', 'the-events-calendar' ),
 				$events_label_plural,
 				date_i18n( tribe_get_date_format( true ), strtotime( $wp_query->get( 'start_date' ) ) )
 			);


### PR DESCRIPTION
In the code the are mixedup functions that uses `__()` and `_x()` functions to translate, the second one don't get translated at all, replaced `esc_html_x()` with `esc_html__()` for the titles in the month and week view.
Feel free to ask for more details.