### PR TITLE
Use the latest "Requires PHP" header field

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ Donate link: http://m.tri.be/29
 Requires at least: 4.5
 Stable tag: 4.6.1
 Tested up to: 4.8.2
+Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -129,12 +130,6 @@ Installing the plugin is easy. Just follow these steps:
 5. When it's finished, activate the plugin via the prompt. A message will show confirming activation was successful. A link to access the calendar directly on the frontend will be presented here as well.
 
 That's it! Just configure your settings as you see fit, and you're on your way to creating events in style. Need help getting things started? Check out our [new user primer](http://m.tri.be/2l) for help with settings and features.
-
-= Requirements =
-
-* PHP 5.2.4 or greater (recommended: PHP 5.4 or greater)
-* WordPress 3.9 or above
-* jQuery 1.11.x
 
 == Screenshots ==
 


### PR DESCRIPTION
* Remove the "requirements" list.
* Required WordPress version is defined in "Requires at least" header field.
* Add the new "Requires PHP" header field.

See more info at: https://generatewp.com/minimum-required-php-version-plugins/