### PR TITLE
Work with the post object wherever possible | #92020

### DIFF
--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -84,7 +84,7 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			}
 
 			// If we don't have a valid post object, skip to the next item
-			if ( ! is_object( $post ) ) {
+			if ( ! $post instanceof WP_Post ) {
 				continue;
 			}
 

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -78,6 +78,16 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 		$return = array();
 
 		foreach ( $posts as $i => $post ) {
+			// We may have been passed a post ID - let's ensure we have the post object
+			if ( is_numeric( $post ) ) {
+				$post = get_post( $post );
+			}
+
+			// If we don't have a valid post object, skip to the next item
+			if ( ! is_object( $post ) ) {
+				continue;
+			}
+
 			$data = parent::get_data( $post, $args );
 
 			// If we have an Empty data we just skip


### PR DESCRIPTION
This method (`Tribe__Events__JSON_LD__Event::get_data()`) can accept a post ID, post object or an array of post objects (or of post IDs). 

This flexibility is great, but we ultimately need to make sure it's the post object we're working with or there can be unexpected side effects when subsequent hooks fire (as the callbacks expect post objects).

Changelog added via previous change.

:ticket: [#92020](https://central.tri.be/issues/92020)