### PR TITLE
Default to the global post object as needed | #92020

### DIFF
--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -62,10 +62,19 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 	 *
 	 * @param  int|WP_Post|null $post The post/event
 	 * @param  array  $args
+	 *
 	 * @return array
 	 */
 	public function get_data( $posts = null, $args = array() ) {
-		$posts = ( $posts instanceof WP_Post ) ? array( $posts ) : (array) $posts;
+		// Fetch the global post object if no posts are provided
+		if ( ! is_array( $posts ) && empty( $posts ) ) {
+			$posts = array( $GLOBALS['post'] );
+		}
+		// If we only received a single post object, wrap it in an array
+		else {
+			$posts = ( $posts instanceof WP_Post ) ? array( $posts ) : (array) $posts;
+		}
+
 		$return = array();
 
 		foreach ( $posts as $i => $post ) {


### PR DESCRIPTION
Explicitly uses the global `$post` object if no other posts are provided. The problem this solves isn't new, but became visible again following the fix made in [#78233](https://central.tri.be/issues/78233).

* No changelog entry, existing entry for 78233 is sufficient
* No props, this was an internal discovery

:ticket: [#92020](https://central.tri.be/issues/92020)