### PR TITLE
Put in place more checks to avoid concurrency issues

### DIFF
--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -130,13 +130,26 @@ class Tribe__Events__Aggregator__Record__Queue {
 		} else {
 			$this->items = $items;
 
-			// Count the Total of items now and stores as the total
+			//php Count the Total of items now and stores as the total
 			$this->total = count( $this->items );
 		}
 	}
 
 	public function load_queue() {
-		if ( empty( $this->record->meta[ self::$queue_key ] ) ) {
+		if ( ! isset( $this->record->meta[ self::$queue_key ] ) ) {
+			// try to fetch the queue meta from the db directly
+			$queue_key  = '_tribe_aggregator_' . self::$queue_key;
+			wp_cache_delete( $this->record->id, 'post_meta' );
+			$queue_meta = get_post_meta( $this->record->id, $queue_key, true );
+			if ( empty( $queue_meta ) ) {
+				// ok, really empty
+				$this->is_fetching = false;
+				$this->items       = array();
+			} else {
+				$this->items                            = $queue_meta;
+				$this->record->meta[ self::$queue_key ] = $queue_meta;
+			}
+		} elseif ( empty( $this->record->meta[ self::$queue_key ] ) ) {
 			$this->is_fetching = false;
 			$this->items       = array();
 		} else {

--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -201,7 +201,15 @@ class Tribe__Events__Aggregator__Record__Queue {
 	 *                 the count is 0, `false` otherwise.
 	 */
 	public function is_empty() {
-		return $this->has_lock && 0 === $this->count();
+		$count_matches = true;
+
+		if ( ! empty( $this->record->meta['ids_to_import'] ) && $this->items !== 'fetch' ) {
+			$to_import_count = count( $this->record->meta['ids_to_import'] );
+			$imported_so_far = $this->activity()->count( $this->get_queue_type() );
+			$count_matches   = $to_import_count === $imported_so_far;
+		}
+
+		return $this->has_lock && $count_matches && 0 === $this->count();
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -129,10 +129,7 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 
 		/** @var \Tribe__Events__Aggregator__Record__Queue $current_queue */
 		$current_queue   = $this->queue_processor->current_queue;
-		$to_import_count = count( $current_queue->record->meta['ids_to_import'] );
-		$imported_so_far = $current_queue->activity()->count( $current_queue->get_queue_type() );
-		$count_matches   = $to_import_count === $imported_so_far;
-		$done            = $current_queue->is_empty() && $count_matches;
+		$done            = $current_queue->is_empty();
 		$percentage      = $current_queue->progress_percentage();
 
 		$this->ajax_operations->exit_data( $this->get_progress_message_data( $current_queue, $percentage, $done ) );

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -128,9 +128,12 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		}
 
 		/** @var \Tribe__Events__Aggregator__Record__Queue $current_queue */
-		$current_queue = $this->queue_processor->current_queue;
-		$done          = $current_queue->is_empty();
-		$percentage    = $current_queue->progress_percentage();
+		$current_queue   = $this->queue_processor->current_queue;
+		$to_import_count = count( $current_queue->record->meta['ids_to_import'] );
+		$imported_so_far = $current_queue->activity()->count( $current_queue->get_queue_type() );
+		$count_matches   = $to_import_count === $imported_so_far;
+		$done            = $current_queue->is_empty() && $count_matches;
+		$percentage      = $current_queue->progress_percentage();
 
 		$this->ajax_operations->exit_data( $this->get_progress_message_data( $current_queue, $percentage, $done ) );
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/87803

This PR adds more check to make sure the realtime AJAX powered Queue will not deem the import done, thus stopping it, due to concurrency issues.
When handling huge feeds the DB is put under such a load that the db-based lock themselves cant be "locked" in time to apply to some AJAX requests and data is not written fast enough.
The changes are aimed at injecting some redundancy on those checks and data coherency to prevent those situations.

**Any suggestion is very much welcome**.