### PR TITLE
Add `found_posts` argument support in `tribe_get_` functions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -341,6 +341,8 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Improved options format in the Event Aggregator settings [88970]
 * Tweak - Added a filter to CSV importer for altering the delimter, escaping, and enclosing characters [70570]
 * Tweak - Adjusted the `tribe_update_venue()` template tag so it no longer creates some unncessary meta fields involving post_title, post_content, etc. (thanks @oheinrich for bringing this to our attention) [66968]
+* Tweak - Improved the performance of The Events Calendar REST API tweaking some queries [89743]
+* Tweak - Add support for a `found_posts` argument in `tribe_get_events`, `tribe_get_venues` and `tribe_get_organizers` functions to return the number of posts found matching the current query arguments [89743]
 * Language - Improvements to aid translatability of text throughout plugin (props: @ramiy) [88982]
 * Deprecated - Deprecated the `tribe-events-bar-date-search-default-value` filter; use `tribe_events_bar_date_search_default_value` instead [67482]
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1009,12 +1009,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		/**
 		 * Customized WP_Query wrapper to setup event queries with default arguments.
 		 *
-		 * @param array $args An array of arguments supported by the `WP_Query` class
-		 *        {
-		 *              @param bool $found_posts If set to a truthy value the returned result will be an integer
-		 *                                       detailiing the number of total found posts for the provided
-		 *                                       query arguments.
-		 *        }
+		 * @param array $args {
+		 *		Optional. Array of Query parameters.
+		 *
+		 *      @type bool $found_posts Return the number of found events.
+		 * }
 		 * @param bool  $full Whether the full WP_Query object should returned (`true`) or just the
 		 *                    found posts (`false`)
 		 *

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1009,8 +1009,14 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		/**
 		 * Customized WP_Query wrapper to setup event queries with default arguments.
 		 *
-		 * @param array $args
-		 * @param bool  $full
+		 * @param array $args An array of arguments supported by the `WP_Query` class
+		 *        {
+		 *              @param bool $found_posts If set to a truthy value the returned result will be an integer
+		 *                                       detailiing the number of total found posts for the provided
+		 *                                       query arguments.
+		 *        }
+		 * @param bool  $full Whether the full WP_Query object should returned (`true`) or just the
+		 *                    found posts (`false`)
 		 *
 		 * @return array|WP_Query
 		 */
@@ -1022,7 +1028,15 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				'posts_per_page'       => tribe_get_option( 'postsPerPage', 10 ),
 				'tribe_render_context' => 'default',
 			);
+
 			$args     = wp_parse_args( $args, $defaults );
+
+			$return_found_posts = ! empty( $args['found_posts'] );
+
+			if ( $return_found_posts ) {
+				$args['posts_per_page'] = 1;
+				$args['paged']          = 1;
+			}
 
 			// remove empty args and sort by key, this increases chance of a cache hit
 			$args = array_filter( $args, array( __CLASS__, 'filter_args' ) );
@@ -1037,7 +1051,16 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			} else {
 				do_action( 'log', 'no cache hit', 'tribe-events-cache', $args );
 				$result = new WP_Query( $args );
+
+				if ( $return_found_posts ) {
+					$result = $result->found_posts;
+				}
+
 				$cache->set( $cache_key, $result, Tribe__Cache::NON_PERSISTENT, 'save_post' );
+			}
+
+			if ( $return_found_posts ) {
+				return $result;
 			}
 
 			if ( ! empty( $result->posts ) ) {

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -452,23 +452,28 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 	}
 
 	/**
+	 * Returns the total number of posts matching the request.
+	 *
+	 * @since 4.6
+	 *
 	 * @param array $args
 	 *
 	 * @return int
 	 */
 	protected function get_total( $args ) {
-		$this->total = count( tribe_get_events( array_merge( $args, array(
-			'posts_per_page'         => - 1,
-			'fields'                 => 'ids',
+		$this->total = tribe_get_events( array_merge( $args, array(
+			'found_posts'            => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
-		) ) ) );
+		) ) );
 
 		return $this->total;
 	}
 
 	/**
 	 * Returns the archive base REST URL
+	 *
+	 * @since 4.6
 	 *
 	 * @return string
 	 */

