### PR TITLE
Venue default fields

### DIFF
--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -94,11 +94,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 </tr>
 <tr class="venue tribe-linked-type-venue-state-province">
 	<?php
-	if ( ! isset( $_VenueStateProvince ) || $_VenueStateProvince == '' ) {
-		$_VenueStateProvince = - 1;
+	if ( 'auto-draft' === get_post_status()	&& empty( $_VenueStateProvince ) ) {
+		$currentState = tribe_get_default_value( 'state' );
+		$currentProvince = tribe_get_default_value( 'province' );
+	} else {
+		$currentProvince = $_VenueProvince;
+		$currentState    = $_VenueStateProvince;
 	}
-	$currentState = ( $_VenueStateProvince == - 1 ) ? tribe_get_default_value( 'state' ) : $_VenueStateProvince;
-	$currentProvince = empty( $_VenueProvince ) ? tribe_get_default_value( 'province' ) : $_VenueProvince;
+
 	?>
 	<td class='tribe-table-field-label'><?php esc_html_e( 'State or Province:', 'the-events-calendar' ); ?></td>
 	<td>


### PR DESCRIPTION
Further cleanup of default venue field handling: previous approach resulted in the province field being populated with the default value for _existing_ venues that in fact do not specify a province.

:ticket: [♯44732](https://central.tri.be/issues/44732)