### PR TITLE
Fixed issue with events that started before but ended within not bein…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -324,6 +324,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 = [4.6.2] TBD =
 
+* Fix - Fixed issue in Month view with multi-month events not appearing on subsequent months (thanks @shinno.kei & @schittly for helping isolate this) [89747]
 * Tweak - Improvements to the readme.txt file surrounding plugin requirements (thanks @ramiy) [90285]
 
 = [4.6.1] 2017-10-04 =

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -932,18 +932,18 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 							WHERE tribe_event_start.meta_key = '_EventStartDate'
 							AND tribe_event_start.post_id IN ( {$sql_ids} )
 							AND (
-									(
-										tribe_event_start.meta_value >= '{$start_date_sql}'
-										AND tribe_event_start.meta_value <= '{$end_date_sql}'
-									)
-									OR (
-										tribe_event_end_date.meta_value >= '{$start_date_sql}'
-										AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
-									)
-									OR (
-										tribe_event_start.meta_value < '{$start_date_sql}'
-										AND tribe_event_end_date.meta_value > '{$end_date_sql}'
-									)
+								(
+									tribe_event_start.meta_value >= '{$start_date_sql}'
+									AND tribe_event_start.meta_value <= '{$end_date_sql}'
+								)
+								OR (
+									tribe_event_end_date.meta_value >= '{$start_date_sql}'
+									AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
+								)
+								OR (
+									tribe_event_start.meta_value < '{$start_date_sql}'
+									AND tribe_event_end_date.meta_value > '{$end_date_sql}'
+								)
 							)
 							ORDER BY menu_order ASC, DATE(tribe_event_start.meta_value) ASC, TIME(tribe_event_start.meta_value) ASC;"
 						);

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -932,18 +932,18 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 							WHERE tribe_event_start.meta_key = '_EventStartDate'
 							AND tribe_event_start.post_id IN ( {$sql_ids} )
 							AND (
-								(
-									tribe_event_start.meta_value >= '{$start_date_sql}'
-									AND  tribe_event_start.meta_value <= '{$end_date_sql}'
-								)
-								OR (
-									tribe_event_start.meta_value <= '{$start_date_sql}'
-									AND tribe_event_end_date.meta_value >= '{$start_date_sql}'
-								)
-								OR (
-									tribe_event_start.meta_value >= '{$start_date_sql}'
-									AND tribe_event_start.meta_value <= '{$end_date_sql}'
-								)
+									(
+										tribe_event_start.meta_value >= '{$start_date_sql}'
+										AND tribe_event_start.meta_value <= '{$end_date_sql}'
+									)
+									OR (
+										tribe_event_end_date.meta_value >= '{$start_date_sql}'
+										AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
+									)
+									OR (
+										tribe_event_start.meta_value < '{$start_date_sql}'
+										AND tribe_event_end_date.meta_value > '{$end_date_sql}'
+									)
 							)
 							ORDER BY menu_order ASC, DATE(tribe_event_start.meta_value) ASC, TIME(tribe_event_start.meta_value) ASC;"
 						);

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -560,18 +560,18 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					LEFT JOIN $wpdb->postmeta as tribe_event_end_date ON ( tribe_event_start.post_id = tribe_event_end_date.post_id AND tribe_event_end_date.meta_key = '_EventEndDate' )
 					WHERE $ignore_hidden_events_AND tribe_event_start.meta_key = '_EventStartDate'
 					AND (
-							(
-								tribe_event_start.meta_value >= '{$start_date_sql}'
-								AND tribe_event_start.meta_value <= '{$end_date_sql}'
-							)
-							OR (
-								tribe_event_end_date.meta_value >= '{$start_date_sql}'
-								AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
-							)
-							OR (
-								tribe_event_start.meta_value < '{$start_date_sql}'
-								AND tribe_event_end_date.meta_value > '{$end_date_sql}'
-							)
+						(
+							tribe_event_start.meta_value >= '{$start_date_sql}'
+							AND tribe_event_start.meta_value <= '{$end_date_sql}'
+						)
+						OR (
+							tribe_event_end_date.meta_value >= '{$start_date_sql}'
+							AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
+						)
+						OR (
+							tribe_event_start.meta_value < '{$start_date_sql}'
+							AND tribe_event_end_date.meta_value > '{$end_date_sql}'
+						)
 					)
 					AND $wpdb->posts.post_status IN('$post_stati')
 					ORDER BY $wpdb->posts.menu_order ASC, DATE(tribe_event_start.meta_value) ASC, TIME(tribe_event_start.meta_value) ASC;

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -560,18 +560,18 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					LEFT JOIN $wpdb->postmeta as tribe_event_end_date ON ( tribe_event_start.post_id = tribe_event_end_date.post_id AND tribe_event_end_date.meta_key = '_EventEndDate' )
 					WHERE $ignore_hidden_events_AND tribe_event_start.meta_key = '_EventStartDate'
 					AND (
-						(
-							tribe_event_start.meta_value >= '{$start_date_sql}'
-							AND tribe_event_start.meta_value <= '{$end_date_sql}'
-						)
-						OR (
-							tribe_event_start.meta_value <= '{$start_date_sql}'
-							AND tribe_event_end_date.meta_value >= '{$end_date_sql}'
-						)
-						OR (
-							tribe_event_start.meta_value >= '{$start_date_sql}'
-							AND tribe_event_start.meta_value <= '{$end_date_sql}'
-						)
+							(
+								tribe_event_start.meta_value >= '{$start_date_sql}'
+								AND tribe_event_start.meta_value <= '{$end_date_sql}'
+							)
+							OR (
+								tribe_event_end_date.meta_value >= '{$start_date_sql}'
+								AND tribe_event_end_date.meta_value <= '{$end_date_sql}'
+							)
+							OR (
+								tribe_event_start.meta_value < '{$start_date_sql}'
+								AND tribe_event_end_date.meta_value > '{$end_date_sql}'
+							)
 					)
 					AND $wpdb->posts.post_status IN('$post_stati')
 					ORDER BY $wpdb->posts.menu_order ASC, DATE(tribe_event_start.meta_value) ASC, TIME(tribe_event_start.meta_value) ASC;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/89747

Not doing a readme entry just yet, we might want to make this a hotfix so I wanted to the readme entry commit to be separate for easy cherry picking.

Near as I can figure we only have three different scenarios which this query needs to account for.

- Events which start during the month: `tribe_event_start.meta_value >= '{$start_date_sql}' AND tribe_event_start.meta_value <= '{$end_date_sql}'`
- Events which end during the month: `tribe_event_end_date.meta_value >= '{$start_date_sql}' AND tribe_event_end_date.meta_value <= '{$end_date_sql}'`
- Events which start prior to the month and end after: `tribe_event_start.meta_value < '{$start_date_sql}' AND tribe_event_end_date.meta_value > '{$end_date_sql}'`

This updated query should handle all of those. In my tests it does. Let me know if you can think of anything I am missing.

The bug from the attached ticket was introduced with this commit: https://github.com/moderntribe/the-events-calendar/commit/5ca21bcf705cfcc2b42b3e714da53750cb1fa7d2 Oddly, I can not find a single functional difference between that commit and the one prior to it. But, bisect doesn't lie. Month view was working fine until this commit. :-/