### PR TITLE
Adding data filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -351,7 +351,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Added all the Aggregator Origins to the Admin Bar [68693]
 * Tweak - Added filters: `tribe_get_state_options`
 * Tweak - Added template tags: `maybe_format_from_datepicker()`
-* Tweak - Added the `tribe_rest_single_event_data` filter to the single event endpoint to allow filtering the returned data (thanks @mwender) [88748]
+* Tweak - Added the `tribe_rest_single_event_data` filter to the single event REST API endpoint to allow filtering the returned data (thanks @mwender) [88748]
 * Language - 2 new strings added, 90 updated, 0 fuzzied, and 1 obsoleted
 
 = [4.5.11] 2017-08-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -351,6 +351,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Added all the Aggregator Origins to the Admin Bar [68693]
 * Tweak - Added filters: `tribe_get_state_options`
 * Tweak - Added template tags: `maybe_format_from_datepicker()`
+* Tweak - Added the `tribe_rest_single_event_data` filter to the single event endpoint to allow filtering the returned data (thanks @mwender) [88748]
 * Language - 2 new strings added, 90 updated, 0 fuzzied, and 1 obsoleted
 
 = [4.5.11] 2017-08-24 =

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -73,7 +73,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		 * @param array           $data    The retrieved data.
 		 * @param WP_REST_Request $request The original request.
 		 */
-		$data = apply_filters( 'tribe_rest_single_event_data', $data, $request );		
+		$data = apply_filters( 'tribe_rest_single_event_data', $data, $request );
 
 		return is_wp_error( $data ) ? $data : new WP_REST_Response( $data );
 	}

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -64,6 +64,14 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		}
 
 		$data = $this->post_repository->get_event_data( $id );
+		
+		/**
+		 * Filters the data that will be returned for a single event request.
+		 *
+		 * @param array           $data    The retrieved data.
+		 * @param WP_REST_Request $request The original request.
+		 */
+		$data = apply_filters( 'tribe_rest_single_event_data', $data, $request );		
 
 		return is_wp_error( $data ) ? $data : new WP_REST_Response( $data );
 	}

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -64,9 +64,11 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		}
 
 		$data = $this->post_repository->get_event_data( $id );
-		
+
 		/**
 		 * Filters the data that will be returned for a single event request.
+		 *
+		 * @since TBD
 		 *
 		 * @param array           $data    The retrieved data.
 		 * @param WP_REST_Request $request The original request.


### PR DESCRIPTION
Adds a filter for modifying the data returned by a REST API call for a single event (e.g. `wp-json/tribe/events/v1/events/[eventId]`).