### PR TITLE
Prevent notice when organizer_ids is not an array

### DIFF
--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -237,7 +237,7 @@ class Tribe__Events__Organizer {
 	 * @return array
 	 */
 	public function filter_out_invalid_organizer_ids( $organizer_ids, $post_id ) {
-		return array_map( 'absint', $organizer_ids );
+		return array_map( 'absint', (array) $organizer_ids );
 	}
 
 	/**

--- a/src/views/day/single-event.php
+++ b/src/views/day/single-event.php
@@ -5,7 +5,7 @@
  *
  * Override this template in your own theme by creating a file at [your-theme]/tribe-events/day/single-event.php
  *
- * @version 4.5.6
+ * @version 4.5.11
  *
  */
 

--- a/src/views/list/single-event.php
+++ b/src/views/list/single-event.php
@@ -5,7 +5,7 @@
  *
  * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list/single-event.php
  *
- * @version 4.5.6
+ * @version 4.5.11
  *
  */
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Additionally fixing some view version numbers

See: https://central.tri.be/issues/71802