### PR TITLE
Fix application of UTC offsets in JSON LD output for events | #78233

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Added some more specification to our jquery-ui-datepicker CSS to limit conflicts with other plugins and themes [90577]
 * Fix - Improve shortcode pagination/view change url so it is reusable (props: @der.chef and others) [70021]
 * Fix - Ensure the `tribe_json_ld_{type}_object` filter is available to make modifications of event, venue and organizer JSON LD data possible (thanks to Mathew for flagging this problem) [89801]
+* Fix - Improved JSON LD output for events by outputting the correct UTC offset where required (our thanks to Nina and many others for flagging this issue) [78233]
 * Tweak - Fixed some display issues for the event schedule details (props @mia-caro)
 * Tweak - Improved the clarity of and amount of context for some linked post labels to make translation of those labels a little easier and more nuanced (props @hnacc and others) [88589]
 * Tweak - Changed the order in which the list view "next events" link is assembled for better translatability (with thanks to @alelouya for highlighting this problem) [72097]

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -40,9 +40,16 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	 */
 	private function get_localized_iso8601_string( $date, $event_tz_string ) {
 		try {
-			$localTime = new DateTime( $date, new DateTimeZone( 'UTC' ) );
-			$localTime->setTimezone( new DateTimeZone( $event_tz_string ) );
-			return $localTime->format( 'c' );
+			$timezone = Tribe__Timezones::timezone_from_utc_offset( $event_tz_string );
+
+			if ( false === $timezone ) {
+				return $date;
+			}
+
+			$datetime = new DateTime( $date, new DateTimeZone( 'UTC' ) );
+			$datetime->setTimezone( $timezone );
+
+			return $datetime->format( 'c' );
 		} catch ( Exception $e ) {
 			return $date;
 		}

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -40,7 +40,9 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	 */
 	private function get_localized_iso8601_string( $date, $event_tz_string ) {
 		try {
-			$timezone = Tribe__Timezones::timezone_from_utc_offset( $event_tz_string );
+			$timezone = 0 === strpos( $event_tz_string, 'UTC' )
+				? Tribe__Timezones::timezone_from_utc_offset( $event_tz_string )
+				: new DateTimeZone( $event_tz_string );
 
 			if ( false === $timezone ) {
 				return $date;


### PR DESCRIPTION
Ensures our JSON LD output includes correctly set timezone offset. Depends on [Tribe Common PR 562](https://github.com/moderntribe/tribe-common/pull/562)

:ticket: [#78233](https://central.tri.be/issues/78233)