### PR TITLE
Fixing the 'Learn more' URL after a failed "Other URL" import preview

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -329,6 +329,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Fix - Removed code which was automatically populating various address fields with default values when creating a new venue from within the event editor [44732]
 * Fix - Added opportunities to override edit linked post links [89015]
 * Fix - Fixed a bug where only some parts of event featured images were clickable in List Views (thanks @mattemkadia for highlighting this issue) [81392]
+* Fix - Fixed the broken 'Learn more' URL received after an unsuccessful "Other URL" import preview [92890]
 * Tweak - Fix PHP 7.1 compatibility with Event Aggregator (props @BJP NEALE) [90002]
 * Tweak - Tweaked some language in Event Aggregator's metabox on individual edit-event screens to reduce confusion around the impact of the Update Authority on CSV imports [77957]
 * Tweak - Added new filter: `tribe_events_force_filtered_ical_link`. This makes the "Export Events" URL more easily modifiable (thanks to @tdudley07 for highlighting this issue) [43908]

--- a/src/Tribe/REST/V1/EA_Messages.php
+++ b/src/Tribe/REST/V1/EA_Messages.php
@@ -35,7 +35,7 @@ class Tribe__Events__REST__V1__EA_Messages extends Tribe__Events__REST__V1__Mess
 			'tec-rest-api-single-event-empty',
 		);
 
-		$learn_more_link = esc_attr( 'https://theeventscalendar.com/knowledgebase/other-url-import-errors-in-event-aggregator' );
+		$learn_more_link = esc_attr( 'https://theeventscalendar.com/knowledgebase/url-import-errors-event-aggregator/' );
 		$learn_more_message = esc_html__( 'Learn more.', 'the-events-calendar' );
 		$learn_more_message_html = sprintf( '<a href="%s" target="_blank">%s</a> ', $learn_more_link, $learn_more_message );
 

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -440,7 +440,7 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 		'tribe_aggregator_default_url_import_range' => array(
 			'type' => 'dropdown',
 			'label' => esc_html__( 'Import Date Range', 'the-events-calendar' ),
-			'tooltip' => esc_html__( 'When importing from a website that uses The Events Calendar, the REST API will attempt to fetch events this far in the future. That website\'s hosting resources may impact the success of imports. Selecting a shorter time period may improve results.', 'the-events-calendar' ) . ' ' . sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_attr( 'https://theeventscalendar.com/knowledgebase/other-url-import-errors-in-event-aggregator' ), esc_html( 'Learn more.' ) ),
+			'tooltip' => esc_html__( 'When importing from a website that uses The Events Calendar, the REST API will attempt to fetch events this far in the future. That website\'s hosting resources may impact the success of imports. Selecting a shorter time period may improve results.', 'the-events-calendar' ) . ' ' . sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_attr( 'https://theeventscalendar.com/knowledgebase/url-import-errors-event-aggregator/' ), esc_html( 'Learn more.' ) ),
 			'size' => 'medium',
 			'validation_type' => 'options',
 			'default' => tribe( 'events-aggregator.settings' )->get_import_range_default(),


### PR DESCRIPTION
After an error msg from 'Other URL' import, the 'Learn more' url was broken.
https://central.tri.be/issues/92890