### PR TITLE
Fix bug where the should_hide_recurrence() / tribeHideRecurrence is ignored in some circumstances

### DIFF
--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -110,6 +110,7 @@ class Tribe__Events__List_Widget extends WP_Widget {
 				'tribe_events_list_widget_query_args', array(
 					'eventDisplay'   => 'list',
 					'posts_per_page' => self::$limit,
+					'is_tribe_widget' => true,
 					'tribe_render_context' => 'widget',
 					'featured' => empty( $instance['featured_events_only'] ) ? false : (bool) $instance['featured_events_only'],
 				)


### PR DESCRIPTION
The should_hide_recurrence() / tribeHideRecurrence functionality breaks when this widget is shown on the same page as the Month view for the event calendar.

I have the list widget shown in the sidebar of my site (showing the 3 latest upcoming events in a particular category) with the "Recurring event instances” setting at Events => Settings => General _checked_ so it would hide recurring instances after the first upcoming. This works as intended on all pages except for the main events page that's set to show the monthly calendar view, because it appears that setting is completely ignored on that specific page.

This one change in the code has it trigger the logic for following that setting as expected. Before this fix, it appears the Monthly view was overwriting that setting (so it shows all events) and then the widget wasn't reporting itself as a widget so it was left using that previous setting.

I would love to see this bug fix included in a future version as this fixed a problem on a site that I have in production. Thanks!

I have also posted this on WP.org so others having this issue might stumble across it here: https://wordpress.org/support/topic/fix-bug-where-should_hide_recurrence-tribehiderecurrence-is-ignored/

:ticket: [#94105](https://central.tri.be/issues/94105)