### PR TITLE
Safety checks and cleanup (JSON LD timezones)

### DIFF
--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -39,11 +39,13 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	 * @return string
 	 */
 	private function get_localized_iso8601_string( $date, $event_tz_string ) {
-		$localTime = new DateTime( $date, new DateTimeZone( 'UTC' ) );
-		$localTime->setTimezone( new DateTimeZone( $event_tz_string ) );
-		$localTime->date = $localTime->format( 'c' );
-
-		return $localTime->date;
+		try {
+			$localTime = new DateTime( $date, new DateTimeZone( 'UTC' ) );
+			$localTime->setTimezone( new DateTimeZone( $event_tz_string ) );
+			return $localTime->format( 'c' );
+		} catch ( Exception $e ) {
+			return $date;
+		}
 	}
 
 	/**
@@ -75,9 +77,14 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			$tz_mode         = tribe_get_option( 'tribe_events_timezone_mode', 'event' );
 			$tz_string       = $event_tz_string && $tz_mode === 'event' ? $event_tz_string : Tribe__Events__Timezones::wp_timezone_string();
 
-			// @todo simplify to `tribe_get_start_date( $post_id, true, 'c' )` once #90984 is resolved
-			$data->startDate = self::get_localized_iso8601_string( Tribe__Events__Timezones::to_utc( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' ), $event_tz_string );
-			$data->endDate   = self::get_localized_iso8601_string( Tribe__Events__Timezones::to_utc( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' ), $event_tz_string );
+			$data->startDate = Tribe__Events__Timezones::to_utc( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
+			$data->endDate   = Tribe__Events__Timezones::to_utc( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
+
+			// @todo once #90984 this extra step should not be required
+			if ( ! empty( $tz_string ) ) {
+				$data->startDate = $this->get_localized_iso8601_string( $data->startDate, $tz_string );
+				$data->endDate   = $this->get_localized_iso8601_string( $data->endDate, $tz_string );
+			}
 
 			if ( tribe_has_venue( $post_id ) ) {
 				$venue_id       = tribe_get_venue_id( $post_id );

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -80,7 +80,7 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			$data->startDate = Tribe__Events__Timezones::to_utc( tribe_get_start_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
 			$data->endDate   = Tribe__Events__Timezones::to_utc( tribe_get_end_date( $post_id, true, Tribe__Date_Utils::DBDATETIMEFORMAT ), $tz_string, 'c' );
 
-			// @todo once #90984 this extra step should not be required
+			// @todo once #90984 is resolved this extra step should not be required
 			if ( ! empty( $tz_string ) ) {
 				$data->startDate = $this->get_localized_iso8601_string( $data->startDate, $tz_string );
 				$data->endDate   = $this->get_localized_iso8601_string( $data->endDate, $tz_string );


### PR DESCRIPTION
Tidies work from a previous PR, changelog entry is already in place. This change:

* Catches possible exceptions when creating DateTime and DateTimeZone objects
* Doesn't attempt timezone conversion/formatting if we lack the info to do so

:ticket: [#42125](https://central.tri.be/issues/42125)