### PR TITLE
Add new utility function

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ Just getting started? Definitely watch and read through the [New User Primer](ht
 * Widget: Upcoming events list
 * Events Taxonomies (Categories & Tags)
 * Google Calendar and iCal exporting
-* WP REST API endpoints 
+* WP REST API endpoints
 * Completely ajaxified for super smooth browsing
 * Completely responsive from mobile to tablet to desktop
 * Tested on the major theme frameworks such as Avada, Genesis, Woo Themes, Thesis and many more.
@@ -313,6 +313,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Fix - Avoid issues when importing multiple organizers that specify images [96354]
 * Fix - Make sure latitude and longitude information from iCal feeds is used if available [96363]
 * Tweak - Made it possible to translate the iCal feed's description field (props @gafderks) [96677]
+* Feature - Add new utility functions tribe_is_events_home and tribe_is_events_front_page similar to native WP is_home and is_front_page [42195]
 
 = [4.6.8] 2017-12-18 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1669,4 +1669,41 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		return $field ? $body_and_separator . $field : $body;
 	}
+
+	/**
+	 * Utility function to test if we are on the home of events, it makes test the case when the page is set to be on
+	 * the frontpage of the site and if the user is on that page is on the homepage or if the user is on the events page
+	 * where the eventDisplay is set to default.
+	 *
+	 * @return bool
+	 */
+	function tribe_is_home_events() {
+		global $wp_query;
+
+		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
+		// If the reading option has an events page as front page and we are on that page is on the home of events.
+		if (
+			$wp_query->tribe_is_event
+			&& $events_as_front_page
+			&& true === get_query_var( 'tribe_events_front_page' )
+		) {
+			return true;
+		}
+
+		// If the readme option does not has an event page as front page and if id the 'default' view on the main query
+		// as is going to set to 'default' when is loading the root of events/ rewrite rule also makes sure is not on
+		// a taxonomy or a tag.
+		if (
+			! $events_as_front_page
+			&& $wp_query->tribe_is_event // Make sure following conditionals operate only on events
+			&& ( isset( $wp_query->query['eventDisplay'] ) && 'default' === $wp_query->query['eventDisplay'] )
+			&& is_post_type_archive()
+			&& ! is_tax()
+			&& ! is_tag()
+		) {
+			return true;
+		}
+		// No condition was true so is not on home of events.
+		return false;
+	}
 }

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -163,7 +163,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * @category Events
 	 * @param bool $view
-	 * @return boolean
+	 * @return bool
 	 */
 	function tribe_is_ajax_view_request( $view = false ) {
 		$is_ajax_view_request = false;
@@ -866,7 +866,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @param string $event_cat_slug
 	 * @param int    $event_id
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	function tribe_event_in_category( $event_cat_slug, $event_id = null ) {
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1671,6 +1671,27 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
+	 * Function to test if we are on the front page of the events, as WordPress language front page is different from
+	 * is_home, if we have a front page on the reading options and if the uzer is on that page, this function will
+	 * return true otherwise will return false.
+	 *
+	 * @since TBD
+	 * @return bool
+	 */
+	function tribe_is_events_front_page() {
+		global $wp_query;
+
+		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
+		// If the reading option has an events page as front page and we are on that page is on the home of events.
+		return (
+			$wp_query->is_main_query()
+			&& $events_as_front_page
+			&& $wp_query->tribe_is_event
+			&& true === get_query_var( 'tribe_events_front_page' )
+		);
+	}
+
+	/**
 	 * Utility function to test if we are on the home of events, it makes test the case when the page is set to be on
 	 * the frontpage of the site and if the user is on that page is on the homepage or if the user is on the events page
 	 * where the eventDisplay is set to default.
@@ -1678,24 +1699,20 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @since TBD
 	 * @return bool
 	 */
-	function tribe_is_home_events() {
+	function tribe_is_events_home() {
 		global $wp_query;
 
-		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
-		// If the reading option has an events page as front page and we are on that page is on the home of events.
-		if (
-			$wp_query->tribe_is_event
-			&& $events_as_front_page
-			&& true === get_query_var( 'tribe_events_front_page' )
-		) {
+		if ( tribe_is_events_front_page() ) {
 			return true;
 		}
 
+		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
 		// If the readme option does not has an event page as front page and if id the 'default' view on the main query
 		// as is going to set to 'default' when is loading the root of events/ rewrite rule also makes sure is not on
 		// a taxonomy or a tag.
 		if (
 			! $events_as_front_page
+			&& $wp_query->is_main_query()
 			&& $wp_query->tribe_is_event // Make sure following conditionals operate only on events
 			&& ( isset( $wp_query->query['eventDisplay'] ) && 'default' === $wp_query->query['eventDisplay'] )
 			&& is_post_type_archive()
@@ -1704,6 +1721,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		) {
 			return true;
 		}
+
 		// No condition was true so is not on home of events.
 		return false;
 	}

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1675,6 +1675,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * the frontpage of the site and if the user is on that page is on the homepage or if the user is on the events page
 	 * where the eventDisplay is set to default.
 	 *
+	 * @since TBD
 	 * @return bool
 	 */
 	function tribe_is_home_events() {

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1671,11 +1671,18 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Function to test if we are on the front page of the events, as WordPress language front page is different from
-	 * is_home, if we have a front page on the reading options and if the uzer is on that page, this function will
-	 * return true otherwise will return false.
+	 * Tests if we are on the site homepage and if it is set to display the main events page.
+	 *
+	 * As WordPress front page it might be different from is_home, if we have a front page on the reading options and
+	 * if the User is on that page, this function will return true otherwise will return false. So either if the User has
+	 * the frontpage set on the reading options and the User is visiting this page.
+	 *
+	 * Another consideration about this is it might behave as a WordPress function which means after any Ajax action is
+	 * fired the result of call this function via Ajax might not be the expected result so ideally can be used to test
+	 * if you are on the front page on first load of the page only.
 	 *
 	 * @since TBD
+	 *
 	 * @return bool
 	 */
 	function tribe_is_events_front_page() {
@@ -1692,11 +1699,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Utility function to test if we are on the home of events, it makes test the case when the page is set to be on
-	 * the frontpage of the site and if the user is on that page is on the homepage or if the user is on the events page
+	 * Test if we are on the home of events either if is set to frontpage or the default /events page.
+	 *
+	 * Utility function to test if we are on the home of events, it makes a test in cases when the page is set to be on
+	 * the frontpage of the site and if the User is on that page is on the homepage or if the User is on the events page
 	 * where the eventDisplay is set to default.
 	 *
+	 * Also consider this might not work as expected inside of Ajax Calls as this one is fired on initial loading of the
+	 * page so be aware of unexpected results via Ajax calls.
+	 *
 	 * @since TBD
+	 *
 	 * @return bool
 	 */
 	function tribe_is_events_home() {


### PR DESCRIPTION
Add `tribe_is_home_events` function similar to `is_home` in WP to test if we are on the homepage of the events.

See Ticket: https://central.tri.be/issues/42195