### PR TITLE
Clear up next events link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -327,6 +327,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Fixed issue where the value of an event's "Show Google Maps Link" option would not properly affect the displaying of the link on List View (props: @etechnologie) [75547]
 * Fix - Improve shortcode pagination/view change url so it is reusable (props: @der.chef and others) [70021]
 * Tweak - Fixed some display issues for the event schedule details (props @mia-caro)
+* Tweak - Changed the order in which the list view "next events" link is assembled for better translatability (with thanks to @alelouya for highlighting this problem) [72097]
 
 = [4.6.2] 2017-10-18 =
 

--- a/src/views/list/nav.php
+++ b/src/views/list/nav.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php if ( tribe_has_previous_event() ) : ?>
 		<li class="<?php echo esc_attr( tribe_left_navigation_classes() ); ?>" aria-label="previous events link">
-			<a href="<?php echo esc_url( tribe_get_listview_prev_link() ); ?>" rel="prev"><?php printf( '<span>&laquo;</span> ' . esc_html__( 'Previous %s', 'the-events-calendar' ), $events_label_plural ); ?></a>
+			<a href="<?php echo esc_url( tribe_get_listview_prev_link() ); ?>" rel="prev"><span>&laquo;</span> <?php echo esc_html( sprintf( __( 'Previous %s', 'the-events-calendar' ), $events_label_plural ) ); ?></a>
 
 		</li><!-- .tribe-events-nav-left -->
 	<?php endif; ?>
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- Right Navigation -->
 	<?php if ( tribe_has_next_event() ) : ?>
 		<li class="<?php echo esc_attr( tribe_right_navigation_classes() ); ?>" aria-label="next events link">
-			<a href="<?php echo esc_url( tribe_get_listview_next_link() ); ?>" rel="next"><?php printf( esc_html__( 'Next %s', 'the-events-calendar' ), $events_label_plural ); ?> <span>&raquo;</span></a>
+			<a href="<?php echo esc_url( tribe_get_listview_next_link() ); ?>" rel="next"><?php echo esc_html( sprintf( __( 'Next %s', 'the-events-calendar' ), $events_label_plural ) ); ?> <span>&raquo;</span></a>
 		</li><!-- .tribe-events-nav-right -->
 	<?php endif; ?>
 </ul>

--- a/src/views/list/nav.php
+++ b/src/views/list/nav.php
@@ -6,7 +6,7 @@
  * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list/nav.php
  *
  * @package TribeEventsCalendar
- * @version 4.2
+ * @version TBD
  *
  */
 global $wp_query;
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- Right Navigation -->
 	<?php if ( tribe_has_next_event() ) : ?>
 		<li class="<?php echo esc_attr( tribe_right_navigation_classes() ); ?>" aria-label="next events link">
-			<a href="<?php echo esc_url( tribe_get_listview_next_link() ); ?>" rel="next"><?php printf( esc_html__( 'Next %s', 'the-events-calendar' ), $events_label_plural . ' <span>&raquo;</span>' ); ?></a>
+			<a href="<?php echo esc_url( tribe_get_listview_next_link() ); ?>" rel="next"><?php printf( esc_html__( 'Next %s', 'the-events-calendar' ), $events_label_plural ); ?> <span>&raquo;</span></a>
 		</li><!-- .tribe-events-nav-right -->
 	<?php endif; ?>
 </ul>


### PR DESCRIPTION
By appending `&raquo;` to the plural events label, in some languages such as French this meant we ended up with _Evénements » suivant_ instead of _Evénements suivant »_ ... this change alters the order in which we do things to avoid this.

:ticket: [#72097](https://central.tri.be/issues/72097)