### PR TITLE
For past events use current date instead of end of day

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,9 +312,10 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 * New - Introduced the `tribe_events_query_force_local_tz` filter to allow for forcing non-UTC event start and end times in Tribe__Events__Query [92948]
 * Fix - Allow The Events Calendar REST API to be disabled using the `tribe_events_rest_api_enabled` filter [97209]
-* Tweak - Added some more context to the labeling of the "Number of events per page" option (thanks to Todd H. for highlighting this label) [73659] 
+* Tweak - Added some more context to the labeling of the "Number of events per page" option (thanks to Todd H. for highlighting this label) [73659]
 * Tweak - Improve performance on Event Admin List Count by removing JOIN and use cached results [63567]
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
+* Fix - Make sure the date for past events is set to the current date not the end of the day of the current date [71936]
 
 = [4.6.9] 2018-01-10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 = [4.6.10] TBD =
 
+* New - Made the "events" and "event" slugs translatable by WPML and other multilingual plugins [95026]
 * New - Introduced the `tribe_events_query_force_local_tz` filter to allow for forcing non-UTC event start and end times in Tribe__Events__Query [92948]
 * Fix - Allow The Events Calendar REST API to be disabled using the `tribe_events_rest_api_enabled` filter [97209]
 * Tweak - Added some more context to the labeling of the "Number of events per page" option (thanks to Todd H. for highlighting this label) [73659]
@@ -317,6 +318,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Tweak - Improve performance on Event Admin List Count by removing JOIN and use cached results [63567]
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
 * Fix - Make sure the date for past events is set to the current date not the end of the day of the current date [71936]
+* Tweak - Button "Merge Duplicates" is always visible from now on [75208]
 
 = [4.6.9] 2018-01-10 =
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -304,7 +304,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 							} else {
 								// on past view, set the passed date as the end date
 								$query->set( 'start_date', '' );
-								$query->set( 'end_date', tribe_end_of_day( $event_date ) );
+								$query->set( 'end_date', $event_date );
 								$query->set( 'order', self::set_order( 'DESC', $query ) );
 							}
 							$query->set( 'orderby', self::set_orderby( null, $query ) );


### PR DESCRIPTION
For any event that is past on the list view we should consider the end
of the event as the current date instead of the current end of the day
as will wrap events of today in the past.

See: https://central.tri.be/issues/71936