### PR TITLE
Fix failing manual run of scheduled imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -330,6 +330,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 = [4.5.12.1] 2017-09-07 =
 
 * Fix - Fixed an issue where events imported via Event Aggregator from an iCal-like source would be duplicated in place of being updated [87654]
+* Fix - Fixed an issue where manually running Scheduled Imports would always result in a failed import [87321]
 
 = [4.5.12] 2017-09-06 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -327,10 +327,13 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.12.2] TBD =
+
+* Fix - Fixed an issue where manually running Scheduled Imports would always result in a failed import [87321]
+
 = [4.5.12.1] 2017-09-07 =
 
 * Fix - Fixed an issue where events imported via Event Aggregator from an iCal-like source would be duplicated in place of being updated [87654]
-* Fix - Fixed an issue where manually running Scheduled Imports would always result in a failed import [87321]
 
 = [4.5.12] 2017-09-06 =
 

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -329,6 +329,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			}
 
 			$record->update_meta( 'last_import_status', 'success:queued' );
+			$record->update_meta( 'import_id', $status->data->import_id );
 
 			$child->finalize();
 			$child->process_posts();

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -329,7 +329,6 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 			}
 
 			$record->update_meta( 'last_import_status', 'success:queued' );
-			$record->update_meta( 'import_id', $status->data->import_id );
 			$child->update_meta( 'import_id', $status->data->import_id );
 
 			$child->finalize();

--- a/src/Tribe/Aggregator/Tabs/Scheduled.php
+++ b/src/Tribe/Aggregator/Tabs/Scheduled.php
@@ -330,6 +330,7 @@ class Tribe__Events__Aggregator__Tabs__Scheduled extends Tribe__Events__Aggregat
 
 			$record->update_meta( 'last_import_status', 'success:queued' );
 			$record->update_meta( 'import_id', $status->data->import_id );
+			$child->update_meta( 'import_id', $status->data->import_id );
 
 			$child->finalize();
 			$child->process_posts();


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/87321

This PR makes sure the import ID assigned to requests generated when manually running a scheduled import is assigned to the child records to prevent failures.