### PR TITLE
Remove unwanted escaping

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed start/end times being displayed in incorrect timezone in structured data (thanks @mtncreative & @esosa) [42125]
 * Fix - Fixed an issue that would cause a 404 error if the selected default view was not enabled (thanks @pruneau) [45612]
 * Fix - Improved translatability by adding missing textdomains for a number of strings (props @pedro-mendonca) [91071]
+* Fix - Removed unneeded escaping to ensure the organizer link displays as expected (pros @f4w-pwharton) [91074]
 * Tweak - Improvements to the readme.txt file surrounding plugin requirements (thanks @ramiy) [90285]
 * Tweak - Improve site identification in multisite installations using Event Aggregator to avoid throttling issues [90489]
 * Tweak - Avoid notice level errors when a non-existent category archive is requested (our thanks to Charles Simmons for highlighting this) [90697]

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -125,7 +125,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		if ( $organizer_id && $link = tribe_get_organizer_website_link() ) {
-			$details[] = '<span class="link"> <a href="' . esc_attr( $link ) . '">' . $link . '</a> </span>';
+			// $link is a full HTML string (<a>) whose components are already escaped, so we don't need create an anchor tag or escape again here
+			$details[] = '<span class="link">' . $link . '</span>';
 		}
 
 		$html = join( '<span class="tribe-events-divider">|</span>', $details );


### PR DESCRIPTION
Incorporates @f4w-pwharton's fix (to avoid wrapping a link in another link) and adds a changelog for same. Originally [reviewed here](https://github.com/moderntribe/the-events-calendar/pull/1461).

:ticket: [#91074](https://central.tri.be/issues/91074)