### PR TITLE
Fix for allday multiday events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -332,6 +332,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed "Next Events" and "Previous Events" navigation links in list views, which would sometimes make a category-filtered list view lose its category filter as a user navigated through pages of future or past events (props @forumhelpdesk and @atomicdust for reporting this!) [72013]
 * Fix - Fixed some layout issues with the Tribe Bar datepicker that would arise when using a Twentysixteen or Twentyfifteen child them (thanks to @stefanrueegger for reporting this) [46471]
 * Fix - Prevented modification of event titles within the loop when using TRIBE_MODIFY_GLOBAL_TITLE [89273]
+* Fix - Fixed issue when exporting all-day multi-day events via iCal where the end date was one day early (Thank you @fairmont for reporting this!) [87775]
 * Fix - Fixed issues with the jQuery Timepicker vendor script conflicting with other plugins' similar scripts (props: @hcny et al.) [74644]
 * Fix - Fixed an issue that would prevent Event Aggregator scheduled imports from running [88395]
 * Tweak - Remove unnecessary paramters from some remove_action calls in the plugin (thanks to @JPry on GitHub for submitting this fix!) [88867]

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -236,6 +236,7 @@ class Tribe__Events__iCal {
 
 			$full_format = 'Ymd\THis';
 			$utc_format = 'Ymd\THis\Z';
+			$all_day = ( 'yes' === get_post_meta( $event_post->ID, '_EventAllDay', true ) );
 			$time = (object) array(
 				'start' => tribe_get_start_date( $event_post->ID, false, 'U' ),
 				'end' => tribe_get_end_date( $event_post->ID, false, 'U' ),
@@ -243,7 +244,7 @@ class Tribe__Events__iCal {
 				'created' => Tribe__Date_Utils::wp_strtotime( $event_post->post_date ),
 			);
 
-			if ( 'yes' == get_post_meta( $event_post->ID, '_EventAllDay', true ) ) {
+			if ( $all_day ) {
 				$type = 'DATE';
 				$format = 'Ymd';
 			} else {
@@ -258,17 +259,25 @@ class Tribe__Events__iCal {
 				'created'  => date( $utc_format, $time->created ),
 			);
 
-			if ( 'DATE' === $type ){
-				$item[] = "DTSTART;VALUE=$type:" . $tzoned->start;
-				$item[] = "DTEND;VALUE=$type:" . $tzoned->end;
+			$dtstart = $tzoned->start;
+			$dtend   = $tzoned->end;
+
+			if ( 'DATE' === $type ) {
+				// For all day events dtend should always be +1 day.
+				if ( $all_day ) {
+					$dtend = date( $format, strtotime( '+1 day', strtotime( $dtend ) ) );
+				}
+
+				$item[] = 'DTSTART;VALUE=' . $type . ':' . $dtstart;
+				$item[] = 'DTEND;VALUE=' . $type . ':' . $dtend;
 			} else {
 				// Are we using the sitewide timezone or the local event timezone?
 				$tz = Tribe__Events__Timezones::EVENT_TIMEZONE === Tribe__Events__Timezones::mode()
 					? Tribe__Events__Timezones::get_event_timezone_string( $event_post->ID )
 					: Tribe__Events__Timezones::wp_timezone_string();
 
-				$item[] = 'DTSTART;TZID=' . $tz . ':' . $tzoned->start;
-				$item[] = 'DTEND;TZID=' . $tz . ':' . $tzoned->end;
+				$item[] = 'DTSTART;TZID=' . $tz . ':' . $dtstart;
+				$item[] = 'DTEND;TZID=' . $tz . ':' . $dtend;
 			}
 
 			$item[] = 'DTSTAMP:' . date( $full_format, time() );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/87775

I was not able to find anywhere in the spec where it stated that a multiday allday event should have DTEND set to the day after it ends. However, for single-day all day events it does specify this (although for those the DTEND field is also optional). Given that the spec it specifies this for single-day events it follows that you would need to do this for multiday ones as well. Furthermore, every calendar export I tested with, like Google Calendar, indeed adds a day to the DTEND of their all day multiday exports. They also properly import when we do this with our exports. 