--- a/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
@@ -250,12 +250,14 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	}
 
 	/**
+	 * Returns the total number of posts matching the request.
+	 *
+	 * @since 4.6
+	 *
 	 * @param array $args
 	 * @param bool  $only_with_upcoming
 	 *
 	 * @return int
-	 *
-	 * @since 4.6
 	 */
 	protected function get_total( $args, $only_with_upcoming = false ) {
 		unset( $args['posts_per_page'] );
@@ -273,9 +275,9 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	/**
 	 * Returns the archive base REST URL
 	 *
-	 * @return string
-	 *
 	 * @since 4.6
+	 *
+	 * @return string
 	 */
 	protected function get_base_rest_url() {
 		$url = tribe_events_rest_url( 'organizers/' );

--- a/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
@@ -260,12 +260,12 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	protected function get_total( $args, $only_with_upcoming = false ) {
 		unset( $args['posts_per_page'] );
 
-		$this->total = count( tribe_get_organizers( $only_with_upcoming, - 1, true,
+		$this->total = tribe_get_organizers( $only_with_upcoming, - 1, true,
 			array_merge( $args, array(
-				'fields'                 => 'ids',
+				'found_posts'            => true,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			) ) ) );
+			) ) );
 
 		return $this->total;
 	}

--- a/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
@@ -249,22 +249,24 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Venue
 	}
 
 	/**
+	 * Returns the total number of posts matching the request.
+	 *
+	 * @since 4.6
+	 *
 	 * @param array $args
 	 * @param bool  $only_with_upcoming
 	 *
 	 * @return int
-	 *
-	 * @since 4.6
 	 */
 	protected function get_total( $args, $only_with_upcoming = false ) {
 		unset( $args['posts_per_page'] );
 
-		$this->total = count( tribe_get_venues( $only_with_upcoming, - 1, true,
+		$this->total = tribe_get_venues( $only_with_upcoming, - 1, true,
 			array_merge( $args, array(
-				'fields'                 => 'ids',
+				'found_posts'            => true,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			) ) ) );
+			) ) );
 
 		return $this->total;
 	}
@@ -272,9 +274,9 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Venue
 	/**
 	 * Returns the archive base REST URL
 	 *
-	 * @return string
-	 *
 	 * @since 4.6
+	 *
+	 * @return string
 	 */
 	protected function get_base_rest_url() {
 		$url = tribe_events_rest_url( 'venues/' );

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -333,7 +333,7 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 
 		foreach ( $data as $key => $var ) {
 			// Prevent these WP_Post object fields from ending up in the meta.
-			if ( in_array( $key, array( 'post_title', 'post_excerpt', 'post_content' ) ) ) {
+			if ( in_array( $key, array( 'post_title', 'post_excerpt', 'post_content', 'post_status' ) ) ) {
 				continue;
 			}
 
@@ -525,16 +525,6 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 		} else {
 			$data['ShowMapLink'] = true;
 		}
-
-		$this->save_meta( $venue_id, $data );
-
-		/**
-		 * Runs right after a successful update of a venue (including its meta being saved).
-		 *
-		 * @param int $venue_id The ID of the venue being updated.
-		 * @param array $data The full array of data that was used to modify the venue.
-		 */
-		do_action( 'tribe_events_venue_updated', $venue_id, $data );
 
 		$post_fields = array_merge( Tribe__Duplicate__Post::$post_table_columns, array(
 			'Venue',

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -324,16 +324,14 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @param array $args {
 	 *		Optional. Array of Query parameters.
 	 *
-	 *		@type int  $event      Only organizers linked to this event post ID.
-	 *		@type bool $has_events Only organizers that have events.
+	 *		@type int  $event       Only organizers linked to this event post ID.
+	 *		@type bool $has_events  Only organizers that have events.
+	 *		@type bool $found_posts Return the number of found organizers.
 	 * }
 	 *
-	 * @return array An array of organizer post objects.
+	 * @return array|int An array of organizer post objects or an integer value if `found_posts` is set to a truthy value.
 	 */
 	function tribe_get_organizers( $only_with_upcoming = false, $posts_per_page = - 1, $suppress_filters = true, array $args = array() ) {
-		/** @var wpdb $wpdb */
-		global $wpdb;
-
 		// filter out the `null` values
 		$args = array_diff_key( $args, array_filter( $args, 'is_null' ) );
 
@@ -377,9 +375,25 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			)
 		);
 
-		$organizers = get_posts( $parsed_args );
+		$return_found_posts = ! empty( $args['found_posts'] );
 
-		return $organizers;
+		if ( $return_found_posts ) {
+			$parsed_args['posts_per_page'] = 1;
+			$parsed_args['paged']          = 1;
+		}
+
+		$query = new WP_Query( $parsed_args );
+
+		if ( $return_found_posts ) {
+			if ( $query->have_posts() ) {
+
+				return $query->found_posts;
+			}
+
+			return 0;
+		}
+
+		return $query->have_posts() ? $query->posts : array();
 	}
 
 }

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -543,16 +543,14 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @param array $args {
 	 *		Optional. Array of Query parameters.
 	 *
-	 *		@type int  $event      Only venues linked to this event post ID.
-	 *		@type bool $has_events Only venues that have events.
+	 *		@type int  $event       Only venues linked to this event post ID.
+	 *		@type bool $has_events  Only venues that have events.
+	 *		@type bool $found_posts Return the number of found venues.
 	 * }
 	 *
 	 * @return array An array of venue post objects.
 	 */
 	function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $suppress_filters = true, array $args = array() ) {
-		/** @var wpdb $wpdb */
-		global $wpdb;
-
 		// filter out the `null` values
 		$args = array_diff_key( $args, array_filter( $args, 'is_null' ) );
 
@@ -596,9 +594,25 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			)
 		);
 
