### PR TITLE
Avoid duplicating events upon import

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.12.1] TBD =
+
+* Fix - Fixed an issue where events imported via Event Aggregator from an iCal-like source would be duplicated in place of being updated [87654]
+
 = [4.5.12] 2017-09-06 =
 
 * Fix - Fixed an issue where, with certain date formats chosen in the Events display settings, the "Next Month" link navigation wasn't working (props to @tttammi and others for reporting this issue!) [86937]

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -189,7 +189,7 @@ class Tribe__Events__Aggregator__Event {
 
 		$key = "_{$fields[ $origin ]['target']}";
 		$post_type = Tribe__Events__Main::POSTTYPE;
-		$interval = "('" . implode( "','", array_map( 'absint', $values ) ) . "')";
+		$interval = "('" . implode( "','", $values ) . "')";
 
 		$sql = "
 			SELECT

--- a/src/Tribe/Aggregator/Event.php
+++ b/src/Tribe/Aggregator/Event.php
@@ -189,7 +189,7 @@ class Tribe__Events__Aggregator__Event {
 
 		$key = "_{$fields[ $origin ]['target']}";
 		$post_type = Tribe__Events__Main::POSTTYPE;
-		$interval = "('" . implode( "','", $values ) . "')";
+		$interval = "('" . implode( "','", array_map( 'esc_sql', $values ) ) . "')";
 
 		$sql = "
 			SELECT


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/87654

During the work done for ticket 79975 I put in place the `array_map` code that tries to convert alphanumeric strings (UIDs) to ints; the consequence is the array is filled with `0` and `1` and EA Client will never spot an existing ID thus duplicating the events.