### PR TITLE
ensure post_author is propagated to children records

### DIFF
--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -566,6 +566,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			'post_date'      => current_time( 'mysql' ),
 			'post_status'    => Tribe__Events__Aggregator__Records::$status->draft,
 			'post_parent'    => $this->id,
+			'post_author'    => $this->post->post_author,
 			'meta_input'     => array(),
 		);
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/92947

This PR updates the code in charge of generating the children records to make sure the post author is propagated and applied to the imported events.