### PR TITLE
Feature/70570 csv param filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -331,6 +331,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 * Tweak - Remove unnecessary paramters from some remove_action calls in the plugin (thanks to @JPry on GitHub for submitting this fix!) [88867]
 * Tweak - Adjusted the EA cron start time so that it never gets created in the past [88965]
+* Tweak - Added a filter to CSV importer for altering the delimter, escaping, and enclosing characters [70570]
 * Tweak - Adjusted the `tribe_update_venue()` template tag so it no longer creates some unncessary meta fields involving post_title, post_content, etc. (thanks @oheinrich for bringing this to our attention) [66968]
 * Language - Improvements to aid translatability of text throughout plugin (props: @ramiy) [88982]
 * Deprecated - Deprecated the `tribe-events-bar-date-search-default-value` filter; use `tribe_events_bar_date_search_default_value` instead [67482]

--- a/src/Tribe/Importer/File_Reader.php
+++ b/src/Tribe/Importer/File_Reader.php
@@ -14,6 +14,7 @@ class Tribe__Events__Importer__File_Reader {
 		$this->path = $file_path;
 		$this->file = new SplFileObject( $this->path );
 		$this->file->setFlags( SplFileObject::SKIP_EMPTY | SplFileObject::READ_CSV | SplFileObject::READ_AHEAD | SplFileObject::DROP_NEW_LINE );
+		$this->set_csv_params( $this->get_csv_params() );
 		$this->file->seek( $this->file->getSize() );
 		$this->lines = $this->file->key();
 		$this->file->rewind();
@@ -80,5 +81,67 @@ class Tribe__Events__Importer__File_Reader {
 	 */
 	public function sanitize_row( $row ) {
 		return array_map( 'wp_kses_post', $row );
+	}
+
+	/**
+	 * Get the field parameters used for reading CSV files.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The CSV field parameters.
+	 */
+	public function get_csv_params() {
+		$csv_params = array(
+			'delimter'  => ',',
+			'enclosure' => '"',
+			'escape'    => '\\',
+		);
+
+		/**
+		 * Set the parameters used for reading and importing CSV files.
+		 *
+		 * @see `SplFileObject::setCsvControl()`
+		 *
+		 * @since TBD
+		 *
+		 * @param array $csv_params (
+		 *      The parameters
+		 *
+		 *      @param string $delimter  The field delimiter (one character only).
+		 *      @param string $enclosure The field enclosure character (one character only).
+		 *      @param string $escape    The field escape character (one character only).
+		 * }
+		 * @param string $file_path The path to the CSV file
+		 */
+		return apply_filters( 'tribe_events_csv_import_file_parameters', $csv_params, $this->path );
+	}
+
+	/**
+	 * Set the import params for CSV fields
+	 *
+	 * @since TBD
+	 *
+	 * @param array $params (
+	 *      The parameters
+	 *
+	 *      @param string $delimter  The field delimiter (one character only).
+	 *      @param string $enclosure The field enclosure character (one character only).
+	 *      @param string $escape    The field escape character (one character only).
+	 * }
+	 */
+	private function set_csv_params( $params ) {
+		// The escape parameter was added in PHP v5.3.
+		if ( version_compare( phpversion(), '5.3', '>' ) ) {
+			$this->file->setCsvControl(
+				$params['delimter'],
+				$params['enclosure'],
+				$params['escape']
+			);
+		} else {
+			$this->file->setCsvControl(
+				$params['delimter'],
+				$params['enclosure']
+			);
+		}
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/70570

Now we can import from Google Spreadsheets again.

```
add_filter( 'tribe_events_csv_import_file_parameters', function( $csv_params ) {
	$csv_params['escape'] = '"';
	return $csv_params;
});
```