### PR TITLE
Call `Tribe__Tickets__Tickets::modules()` directly instead of using `…

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -733,7 +733,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return bool
 	 */
 	function tribe_events_admin_show_cost_field() {
-		$modules      = apply_filters( 'tribe_events_tickets_modules', null );
+		$modules      = Tribe__Tickets__Tickets::modules();
 		$event_origin = get_post_meta( get_the_ID(), '_EventOrigin', true );
 		$show_cost    = empty( $modules ) ||
 						class_exists( 'Tribe__Events__Tickets__Eventbrite__Main' ) ||

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -733,7 +733,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return bool
 	 */
 	function tribe_events_admin_show_cost_field() {
-		$modules      = Tribe__Tickets__Tickets::modules();
+		$modules = null;
+
+		if ( class_exists( 'Tribe__Tickets__Tickets' ) ) {
+			$modules = Tribe__Tickets__Tickets::modules();
+		}
+
 		$event_origin = get_post_meta( get_the_ID(), '_EventOrigin', true );
 		$show_cost    = empty( $modules ) ||
 						class_exists( 'Tribe__Events__Tickets__Eventbrite__Main' ) ||


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/66421

I did not feel like this merited a changelog entry, it's basically a spotfix and is highly backwards compatible. I did put a changelog entry in the [related ET PR.](https://github.com/moderntribe/event-tickets/pull/476)