### PR TITLE
Switch to the previous language correctly

### DIFF
--- a/src/Tribe/Integrations/WPML/Linked_Posts.php
+++ b/src/Tribe/Integrations/WPML/Linked_Posts.php
@@ -203,7 +203,7 @@ class Tribe__Events__Integrations__WPML__Linked_Posts {
 
 		$posts = $query->have_posts() ? $query->posts : array();
 
-		$sitepress->switch_lang( $sitepress->get_current_language() );
+		$sitepress->switch_lang( ICL_LANGUAGE_CODE );
 
 		$not_translated = array_filter( $posts, array( $this, 'is_not_translated' ) );
 		$assigned = $this->get_linked_post_assigned_to_current( $args );


### PR DESCRIPTION
A few lines above this change you are switching to the default language.
Once you have switched language it becomes the current language.
So this line is doing nothing:
`$sitepress->switch_lang( $sitepress->get_current_language() );`

Instead, we can use the ICL_LANGUAGE_CODE constant which is set at the beginning and doesn't change.

One of the problems caused by this was reported here:
https://wpml.org/forums/topic/we-need-to-continue-troubleshooting-a-problem-with-ankit-our-thread-was-closed/#post-1435947
In this case its a combination of ACF with WPML and The Events Calendar, but I'm sure this causes other side effects.