### PR TITLE
Filter events if we are on a category

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -334,6 +334,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * Remove any event that is not the same as the current term of the array of events, it return a modified events
 		 * array with the events that only has the current term or original events if the term is not valid.
 		 *
+		 * @since TBD
  		 * @param array
 		 * @return array
 		 */

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -284,13 +284,18 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 		 * @return void
 		 */
 		public function json_ld_markup() {
+
 			if ( ! $this->use_cache ) {
 				$this->produce_json_ld_markup( true );
 				return;
 			}
 
 			$cache     = new Tribe__Cache();
-			$cache_key = $this->get_month_view_cache_key( 'events_month_jsonld' );
+			$prefix = 'events_month_jsonld';
+			if ( tribe_is_event_category() ) {
+				$prefix = sprintf( 'events_cat_%d_month_jsonld', get_queried_object_id() );
+			}
+			$cache_key = $this->get_month_view_cache_key( $prefix );
 			$json_ld   = $cache->get_transient( $cache_key, 'save_post' );
 
 			if ( ! $json_ld ) {
@@ -314,11 +319,39 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			$events = wp_list_pluck( $this->events_in_month, 'ID' );
+			if ( tribe_is_event_category() ) {
+				$events = $this->filter_by_current_term( $events );
+			}
+
 			Tribe__Events__JSON_LD__Event::instance()->markup( $events );
 
 			if ( ! $echo ) {
 				return ob_get_clean();
 			}
+		}
+
+		/**
+		 * Remove any event that is not the same as the current term of the array of events, it return a modified events
+		 * array with the events that only has the current term or original events if the term is not valid.
+		 *
+ 		 * @param array
+		 * @return array
+		 */
+		private function filter_by_current_term( $events ) {
+			$taxonomy = get_query_var( 'taxonomy' );
+			$current_term = get_term_by( 'id', get_queried_object_id(), $taxonomy );
+
+			// get_term_by returns false if term does not exists or on failure.
+			if ( false === $current_term ) {
+				return $events;
+			}
+
+			foreach ( (array) $events as $key => $event_id ) {
+				if ( ! has_term( $current_term->term_id, $taxonomy, $event_id ) ) {
+					unset( $events[ $key ] );
+				}
+			}
+			return $events;
 		}
 
 		/**


### PR DESCRIPTION
This will allow to have only events that are part of the current term
inside of the the list of events to avoid render extra events that are
not part of the same category.

See https://central.tri.be/issues/80551