### PR TITLE
Enable translation of iCal calendar description

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -420,7 +420,7 @@ class Tribe__Events__iCal {
 
 		$content .= 'X-WR-CALNAME:' . $x_wr_calname . "\r\n";
 		$content .= 'X-ORIGINAL-URL:' . $blogHome . "\r\n";
-		$content .= 'X-WR-CALDESC:Events for ' . $blogName . "\r\n";
+		$content .= 'X-WR-CALDESC:' . esc_html__( 'Events for ', 'the-events-calendar' ) . $blogName . "\r\n";
 
 		/**
 		 * Allows for customization of the various properties at the top of the generated iCal file.

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -420,7 +420,7 @@ class Tribe__Events__iCal {
 
 		$content .= 'X-WR-CALNAME:' . $x_wr_calname . "\r\n";
 		$content .= 'X-ORIGINAL-URL:' . $blogHome . "\r\n";
-		$content .= 'X-WR-CALDESC:' . esc_html__( 'Events for ', 'the-events-calendar' ) . $blogName . "\r\n";
+		$content .= 'X-WR-CALDESC:' . sprintf( esc_html_x( 'Events for %s', 'iCal feed description', 'the-events-calendar' ), $blogname ) . "\r\n";
 
 		/**
 		 * Allows for customization of the various properties at the top of the generated iCal file.


### PR DESCRIPTION
# Issue
The calendar description in a generated iCal feed is not translated.

# Details
The translation is not used.

# Proposed solutions
Use esc_html__ to enable translation of the description.