### PR TITLE
Make sure the Map options are present on save venue

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3201,7 +3201,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$data = wp_parse_args( (array) $data, array(
 				'ShowMap' => 'false',
 				'ShowMapLink' => 'false',
-			));
+			) );
 			Tribe__Events__API::updateVenue( $postID, $data );
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3192,6 +3192,16 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			$data = stripslashes_deep( $_POST['venue'] );
+			/**
+			 * When a new venue is saved set the value for ShowMap and ShowMapLink if they are not present as if
+			 * a checkbox is set to false $_POST is not going to send the value and is not going to be present inside
+			 * of the array. This action is fired on update or creation from the admin so it's not goint to affect
+			 * external components like Community Plugin.
+			 */
+			$data = wp_parse_args( (array) $data, array(
+				'ShowMap' => 'false',
+				'ShowMapLink' => 'false',
+			));
 			Tribe__Events__API::updateVenue( $postID, $data );
 		}
 

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -422,16 +422,29 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 				? wp_insert_post( array_filter( $postdata ), true )
 				: $found;
 
+			/**
+			 * Filters the default value to be set on the creation of a new venue.
+			 *
+			 * Useful as this might be fired or required by a third party plugin like community events that would like
+			 * to change the default value for the map fields.
+			 *
+			 * @param mixed $default_value    The default value to be applied on creation.
+			 *
+			 * @since TBD
+			 */
+			$default_value = apply_filters( 'tribe_events_venue_created_map_default', true );
+
 			// By default, the show map and show map link options should be on
 			if ( isset( $data['ShowMap'] ) && ! tribe_is_truthy( $data['ShowMap'] ) ) {
 				unset( $data['ShowMap'] );
 			} else {
-				$data['ShowMap'] = true;
+				$data['ShowMap'] = $default_value;
 			}
+
 			if ( isset( $data['ShowMapLink'] ) && ! tribe_is_truthy( $data['ShowMapLink'] ) ) {
 				unset( $data['ShowMapLink'] );
 			} else {
-				$data['ShowMapLink'] = true;
+				$data['ShowMapLink'] = $default_value;
 			}
 
 			if ( ! is_wp_error( $venue_id ) ) {


### PR DESCRIPTION
This will ensure the options for the map are always present when a venue is saved in order to allow the option to set
them to false if that's the case from the admin panel as they are not present inside of the `$_POST` request if the
checkbox are set to `false`.

It adds a new filter as well `tribe_events_venue_created_map_default` that will allow the community events the option
to fix a bug when `tribe_events_community_apply_map_defaults` is set to `false`.

[Central](https://central.tri.be/issues/91869)