-		$venues = get_posts( $parsed_args );
+		$return_found_posts = ! empty( $args['found_posts'] );
 
-		return $venues;
+		if ( $return_found_posts ) {
+			$parsed_args['posts_per_page'] = 1;
+			$parsed_args['paged']          = 1;
+		}
+
+		$query = new WP_Query( $parsed_args );
+
+		if ( $return_found_posts ) {
+			if ( $query->have_posts() ) {
+
+				return $query->found_posts;
+			}
+
+			return 0;
+		}
+
+		return $query->have_posts() ? $query->posts : array();
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -128,8 +128,9 @@ class AbstractTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_mark_a_scheduled_import_that_has_no_children_and_no_last_import_status_as_in_schedule_if_in_schedule() {
-		$schedule_day     = date( 'N', strtotime( 'yesterday' ) );
-		$scheduled_record = $this->make_scheduled_record_instance( 'daily', '-1 week', $schedule_day );
+		$schedule_day     = date( 'N', strtotime( 'today' ) );
+		$schedule_time    = date( 'H:i:s', time() - 10 );
+		$scheduled_record = $this->make_scheduled_record_instance( 'daily', '-1 week', $schedule_day, $schedule_time );
 
 		$this->assertTrue( $scheduled_record->is_schedule_time() );
 	}

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -172,4 +172,16 @@ class QueryTest extends Events_TestCase {
 
 		$this->assertEquals( 5, $found_posts );
 	}
+
+	/**
+	 * It should return 0 when no posts are found and found_posts is set
+	 *
+	 * @test
+	 */
+	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set() {
+		$args        = [ 'found_posts' => true ];
+		$found_posts = Query::getEvents( $args );
+
+		$this->assertEquals( 0, $found_posts );
+	}
 }

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Tribe\Events;
 
-use WP_Query;
-use Tribe__Events__Main;
-use Tribe__Events__Query;
+use Tribe\Events\Tests\Testcases\Events_TestCase;
+use Tribe__Events__Main as Main;
+use Tribe__Events__Query as Query;
 use Tribe__Main;
+use WP_Query;
+
 /**
  * Test that the Event Queries behave as expected
  *
@@ -12,7 +14,7 @@ use Tribe__Main;
  *
  * @package Tribe__Events__Main
  */
