### PR TITLE
Avoid notice level error if term does not exist | #90697

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -325,6 +325,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 = [4.6.2] TBD =
 
 * Tweak - Improvements to the readme.txt file surrounding plugin requirements (thanks @ramiy) [90285]
+* Tweak - Avoid notice level errors when a non-existent category archive is requested (our thanks to Charles Simmons for highlighting this) [90697]
 
 = [4.6.1] 2017-10-04 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -660,7 +660,10 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		if ( ! empty( $term_name ) ) {
 			$term_obj = get_term_by( 'name', $term_name, Tribe__Events__Main::TAXONOMY );
-			$term     = 0 < $term_obj->term_id ? $term_obj->term_id : false;
+		}
+
+		if ( ! empty( $term_obj ) ) {
+			$term = 0 < $term_obj->term_id ? $term_obj->term_id : false;
 		}
 
 		// wp_title was deprecated in WordPress 4.4. Fetch the document title with the new function (added in 4.4) if available


### PR DESCRIPTION
Within `tribe_events_the_header_attributes()` we grab the requested event category name and try to load the corresponding term object ... however it's possible the category will not exist and we'll get back null in instead of a term object. This change accommodates that.

:ticket: [#90697](https://central.tri.be/issues/90697)