### PR TITLE
Whitelist attrchange lib in common | spotfix | M17.21

### DIFF
--- a/package-whitelist.json
+++ b/package-whitelist.json
@@ -32,6 +32,7 @@
   "common/vendor/tribe-select2/*.js",
   "common/vendor/tribe-select2/*.gif",
   "common/vendor/tribe-select2/*.png",
+  "common/vendor/attrchange/js/*.js",
   "lang/**/*",
   "license.txt",
   "readme.txt",


### PR DESCRIPTION
Don't strip the attrchange lib (from tribe-common - [added here](https://github.com/moderntribe/tribe-common/pull/559)) during packaging.