### PR TITLE
No Google Maps Link if no address to link to

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,6 +312,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 * Fix - Ensure the correct properties are set for list widget queries, to avoid problems when running alongside Events Calendar PRO (props @KZeni) [94105]
 * Fix - Fixed issue where left- or right-aligned images at the bottom of event descriptions would overlap event meta on single-event pages [71134]
+* Fix - Fixed issue where Google Maps Link would display in some situations even when there is no address information for which to generate a link. [94909]
 * Tweak - Adjusted CSS to improve the display of venue URLs/phone numbers (especially when Events Calendar PRO is also active) (our thanks to Mathew on the forums for flagging this issue) [69127]
 
 = [4.6.6] 2017-11-21 =

--- a/src/functions/template-tags/google-map.php
+++ b/src/functions/template-tags/google-map.php
@@ -40,12 +40,18 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return string A fully qualified link to https://maps.google.com/ for this event
 	 */
 	function tribe_get_map_link_html( $postId = null ) {
-		$link = sprintf(
-			'<a class="tribe-events-gmap" href="%s" title="%s" target="_blank">%s</a>',
-			esc_url( tribe_get_map_link( $postId ) ),
-			esc_html__( 'Click to view a Google Map', 'the-events-calendar' ),
-			esc_html__( '+ Google Map', 'the-events-calendar' )
-		);
+		$map_link = esc_url( tribe_get_map_link( $postId ) );
+
+		$link = '';
+
+		if ( ! empty( $map_link ) ) {
+			$link = sprintf(
+				'<a class="tribe-events-gmap" href="%s" title="%s" target="_blank">%s</a>',
+				$map_link,
+				esc_html__( 'Click to view a Google Map', 'the-events-calendar' ),
+				esc_html__( '+ Google Map', 'the-events-calendar' )
+			);
+		}
 
 		return apply_filters( 'tribe_get_map_link_html', $link );
 	}


### PR DESCRIPTION
https://central.tri.be/issues/94909

Went the route of modifying `tribe_get_map_link_html()` because it seemed the best way to go (if there's no URL, why output <a> tag?) but also because I found quite a few checks against `tribe_show_google_map_link()` without first checking `&& tribe_address_exists()`, as PRO does in one case.