### PR TITLE
Prevent errors on empty iCal

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -403,6 +403,7 @@ class Tribe__Events__iCal {
 		 */
 		$filename = apply_filters( 'tribe_events_ical_feed_filename', $site . '-' . $hash . '.ics', $post );
 
+		header( 'HTTP/1.0 200 OK', true, 200 );
 		header( 'Content-type: text/calendar; charset=UTF-8' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 		$content  = "BEGIN:VCALENDAR\r\n";


### PR DESCRIPTION
Due the WP Query was having empty elements it was causing a header other
that a 200 which was creating an issue during the download of the file,
making sure we always have a 200 even if the file is empty allows the
correct download of the file even if is empty.

See: https://central.tri.be/issues/84394