### PR TITLE
Set edit_date when setting the date on a future event (RER merge)

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -580,6 +580,11 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		$postarr['EventShowInCalendar']   = tribe_is_truthy( $request['sticky'] );
 		$postarr['feature_event']         = tribe_is_truthy( $request['featured'] );
 
+		// If we are scheduling an event and a date has been provided, WP requires an additional argument
+		if ( ! empty( $postarr['post_status'] ) && 'future' === $postarr['post_status'] && ! empty( $postarr['post_date'] ) ) {
+			$postarr['edit_date'] = true;
+		}
+
 		/**
 		 * Allow filtering of $postarr data with additional $request arguments.
 		 *

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
@@ -501,4 +501,25 @@ class Single_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 		$data = $response->get_data();
 		$this->assertNotEmpty( $data['featured'] );
 	}
+
+	/**
+	 * @test
+	 * it should set date for scheduled event that was draft
+	 */
+	public function it_should_set_date_for_scheduled_event_that_was_draft() {
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $this->factory()->event->create( [ 'post_status' => 'draft' ] ) );
+		$request->set_param( 'status', 'future' );
+		$request->set_param( 'date', date_i18n( 'Y-m-d H:i:s', strtotime( '+1 month' ) ) );
+
+		/** @var \WP_REST_Response $response */
+		$response = $sut->update( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->status );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( $request->get_param( 'date' ), $data['date'] );
+	}
 }


### PR DESCRIPTION
https://central.tri.be/issues/96002

This PR is so we can merge the fix into RER branch for our immediate use.