### PR TITLE
Complete clean up of default venue field handling 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -326,6 +326,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 
 * Fix - Improved legacy URL redirect logic to prevent unwanted redirects (our thanks to wesleyanhq and Adam Schwartz for highlighting this issue) [86942]
 * Fix - Modified tribe_get_template_part() to remove potential for multiple templates to be rendered in a single call [46630]
+* Fix - Removed code which was automatically populating various address fields with default values when creating a new venue from within the event editor [44732]
 * Tweak - Fix PHP 7.1 compatibility with Event Aggregator (props @BJP NEALE) [90002]
 * Fix - Fixed a bug where only some parts of event featured images were clickable in List Views (thanks @mattemkadia for highlighting this issue) [81392]
 * Tweak - Added new filter: `tribe_events_force_filtered_ical_link`. This makes the "Export Events" URL more easily modifiable (thanks to @tdudley07 for highlighting this issue) [43908]

--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -104,7 +104,7 @@ if ( ! $_POST ) {
 				if ( $abbr == '' ) {
 					echo '<option value="">' . esc_html( $fullname ) . '</option>';
 				} else {
-					echo '<option value="' . esc_attr( $fullname ) . '" ' . selected( ( $current == $fullname ), true, false ) . '>' . esc_html( $fullname ) . '</option>';
+					echo '<option value="' . esc_attr( $fullname ) . '">' . esc_html( $fullname ) . '</option>';
 				}
 			}
 			?>
@@ -132,7 +132,7 @@ if ( ! $_POST ) {
 			<option value=""><?php esc_html_e( 'Select a State:', 'the-events-calendar' ); ?></option>
 			<?php
 			foreach ( Tribe__View_Helpers::loadStates() as $abbr => $fullname ) {
-				echo '<option value="' . esc_attr( $abbr ) . '" ' . selected( ( ( $_VenueStateProvince != - 1 ? $_VenueStateProvince : $currentState ) == $abbr ), true, false ) . '>' . esc_html( $fullname ) . '</option>';
+				echo '<option value="' . esc_attr( $abbr ) . '">' . esc_html( $fullname ) . '</option>';
 			}
 			?>
 		</select>


### PR DESCRIPTION
Tidies up the country and state-province fields (that display inline within the event editor when defining a new venue) so they behave as per other address fields in relation to default venue content.

Background: we previously decided that we _do_ want to use defaults specified in the **Events ‣ Settings ‣ Default Content ‣ Address** fields within the venue editor when defining a brand new venue, but _not_ from within the event editor (whether frontend or backend) when defining new venues inline. This change seems to have mostly rolled out but two fields were left behind.

:ticket: [#44732](https://central.tri.be/issues/44732)