### PR TITLE
Check for WP version before taxonomy endpoint registration

### DIFF
--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -117,8 +117,13 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 		$this->register_single_venue_endpoint( $register_routes );
 		$this->register_organizer_archives_endpoint( $register_routes );
 		$this->register_single_organizer_endpoint( $register_routes );
-		$this->register_categories_endpoint( $register_routes );
-		$this->register_tags_endpoint( $register_routes );
+
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '4.7.0', '>=' ) ) {
+			$this->register_categories_endpoint( $register_routes );
+			$this->register_tags_endpoint( $register_routes );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Ticket:  n/a

From PR: https://github.com/moderntribe/the-events-calendar/pull/1663#issuecomment-343469126

Since the `WP_REST_Terms_Controller` class was introduced in WP 4.7 this PR modified the REST endpoint registration code to avoid registering the taxonomy endpoints if WP is not version `4.7` or above.