### PR TITLE
Remove duplicate filter | M17.19 | Spotfix

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -83,16 +83,6 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		/**
 		 * Filters the data that will be returned for a single event request.
 		 *
-		 * @since 4.6
-		 *
-		 * @param array           $data    The retrieved data.
-		 * @param WP_REST_Request $request The original request.
-		 */
-		$data = apply_filters( 'tribe_rest_single_event_data', $data, $request );
-
-		/**
-		 * Filters the data that will be returned for a single event request.
-		 *
 		 * @since 4.5.13
 		 *
 		 * @param array           $data    The retrieved data.


### PR DESCRIPTION
Two different but identical `tribe_rest_single_event_data` hooks somehow co-evolved independently of one another. This spotfix removes the later one.