### PR TITLE
Set required version to 4.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: ModernTribe, aguseo, borkweb, barry.hughes, bordoni, brianjessee, brook-tribe, cliffpaulick, courane01, faction23, GeoffBel, geoffgraham, ggwicz, jbrinley, leahkoerper, jentheo, lucatume, mastromktg, mat-lipe, MZAWeb, neillmcshea, nicosantos, patriciahillebrandt, peterchester, reid.peifer, roblagatta, ryancurban, shane.pearlman, shelbelliott, tribecari, vicskf, zbtirrell
 Tags: events, calendar, event, venue, organizer, dates, date, google maps, conference, workshop, concert, meeting, seminar, summit, class, modern tribe, tribe, widget
 Donate link: http://m.tri.be/29
-Requires at least: 4.5
+Requires at least: 4.7
 Stable tag: 4.6.3
 Tested up to: 4.8.3
 Requires PHP: 5.2.4


### PR DESCRIPTION
the plugin makes usage of `WP_REST_Terms_Controller` but this was introduced with WordPress 4.7.0. The readme should reflect that requirement correctly.