### PR TITLE
Avoid unnecessary/unwanted extra iterations within tribe_get_template_part()

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -322,6 +322,10 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 == Changelog ==
 
+= [4.6.4] TBD =
+
+* Fix - Modified tribe_get_template_part() to remove potential for multiple templates to be rendered in a single call [46630]
+
 = [4.6.3] 2017-11-02 =
 
 * Fix - Prevent JS error when adding a Pro widget in the WP Customizer screen [72127]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -152,6 +152,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				do_action( 'tribe_after_get_template_part', $template, $file, $slug, $name );
 				$html = ob_get_clean();
 				echo apply_filters( 'tribe_get_template_part_content', $html, $template, $file, $slug, $name );
+				break; // We found our template, no need to continue the loop
 			}
 		}
 		do_action( 'tribe_post_get_template_part_' . $slug, $slug, $name, $data );


### PR DESCRIPTION
Once we've successfully found and printed our template, we don't need to continue the loop.

:ticket: [#46630](https://central.tri.be/issues/46630)