### PR TITLE
Check for event category by slug, not by name | #90697

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -659,7 +659,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$term_name    = get_query_var( Tribe__Events__Main::TAXONOMY );
 
 		if ( ! empty( $term_name ) ) {
-			$term_obj = get_term_by( 'name', $term_name, Tribe__Events__Main::TAXONOMY );
+			$term_obj = get_term_by( 'slug', $term_name, Tribe__Events__Main::TAXONOMY );
 		}
 
 		if ( ! empty( $term_obj ) ) {


### PR DESCRIPTION
Further enhancement to `tribe_events_the_header_attributes()` — load the term object by _slug_ rather than by name. 

While there was no problem for simple categories (ie where the category was something like 'foo') for more complex names like 'Foo Bar' the slug and the name don't match, as the slug will be hyphenated etc. This fixes that shortcoming.

:ticket: [#90697](https://central.tri.be/issues/90697)