### PR TITLE
Create a wrapper to make the timezone picker output filterable | #92909

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -334,6 +334,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Tweaked some language in Event Aggregator's metabox on individual edit-event screens to reduce confusion around the impact of the Update Authority on CSV imports [77957]
 * Tweak - Added new filter: `tribe_events_force_filtered_ical_link`. This makes the "Export Events" URL more easily modifiable (thanks to @tdudley07 for highlighting this issue) [43908]
 * Tweak - Made the "End of Day Cutoff" option better accommodate 24-hour and other time formats (thanks @festivalgeneral for bringing this issue to our attention!) [78621]
+* Tweak - Made the options presented by the timezone selector filterable (our thanks to National University's Marketing Department for this idea) [92909]
 
 = [4.6.3] 2017-11-02 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -334,7 +334,7 @@ Please see the changelog for the complete list of changes in this release. Remem
 * Tweak - Tweaked some language in Event Aggregator's metabox on individual edit-event screens to reduce confusion around the impact of the Update Authority on CSV imports [77957]
 * Tweak - Added new filter: `tribe_events_force_filtered_ical_link`. This makes the "Export Events" URL more easily modifiable (thanks to @tdudley07 for highlighting this issue) [43908]
 * Tweak - Made the "End of Day Cutoff" option better accommodate 24-hour and other time formats (thanks @festivalgeneral for bringing this issue to our attention!) [78621]
-* Tweak - Made the options presented by the timezone selector filterable (our thanks to National University's Marketing Department for this idea) [92909]
+* Tweak - Made the options presented by the timezone selector filterable (via the newly added `tribe_events_timezone_choice` hook - our thanks to National University's Marketing Department for this idea) [92909]
 
 = [4.6.3] 2017-11-02 =
 

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -129,7 +129,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 								data-timezone-label="<?php esc_attr_e( 'Timezone:', 'the-events-calendar' ) ?>"
 								data-timezone-value="<?php echo esc_attr( Tribe__Events__Timezones::get_event_timezone_string() ) ?>"
 							>
-								<?php echo wp_timezone_choice( Tribe__Events__Timezones::get_event_timezone_string() ); ?>
+								<?php echo tribe_events_timezone_choice( Tribe__Events__Timezones::get_event_timezone_string() ); ?>
 							</select>
 
 							<p class="tribe-allday">

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -112,6 +112,8 @@ if ( ! function_exists( 'tribe_events_timezone_choice' ) ) {
 	/**
 	 * Event-specific wrapper for wp_timezone_choice().
 	 *
+	 * @since TBD
+	 *
 	 * @param string $selected_zone
 	 * @param string $locale (optional)
 	 *
@@ -121,6 +123,8 @@ if ( ! function_exists( 'tribe_events_timezone_choice' ) ) {
 		/**
 		 * Opportunity to modify the timezone <option>s used within the timezone picker.
 		 *
+		 * @since TBD
+		 * 
 		 * @param string $selected_zone
 		 * @param string $locale
 		 */

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -124,7 +124,7 @@ if ( ! function_exists( 'tribe_events_timezone_choice' ) ) {
 		 * Opportunity to modify the timezone <option>s used within the timezone picker.
 		 *
 		 * @since TBD
-		 * 
+		 *
 		 * @param string $selected_zone
 		 * @param string $locale
 		 */

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -125,6 +125,7 @@ if ( ! function_exists( 'tribe_events_timezone_choice' ) ) {
 		 *
 		 * @since TBD
 		 *
+		 * @param string $html
 		 * @param string $selected_zone
 		 * @param string $locale
 		 */

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -107,3 +107,28 @@ if ( ! function_exists( 'tribe_event_is_on_date' ) ) {
 		return apply_filters( 'tribe_event_is_on_date', $event_is_on_date, $date, $event );
 	}
 }
+
+if ( ! function_exists( 'tribe_events_timezone_choice' ) ) {
+	/**
+	 * Event-specific wrapper for wp_timezone_choice().
+	 *
+	 * @param string $selected_zone
+	 * @param string $locale (optional)
+	 *
+	 * @return string
+	 */
+	function tribe_events_timezone_choice( $selected_zone, $locale = null ) {
+		/**
+		 * Opportunity to modify the timezone <option>s used within the timezone picker.
+		 *
+		 * @param string $selected_zone
+		 * @param string $locale
+		 */
+		return apply_filters(
+			'tribe_events_timezone_choice',
+			wp_timezone_choice( $selected_zone, $locale ),
+			$selected_zone,
+			$locale
+		);
+	}
+}


### PR DESCRIPTION
Adds `tribe_events_timezone_choice()` as a preferred replacement for `wp_timezone_choice()` (key advantage being the output of the former is filterable, which isn't true of the latter).

:ticket: [#92909](https://central.tri.be/issues/92909)