### PR TITLE
Smarten redirect logic, avoid unwanted redirects | #86942

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -322,6 +322,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.6.4] TBD =
+
+* Fix - Improved legacy URL redirect logic to prevent unwanted redirects (our thanks to wesleyanhq and Adam Schwartz for highlighting this issue) [86942]
+
 = [4.6.3] 2017-11-02 =
 
 * Fix - Prevent JS error when adding a Pro widget in the WP Customizer screen [72127]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2399,23 +2399,23 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$legacy_upcoming_events_url = $this->getRewriteSlug() . '/' . $this->upcomingSlug;
 
 			// Check if the request is for either the legacy past or upcoming event views and redirect if appropriate
-				switch ( $requested_path ) {
-					case $legacy_past_events_url:
-						$search = '#/' . $this->pastSlug . '/?#';
-						$replace = '/' . $this->listSlug . '/';
-						$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
-						$redirect_url = esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), $redirect_url ) );
-						wp_redirect( $redirect_url );
-						tribe_exit();
-						break;
+			switch ( $requested_path ) {
+				case $legacy_past_events_url:
+					$search = '#/' . $this->pastSlug . '/?#';
+					$replace = '/' . $this->listSlug . '/';
+					$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+					$redirect_url = esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), $redirect_url ) );
+					wp_redirect( $redirect_url );
+					tribe_exit();
+					break;
 
-					case $legacy_upcoming_events_url:
-						$search = '#/' . $this->upcomingSlug . '/?#';
-						$replace = '/' . $this->listSlug . '/';
-						$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
-						wp_redirect( $redirect_url );
-						tribe_exit();
-						break;
+				case $legacy_upcoming_events_url:
+					$search = '#/' . $this->upcomingSlug . '/?#';
+					$replace = '/' . $this->listSlug . '/';
+					$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+					wp_redirect( $redirect_url );
+					tribe_exit();
+					break;
 			}
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2384,37 +2384,39 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 		/**
 		 * Redirect the legacy past/upcoming view URLs to list
-         *
-         * @since TBD revised to avoid unwanted redirects
+		 *
+		 * @since TBD revised to avoid unwanted redirects
 		 */
 		public function redirect_past_upcoming_view_urls() {
-		    // We are only interested in the path and not any query args
-            if ( ! $requested_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) {
-                return;
-            }
+			// We are only interested in the path and not any query args
+			if ( ! $requested_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) {
+				return;
+			}
 
-            // Prep strings so we can compare paths sans any leading/trailing slashes
-            $requested_path = trim( $requested_path, '/' );
-            $legacy_past_events_url = $this->getRewriteSlug() . '/' . $this->pastSlug;
+			// Prep strings so we can compare paths sans any leading/trailing slashes
+			$requested_path = trim( $requested_path, '/' );
+			$legacy_past_events_url = $this->getRewriteSlug() . '/' . $this->pastSlug;
 			$legacy_upcoming_events_url = $this->getRewriteSlug() . '/' . $this->upcomingSlug;
 
 			// Check if the request is for either the legacy past or upcoming event views and redirect if appropriate
-            switch ( $requested_path ) {
-                case $legacy_past_events_url:
-	                $search = '#/' . $this->pastSlug . '/?#';
-	                $replace = '/' . $this->listSlug . '/';
-	                $redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
-	                $redirect_url = esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), $redirect_url ) );
-	                wp_redirect( $redirect_url );
-	                exit;
+				switch ( $requested_path ) {
+					case $legacy_past_events_url:
+						$search = '#/' . $this->pastSlug . '/?#';
+						$replace = '/' . $this->listSlug . '/';
+						$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+						$redirect_url = esc_url_raw( add_query_arg( array( 'tribe_event_display' => 'past' ), $redirect_url ) );
+						wp_redirect( $redirect_url );
+						tribe_exit();
+						break;
 
-                case $legacy_upcoming_events_url:
-	                $search = '#/' . $this->upcomingSlug . '/?#';
-	                $replace = '/' . $this->listSlug . '/';
-	                $redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
-	                wp_redirect( $redirect_url );
-	                exit;
-            }
+					case $legacy_upcoming_events_url:
+						$search = '#/' . $this->upcomingSlug . '/?#';
+						$replace = '/' . $this->listSlug . '/';
+						$redirect_url = preg_replace( $search, $replace, $_SERVER['REQUEST_URI'] );
+						wp_redirect( $redirect_url );
+						tribe_exit();
+						break;
+			}
 		}
 
 		/**


### PR DESCRIPTION
Improves/tightens conditions under which we redirect from a legacy upcoming/past events URL to the current list view equivalents.

This change is needed because if the single and archive event slugs are the same (something we currently permit) then a single event URL such as `/calendar/pastoral-pleasures/` triggers unwanted redirects to the past events view.

:ticket: [#86942](https://central.tri.be/issues/86942)