### PR TITLE
Fixed events gmap id index was translated.

### DIFF
--- a/src/views/modules/map.php
+++ b/src/views/modules/map.php
@@ -16,4 +16,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $style = apply_filters( 'tribe_events_embedded_map_style', "height: $height; width: $width", $index );
 ?>
-<div id="tribe-events-gmap-<?php esc_attr_e( $index ) ?>" style="<?php esc_attr_e( $style ) ?>"></div><!-- #tribe-events-gmap-<?php esc_attr_e( $index ) ?> -->
+<div id="tribe-events-gmap-<?php esc_attr( $index ) ?>" style="<?php esc_attr_e( $style ) ?>"></div><!-- #tribe-events-gmap-<?php esc_attr( $index ) ?> -->


### PR DESCRIPTION
## Issue
Google Maps are not loaded due to wrong map ID.

## Details
1. The JS [see [here](https://github.com/moderntribe/the-events-calendar/blob/master/src/resources/js/embedded-map.js#L90)] is looking for an ID that starts with `tribe-events-gmap-` + index.
2. Events Gmap ID is assigned into the map view [see [here](https://github.com/moderntribe/the-events-calendar/blob/master/src/views/modules/map.php#L19)].
3. The original value of index is an integer, e.g. `0`, but, since `esc_attr_e` is used, It expects a string and it does not automatically casting it. So the plugin is doing `esc_attr_e(0)` instead of `esc_attr_e('0')`. This leads to very unexpected results, e.g, in my case I have `tribe-events-gmap-0/Email` instead of `tribe-events-gmap-0`.
3. Then I'm wondering why using `esc_attr_e` (so also applying a translation, see https://codex.wordpress.org/Function_Reference/esc_attr_e), instead of just `esc_attr`.

## Proposed solutions
- Use `esc_attr` instead of `esc_attr_e`.