### PR TITLE
i18n: split translation strings

### DIFF
--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -45,8 +45,9 @@ $display_tab_fields = Tribe__Main::array_insert_before_key(
 		),
 		'info-box-description'               => array(
 			'type' => 'html',
-			'html' => '<p>' . sprintf(
-				__( 'The settings below control the display of your calendar. If things don\'t look right, try switching between the three style sheet options or pick a page template from your theme.</p><p>There are going to be situations where no out-of-the-box template is 100&#37; perfect. Check out our <a href="%s">our themer\'s guide</a> for instructions on custom modifications.', 'the-events-calendar' ),
+			'html' => '<p>' . __( 'The settings below control the display of your calendar. If things don\'t look right, try switching between the three style sheet options or pick a page template from your theme.', 'the-events-calendar' )  . '</p>' .
+			'<p>' . sprintf(
+				__( 'There are going to be situations where no out-of-the-box template is 100&#37; perfect. Check out our <a href="%s">our themer\'s guide</a> for instructions on custom modifications.', 'the-events-calendar' ),
 				Tribe__Main::$tec_url . 'knowledgebase/themers-guide/?utm_medium=plugin-tec&utm_source=generaltab&utm_campaign=in-app'
 			) . '</p>',
 		),


### PR DESCRIPTION
The following translation string:

`The settings below control the display of your calendar. If things don't look right, try switching between the three style sheet options or pick a page template from your theme.</p><p>There are going to be situations where no out-of-the-box template is 100&#37; perfect. Check out our <a href="%s">our themer's guide</a> for instructions on custom modifications.`

has `</p><p>` HTML tags is the string. It should be splited into two strings.