### PR TITLE
Restore JSON LD filtering

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -326,6 +326,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 * Fix - Fixed issue where the value of an event's "Show Google Maps Link" option would not properly affect the displaying of the link on List View (props: @etechnologie) [75547]
 * Fix - Improve shortcode pagination/view change url so it is reusable (props: @der.chef and others) [70021]
+* Fix - Ensure the `tribe_json_ld_{type}_object` filter is available to make modifications of event, venue and organizer JSON LD data possible (thanks to Mathew for flagging this problem) [89801]
 * Tweak - Fixed some display issues for the event schedule details (props @mia-caro)
 
 = [4.6.2] 2017-10-18 =

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -111,6 +111,7 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 				);
 			}
 
+			$data = $this->apply_object_data_filter( $data, $args, $post );
 			$return[ $post_id ] = $data;
 		}
 

--- a/src/Tribe/JSON_LD/Organizer.php
+++ b/src/Tribe/JSON_LD/Organizer.php
@@ -56,6 +56,7 @@ class Tribe__Events__JSON_LD__Organizer extends Tribe__JSON_LD__Abstract {
 		$data->email = tribe_get_organizer_email( $post_id );
 		$data->sameAs = tribe_get_organizer_website_url( $post_id );
 
+		$data = $this->apply_object_data_filter( $data, $args, $post );
 		return array( $post_id => $data );
 	}
 

--- a/src/Tribe/JSON_LD/Venue.php
+++ b/src/Tribe/JSON_LD/Venue.php
@@ -77,6 +77,7 @@ class Tribe__Events__JSON_LD__Venue extends Tribe__JSON_LD__Abstract {
 		$data->telephone = tribe_get_phone( $post_id );
 		$data->sameAs = tribe_get_venue_website_url( $post_id );
 
+		$data = $this->apply_object_data_filter( $data, $args, $post );
 		return array( $post_id => $data );
 	}
 


### PR DESCRIPTION
Builds on the change [made here (in Tribe Common)](https://github.com/moderntribe/tribe-common/pull/561) and ensures the `tribe_json_ld_{$type}_object` filter is available for event, venue and organizer JSON LD data.

:ticket: [#89801](https://central.tri.be/issues/89801)