### PR TITLE
Add in randomization when scheduling and initiating scheduled imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.5.13] TBD =
+
+* Tweak - Aggregator will now allow for some minor shifts in schedule execution time to help distribute requests to EA Service [86628]
+
 = [4.5.12.1] 2017-09-07 =
 
 * Fix - Fixed an issue where events imported via Event Aggregator from an iCal-like source would be duplicated in place of being updated [87654]

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -172,6 +172,14 @@ class Tribe__Events__Aggregator__Cron {
 		// Fetch the last half hour as a timestamp
 		$start_timestamp = strtotime( $date );
 
+		// randomize the time by plus/minus 0-5 minutes
+		$start_timestamp += ( mt_rand( -5, 5 ) * 60 );
+
+		// if the start timestamp is older than RIGHT NOW, set it for 5 minutes from now
+		if ( time() > $start_timestamp ) {
+			$start_timestamp += 300;
+		}
+
 		// Now add an action twice hourly
 		wp_schedule_event( $start_timestamp, 'tribe-every15mins', self::$action );
 	}

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -932,6 +932,9 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$last    = strtotime( $this->post->post_modified_gmt );
 		$next    = $last + $this->frequency->interval;
 
+		// let's add some randomization of -5 to 0 minutes (this makes sure we don't push a schedule beyond when it should fire off)
+		$next += ( mt_rand( -5, 0 ) * 60 );
+
 		// Only do anything if we have one of these metas
 		if ( ! empty( $this->meta['schedule_day'] ) || ! empty( $this->meta['schedule_time'] ) ) {
 			// Setup to avoid notices


### PR DESCRIPTION
* When scheduling the next cron event, allow for +/- 5 minute adjustments
* When checking if a scheduled import is ready to run, allow for -5 to 0 minutes from the expected scheduled time

See: https://central.tri.be/issues/86628