### PR TITLE
Make sure to set is_home if we are on the front page

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -169,7 +169,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				&& true === get_query_var( 'tribe_events_front_page' )
 			) {
 				$query->is_home = true;
-			} else if ( $query->tribe_is_event_query ) {
+			} elseif ( $query->tribe_is_event_query ) {
 				// fixing is_home param
 				$query->is_home = empty( $query->query_vars['is_home'] ) ? false : $query->query_vars['is_home'];
 				do_action( 'tribe_events_parse_query', $query );

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			// never allow 404 on month view
 			if (
 				$query->is_main_query()
-				&& $query->get( 'eventDisplay' ) == 'month'
+				&& 'month' === $query->get( 'eventDisplay' )
 				&& ! $query->is_tax
 				&& ! $query->tribe_is_event_category
 			) {

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -160,7 +160,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$query->queried_object_id    = 0;
 			}
 
-			$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
 			if ( tribe_is_events_front_page() ) {
 				$query->is_home = true;
 			} elseif ( $query->tribe_is_event_query ) {

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -149,16 +149,29 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			// never allow 404 on month view
-			if ( $query->is_main_query() && $query->get( 'eventDisplay' ) == 'month' && ! $query->is_tax && ! $query->tribe_is_event_category ) {
+			if (
+				$query->is_main_query()
+				&& $query->get( 'eventDisplay' ) == 'month'
+				&& ! $query->is_tax
+				&& ! $query->tribe_is_event_category
+			) {
 				$query->is_post_type_archive = true;
 				$query->queried_object       = get_post_type_object( Tribe__Events__Main::POSTTYPE );
 				$query->queried_object_id    = 0;
 			}
 
-			// check if is_event_query === true and hook filter
-			if ( $query->tribe_is_event_query ) {
+			$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
+			// TODO: Replace with new utility function tribe_is_event_front_page();
+			if (
+				$query->is_main_query()
+				&& $events_as_front_page
+				&& $query->tribe_is_event
+				&& true === get_query_var( 'tribe_events_front_page' )
+			) {
+				$query->is_home = true;
+			} else if ( $query->tribe_is_event_query ) {
 				// fixing is_home param
-				$query->is_home = ! empty( $query->query_vars['is_home'] ) ? $query->query_vars['is_home'] : false;
+				$query->is_home = empty( $query->query_vars['is_home'] ) ? false : $query->query_vars['is_home'];
 				do_action( 'tribe_events_parse_query', $query );
 			}
 		}

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -161,13 +161,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
-			// TODO: Replace with new utility function tribe_is_event_front_page();
-			if (
-				$query->is_main_query()
-				&& $events_as_front_page
-				&& $query->tribe_is_event
-				&& true === get_query_var( 'tribe_events_front_page' )
-			) {
+			if ( tribe_is_events_front_page() ) {
 				$query->is_home = true;
 			} elseif ( $query->tribe_is_event_query ) {
 				// fixing is_home param


### PR DESCRIPTION
In order to prevent any 404 error code we need to set `is_home` to `true` if.
we are on the front page, which means the main reading settings are set
to display a page that is displaying an events page, this should turn:

- `is_home`
- `is_front_page`

To `true`.

See: https://central.tri.be/issues/90001