-class QueryTest extends \Codeception\TestCase\WPTestCase {
+class QueryTest extends Events_TestCase {
 	/**
 	 * Event date & upcoming filters should not be removed from non-admin pages
 	 *
@@ -21,10 +23,10 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 	public function it_should_not_remove_date_filters_on_front_end() {
 		$query = new WP_Query;
 		$query->parse_query( [
-			'post_type' => Tribe__Events__Main::POSTTYPE,
+			'post_type' => Main::POSTTYPE,
 		] );
 
-		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on the front end' );
+		$this->assertFalse( Query::should_remove_date_filters( $query ), 'Date filters should not be removed on the front end' );
 	}
 
 	/**
@@ -38,7 +40,7 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 			'post_type' => 'post',
 		] );
 
-		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event queries' );
+		$this->assertFalse( Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event queries' );
 	}
 
 	/**
@@ -51,10 +53,10 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 
 		$query = new WP_Query;
 		$query->parse_query( [
-			'post_type' => Tribe__Events__Main::POSTTYPE,
+			'post_type' => Main::POSTTYPE,
 		] );
 
-		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event edit pages' );
+		$this->assertFalse( Query::should_remove_date_filters( $query ), 'Date filters should not be removed on non-event edit pages' );
 	}
 
 	/**
@@ -63,17 +65,17 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function it_should_remove_date_filters_on_event_import_page() {
-		set_current_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
+		set_current_screen( 'edit-' . Main::POSTTYPE );
 
 		$_GET['page'] = 'events-importer';
 		$_GET['tab'] = 'general';
 
 		$query = new WP_Query;
 		$query->parse_query( [
-			'post_type' => Tribe__Events__Main::POSTTYPE,
+			'post_type' => Main::POSTTYPE,
 		] );
 
-		$this->assertTrue( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event import page' );
+		$this->assertTrue( Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event import page' );
 	}
 
 	/**
@@ -88,10 +90,10 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 
 		$query = new WP_Query;
 		$query->parse_query( [
-			'post_type' => Tribe__Events__Main::POSTTYPE,
+			'post_type' => Main::POSTTYPE,
 		] );
 
-		$this->assertFalse( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should not be removed when doing AJAX stuff' );
+		$this->assertFalse( Query::should_remove_date_filters( $query ), 'Date filters should not be removed when doing AJAX stuff' );
 
 		Tribe__Main::instance()->doing_ajax( false );
 	}
@@ -102,11 +104,11 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function it_should_remove_date_filters_on_event_list() {
-		set_current_screen( 'edit-' . Tribe__Events__Main::POSTTYPE );
+		set_current_screen( 'edit-' . Main::POSTTYPE );
 
 		$query = new WP_Query;
 		$query->parse_query( [
-			'post_type' => Tribe__Events__Main::POSTTYPE,
+			'post_type' => Main::POSTTYPE,
 		] );
 
 		if ( isset( $_GET['page'] ) ) {
@@ -117,6 +119,57 @@ class QueryTest extends \Codeception\TestCase\WPTestCase {
 			unset( $_GET['tab'] );
 		}
 
-		$this->assertTrue( Tribe__Events__Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event list page' );
+		$this->assertTrue( Query::should_remove_date_filters( $query ), 'Date filters should be removed when on the event list page' );
+	}
+
+	/**
+	 * It should allow getting found posts for arguments
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_found_posts_for_arguments() {
+		$this->factory()->event->create_many( 5 );
+
+		$args        = [ 'found_posts' => true ];
+		$found_posts = Query::getEvents( $args );
+
+		$this->assertEquals( 5, $found_posts );
+	}
+
+	public function truthy_and_falsy_values(  ) {
+		return [
+			[ 'true', true ],
+			[ 'true', true ],
+			[ '0', false ],
+			[ '1', true ],
+			[ 0, false ],
+			[ 1, true ],
+		];
+
+}
+	/**
+	 * It should allow truthy and falsy values for the found_posts argument
+	 *
+	 * @test
+	 * @dataProvider truthy_and_falsy_values
+	 */
+	public function should_allow_truthy_and_falsy_values_for_the_found_posts_argument($found_posts, $bool) {
+		$this->factory()->event->create_many( 5 );
+
+		$this->assertEquals( Query::getEvents( [ 'found_posts' => $found_posts ] ), Query::getEvents( [ 'found_posts' => $bool ] ) );
+	}
+
+	/**
+	 * It should override posts_per_page and paged arguments when using found_posts
+	 *
+	 * @test
+	 */
+	public function should_override_posts_per_page_and_paged_arguments_when_using_found_posts() {
+		$this->factory()->event->create_many( 5 );
+
+		$args        = [ 'found_posts' => true, 'posts_per_page' => 3, 'paged' => 2 ];
+		$found_posts = Query::getEvents( $args );
+
+		$this->assertEquals( 5, $found_posts );
 	}
 }

--- a/tests/wpunit/functions/template-tags/organizerTest.php
+++ b/tests/wpunit/functions/template-tags/organizerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace functions\template_tags;
+
+use Tribe\Events\Tests\Testcases\Events_TestCase;
+
+class organizerTest extends Events_TestCase {
+
+	/**
+	 * It should allow getting found posts when querying organizers
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_found_posts_when_querying_organizers() {
+		$this->factory()->organizer->create_many( 5 );
+
+		$this->assertEquals( 5, tribe_get_organizers( false, - 1, true, [ 'found_posts' => true ] ) );
+	}
+
+	public function truthy_and_falsy_values() {
+		return [
+			[ 'true', true ],
+			[ 'true', true ],
+			[ '0', false ],
+			[ '1', true ],
+			[ 0, false ],
+			[ 1, true ],
+		];
+
+	}
+
+	/**
+	 * It should allow truthy and falsy values for the found_posts argument
+	 *
+	 * @test
+	 * @dataProvider truthy_and_falsy_values
+	 */
+	public function should_allow_truthy_and_falsy_values_for_the_found_posts_argument( $found_posts, $bool ) {
+		$this->factory()->organizer->create_many( 5 );
+
+		$this->assertEquals(
+			tribe_get_organizers( false, - 1, true, [ 'found_posts' => $found_posts ] ),
+			tribe_get_organizers( false, - 1, true, [ 'found_posts' => $bool ] )
+		);
+	}
+
+	/**
+	 * It should override posts_per_page and paged arguments when using found_posts
+	 *
+	 * @test
+	 */
+	public function should_override_posts_per_page_and_paged_arguments_when_using_found_posts() {
+		$this->factory()->organizer->create_many( 5 );
+
+		$found_posts = tribe_get_organizers( false, - 1, true, [ 'found_posts' => true, 'paged' => 2 ] );
+
+		$this->assertEquals( 5, $found_posts );
+	}
+
+	/**
+	 * It should return 0 when no posts are found and found_posts is set
+	 *
+	 * @test
+	 */
+	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set() {
+		$found_posts = tribe_get_organizers( false, - 1, true, [ 'found_posts' => true] );
+
+		$this->assertEquals( 0, $found_posts );
+	}
+}

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -2,7 +2,9 @@
 
 namespace Tribe\Events\functions\templateTags;
 
-class venueTest extends \Codeception\TestCase\WPTestCase {
+use Tribe\Events\Tests\Testcases\Events_TestCase;
+
+class venueTest extends Events_TestCase {
 	protected $posts = [];
 	protected $venue_url = 'http://power.of.greyskull/by-the';
 
@@ -11,56 +13,6 @@ class venueTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$settings = array(
-			'post_author'           => 3,
-			'post_title'            => 'Test event',
-			'post_content'          => 'This is event content!',
-			'post_status'           => 'publish',
-			'EventAllDay'           => false,
-			'EventHideFromUpcoming' => true,
-			'EventOrganizerID'      => 5,
-			'EventVenueID'          => 8,
-			'EventShowMapLink'      => true,
-			'EventShowMap'          => true,
-			'EventStartDate'        => '2012-01-01',
-			'EventEndDate'          => '2012-01-03',
-			'EventStartHour'        => '01',
-			'EventStartMinute'      => '15',
-			'EventStartMeridian'    => 'am',
-			'EventEndHour'          => '03',
-			'EventEndMinute'        => '25',
-			'EventEndMeridian'      => 'pm',
-		);
-		unset( $settings['EventHideFromUpcoming'] );
-
-		// Create a test venue with a URL
-		$this->posts['venue_with_url'] = tribe_create_venue( [
-			'Venue' => 'Castle Greyskull',
-			'URL'   => $this->venue_url
-		] );
-
-		// Create a test venue without a URL
-		$this->posts['venue_without_url'] = tribe_create_venue( [
-			'Venue' => 'Deathstar Loading Dock'
-		] );
-
-		// Create a venueless event
-		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
-		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
-		$this->posts['no_venue'] = tribe_create_event( $settings );
-
-		// Create an event with a venue
-		$settings['EventVenueID'] = $this->posts['venue_with_url'];
-		$this->posts['has_venue'] = tribe_create_event( $settings );
-	}
-
-	/**
-	 * Remove our test events and venues.
-	 */
-	public function tearDown() {
-		foreach ( $this->posts as $test_post_id ) {
-			wp_delete_post( $test_post_id, true );
-		}
 	}
 
 	/**
@@ -69,6 +21,7 @@ class venueTest extends \Codeception\TestCase\WPTestCase {
 	 * without URLs.
 	 */
 	public function test_get_venue_website_url() {
+		$this->setup_venues();
 		$venue_website_url = tribe_get_venue_website_url( $this->posts['no_venue'] );
 		$this->assertEmpty( $venue_website_url,
 			'Events without a venue should return an empty string'
@@ -96,6 +49,7 @@ class venueTest extends \Codeception\TestCase\WPTestCase {
 	 * without URLs.
 	 */
 	public function test_get_venue_website_link() {
+		$this->setup_venues();
 		$venue_website_link = tribe_get_venue_website_link( $this->posts['no_venue'] );
 		$this->assertEmpty( $venue_website_link,
 			'Events without a venue should return an empty string'
@@ -135,5 +89,111 @@ class venueTest extends \Codeception\TestCase\WPTestCase {
 			&& strpos( $html_fragment, '</a>' ) === strlen( $html_fragment ) - 4
 			&& 2 <= strpos( $html_fragment, $url )
 		);
+	}
+
+	/**
+	 * It should allow getting found posts when querying venues
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_found_posts_when_querying_venues() {
+		$this->factory()->venue->create_many( 5 );
+
+		$this->assertEquals( 5, tribe_get_venues( false, - 1, true, [ 'found_posts' => true ] ) );
+	}
+
+	public function truthy_and_falsy_values() {
+		return [
+			[ 'true', true ],
+			[ 'true', true ],
+			[ '0', false ],
+			[ '1', true ],
+			[ 0, false ],
+			[ 1, true ],
+		];
+
+	}
+
+	/**
+	 * It should allow truthy and falsy values for the found_posts argument
+	 *
+	 * @test
+	 * @dataProvider truthy_and_falsy_values
+	 */
+	public function should_allow_truthy_and_falsy_values_for_the_found_posts_argument( $found_posts, $bool ) {
+		$this->factory()->venue->create_many( 5 );
+
+		$this->assertEquals(
+			tribe_get_venues( false, - 1, true, [ 'found_posts' => $found_posts ] ),
+			tribe_get_venues( false, - 1, true, [ 'found_posts' => $bool ] )
+		);
+	}
+
+	/**
+	 * It should override posts_per_page and paged arguments when using found_posts
+	 *
+	 * @test
+	 */
+	public function should_override_posts_per_page_and_paged_arguments_when_using_found_posts() {
+		$this->factory()->venue->create_many( 5 );
+
+		$found_posts = tribe_get_venues( false, - 1, true, [ 'found_posts' => true, 'paged' => 2 ] );
+
+		$this->assertEquals( 5, $found_posts );
+	}
+
+	/**
+	 * It should return 0 when no posts are found and found_posts is set
+	 *
+	 * @test
+	 */
+	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set() {
+		$found_posts = tribe_get_venues( false, - 1, true, [ 'found_posts' => true] );
+
+		$this->assertEquals( 0, $found_posts );
+	}
+
+	public function setup_venues() {
+		$settings = array(
+			'post_author'           => 3,
+			'post_title'            => 'Test event',
+			'post_content'          => 'This is event content!',
+			'post_status'           => 'publish',
+			'EventAllDay'           => false,
+			'EventHideFromUpcoming' => true,
+			'EventOrganizerID'      => 5,
+			'EventVenueID'          => 8,
+			'EventShowMapLink'      => true,
+			'EventShowMap'          => true,
+			'EventStartDate'        => '2012-01-01',
+			'EventEndDate'          => '2012-01-03',
+			'EventStartHour'        => '01',
+			'EventStartMinute'      => '15',
+			'EventStartMeridian'    => 'am',
+			'EventEndHour'          => '03',
+			'EventEndMinute'        => '25',
+			'EventEndMeridian'      => 'pm',
+		);
+		unset( $settings['EventHideFromUpcoming'] );
+
+		// Create a test venue with a URL
+		$this->posts['venue_with_url'] = tribe_create_venue( [
+			'Venue' => 'Castle Greyskull',
+			'URL'   => $this->venue_url
+		] );
+
+		// Create a test venue without a URL
+		$this->posts['venue_without_url'] = tribe_create_venue( [
+			'Venue' => 'Deathstar Loading Dock'
+		] );
+
+		// Create a venueless event
+		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$settings['EventEndDate']   = date( 'Y-m-d', strtotime( '+1 day' ) );
+		$this->posts['no_venue']    = tribe_create_event( $settings );
+
+		// Create an event with a venue
+		$settings['EventVenueID'] = $this->posts['venue_with_url'];
+		$this->posts['has_venue'] = tribe_create_event( $settings );
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/89743

This PR:
* add support for the `found_posts` argument to the `tribe_get_events`, `tribe_get_organizers` and `tribe_get_venues` functions
* in so doing the support is added in the `Tribe__Events__Query::getEvents` method too
* adds the tests to cover the new behaviours
* updates TEC REST API code to use the new argument