### PR TITLE
Add pre and after actions in EA post insertion

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -332,7 +332,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed a typo in the Event List widget options [71081]
 * Tweak - Aggregator will now allow for some minor shifts in schedule execution time to help distribute requests to EA Service [86628]
 * Tweak - Improve Event Aggregator settings texts [77452]
-* Tweak - Add actions before and after posts are inserted or updated by Event Aggregator to allow custom functions to kick in [87530]
+* Tweak - Add actions before and after posts are inserted or updated by Event Aggregator to allow custom functions to kick in: `tribe_aggregator_before_insert_posts` and `tribe_aggregator_after_insert_posts`, respectively. [87530]
 
 = [4.5.12.1] 2017-09-07 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -332,6 +332,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed a typo in the Event List widget options [71081]
 * Tweak - Aggregator will now allow for some minor shifts in schedule execution time to help distribute requests to EA Service [86628]
 * Tweak - Improve Event Aggregator settings texts [77452]
+* Tweak - Add actions before and after posts are inserted or updated by Event Aggregator to allow custom functions to kick in [87530]
 
 = [4.5.12.1] 2017-09-07 =
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1204,7 +1204,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		 * @param array $items An array of items to insert.
 		 * @param array $meta  The record meta information.
 		 */
-		do_action( 'tribe_aggregator_pre_insert_posts', $items, $this->meta );
+		do_action( 'tribe_aggregator_before_insert_posts', $items, $this->meta );
 
 		// sets the default user ID to that of the first user that can edit events
 		$default_user_id = $this->get_default_user_id();

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1196,6 +1196,16 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	public function insert_posts( $items = array() ) {
 		add_filter( 'tribe-post-origin', array( Tribe__Events__Aggregator__Records::instance(), 'filter_post_origin' ), 10 );
 
+		/**
+		 * Fires before events and linked posts are inserted in the database.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $items An array of items to insert.
+		 * @param array $meta  The record meta information.
+		 */
+		do_action( 'tribe_aggregator_pre_insert_posts', $items, $this->meta );
+
 		// sets the default user ID to that of the first user that can edit events
 		$default_user_id = $this->get_default_user_id();
 
@@ -1786,6 +1796,17 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		}
 
 		remove_filter( 'tribe-post-origin', array( Tribe__Events__Aggregator__Records::instance(), 'filter_post_origin' ), 10 );
+
+		/**
+		 * Fires after events and linked posts have been inserted in the database.
+		 *
+		 * @since TBD
+		 *
+		 * @param array                                       $items    An array of items to insert.
+		 * @param array                                       $meta     The record meta information.
+		 * @param Tribe__Events__Aggregator__Record__Activity $activity The record insertion activity report.
+		 */
+		do_action( 'tribe_aggregator_after_insert_posts', $items, $this->meta, $activity );
 
 		return $activity;
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/87530

This PR adds two simple actions before and after EA post insertion to allow plugins or devs that need to know when that happens (e.g. multilingual ones) to act accordingly.