### PR TITLE
Fix bug composing parameters for rest url

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -298,7 +298,11 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 		$keys    = array_intersect_key( $flipped, $values );
 
 		if ( ! empty( $keys ) ) {
-			$url = add_query_arg( array_combine( array_values( $keys ), array_values( $values ) ), $url );
+			$param = array_fill_keys( array_values( $keys ), '');
+			foreach ($keys as $key => $value) {
+				$param[$value] = $args[$key];
+			}
+			$url = add_query_arg( $param , $url );
 		}
 
 		return $url;

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -298,11 +298,11 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 		$keys    = array_intersect_key( $flipped, $values );
 
 		if ( ! empty( $keys ) ) {
-			$param = array_fill_keys( array_values( $keys ), '');
-			foreach ($keys as $key => $value) {
-				$param[$value] = $args[$key];
+			$param = array_fill_keys( array_values( $keys ), '' );
+			foreach ( $keys as $key => $value ) {
+				$param[ $value ] = $args[ $key ];
 			}
-			$url = add_query_arg( $param , $url );
+			$url = add_query_arg( $param, $url );
 		}
 
 		return $url;

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -298,11 +298,11 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 		$keys    = array_intersect_key( $flipped, $values );
 
 		if ( ! empty( $keys ) ) {
-			$param = array_fill_keys( array_values( $keys ), '' );
+			$parameters = array_fill_keys( array_values( $keys ), '' );
 			foreach ( $keys as $key => $value ) {
-				$param[ $value ] = $args[ $key ];
+				$parameters[ $value ] = $args[ $key ];
 			}
-			$url = add_query_arg( $param, $url );
+			$url = add_query_arg( $parameters, $url );
 		}
 
 		return $url;


### PR DESCRIPTION
The current code is assuming that both arrays are on the same order, resulting in a pagination bug when the parameter array is composed.