### PR TITLE
make sure record author is set in children records

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -566,6 +566,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			'post_date'      => current_time( 'mysql' ),
 			'post_status'    => Tribe__Events__Aggregator__Records::$status->draft,
 			'post_parent'    => $this->id,
+			'post_author'    => $this->post->post_author,
 			'meta_input'     => array(),
 		);
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/92947

This fix, along with the workd done for M17.22, will ensure the record author, and the event author as well, are set, if possible, to the original scheduled import author.