### PR TITLE
Use correct WPML constant to return to current language

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -311,6 +311,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 = [4.6.7] TBD =
 
 * Fix - Fixed an issue where EA imports might not correctly create venues for iCalendar imports [94323]
+* Fix - Fixed a WPML incompatibility issue where language could be switched to the wrong one (thanks @dgwatkins) [94732]
 
 = [4.6.6] 2017-11-21 =
 

--- a/src/Tribe/Integrations/WPML/Linked_Posts.php
+++ b/src/Tribe/Integrations/WPML/Linked_Posts.php
@@ -203,7 +203,7 @@ class Tribe__Events__Integrations__WPML__Linked_Posts {
 
 		$posts = $query->have_posts() ? $query->posts : array();
 
-		$sitepress->switch_lang( $sitepress->get_current_language() );
+		$sitepress->switch_lang( ICL_LANGUAGE_CODE );
 
 		$not_translated = array_filter( $posts, array( $this, 'is_not_translated' ) );
 		$assigned = $this->get_linked_post_assigned_to_current( $args );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/94732

From PR: https://github.com/moderntribe/the-events-calendar/pull/1707 (by @dgwatkins)