### PR TITLE
Allow the usage of `featured_color_scheme_custom` if present

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -312,9 +312,10 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 * New - Introduced the `tribe_events_query_force_local_tz` filter to allow for forcing non-UTC event start and end times in Tribe__Events__Query [92948]
 * Fix - Allow The Events Calendar REST API to be disabled using the `tribe_events_rest_api_enabled` filter [97209]
-* Tweak - Added some more context to the labeling of the "Number of events per page" option (thanks to Todd H. for highlighting this label) [73659] 
+* Tweak - Added some more context to the labeling of the "Number of events per page" option (thanks to Todd H. for highlighting this label) [73659]
 * Tweak - Improve performance on Event Admin List Count by removing JOIN and use cached results [63567]
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
+* Fix - Use `featured_color_scheme_custom` if present as mechanism to overwrite the default color scheme for highlight color [96821]
 
 = [4.6.9] 2018-01-10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -318,6 +318,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Tweak - Improve performance on Event Admin List Count by removing JOIN and use cached results [63567]
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
 * Fix - Use `featured_color_scheme_custom` if present as mechanism to overwrite the default color scheme for highlight color [96821]
+* Tweak - Button "Merge Duplicates" is always visible from now on [75208]
 
 = [4.6.9] 2018-01-10 =
 

--- a/src/Tribe/Amalgamator.php
+++ b/src/Tribe/Amalgamator.php
@@ -32,7 +32,6 @@ class Tribe__Events__Amalgamator {
 		$this->merge_identical_venues();
 
 		$events = Tribe__Events__Main::instance();
-		$events->setOption( 'organizer_venue_amalgamation', 1 );
 		wp_cache_flush();
 	}
 

--- a/src/Tribe/Customizer/General_Theme.php
+++ b/src/Tribe/Customizer/General_Theme.php
@@ -121,36 +121,42 @@ final class Tribe__Events__Customizer__General_Theme extends Tribe__Customizer__
 		}
 
 		if ( $customizer->has_option( $this->ID, 'featured_color_scheme' ) ) {
-			$template .= '
+			$featured_bg = '<%= general_theme.button_bg %>';
+
+			if ( $customizer->has_option( $this->ID, 'featured_color_scheme_custom' ) ) {
+				$featured_bg = '<%= general_theme.featured_color_scheme_custom %>';
+			}
+
+			$template .= "
 				.tribe-events-list .tribe-events-loop .tribe-event-featured,
 				.tribe-events-list #tribe-events-day.tribe-events-loop .tribe-event-featured,
 				.type-tribe_events.tribe-events-photo-event.tribe-event-featured .tribe-events-photo-event-wrap,
 				.type-tribe_events.tribe-events-photo-event.tribe-event-featured .tribe-events-photo-event-wrap:hover {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				#tribe-events-content table.tribe-events-calendar .type-tribe_events.tribe-event-featured {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-events-list-widget .tribe-event-featured,
 				.tribe-events-venue-widget .tribe-event-featured,
 				.tribe-mini-calendar-list-wrapper .tribe-event-featured,
 				.tribe-events-adv-list-widget .tribe-event-featured .tribe-mini-calendar-event {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-grid-body .tribe-event-featured.tribe-events-week-hourly-single {
 					background-color: rgba(<%= general_theme.button_bg_hex_red %>,<%= general_theme.button_bg_hex_green %>,<%= general_theme.button_bg_hex_blue %>, .7 );
-					border-color: <%= general_theme.button_bg %>;
+					border-color: {$featured_bg};
 				}
 
 				.tribe-grid-body .tribe-event-featured.tribe-events-week-hourly-single:hover {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-button {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 					color: <%= general_theme.button_color %>;
 				}
 
@@ -163,7 +169,7 @@ final class Tribe__Events__Customizer__General_Theme extends Tribe__Customizer__
 				#tribe-events .tribe-event-featured .tribe-button:hover {
 					color: <%= general_theme.button_color_hover %>;
 				}
-			';
+			";
 
 			if ( $background_color_obj->isLight() ) {
 				$template .= '

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -159,7 +159,6 @@ $general_tab_fields = Tribe__Main::array_insert_before_key(
 		'amalgamateDuplicates'          => array(
 			'type'        => 'html',
 			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'Duplicate Venues &amp; Organizers', 'the-events-calendar' ) . '</legend><div class="tribe-field-wrap">' . Tribe__Events__Amalgamator::migration_button( esc_html__( 'Merge Duplicates', 'the-events-calendar' ) ) . '<p class="tribe-field-indent description">' . esc_html__( 'You might find duplicate venues and organizers when updating The Events Calendar from a pre-3.0 version. Click this button to automatically merge identical venues and organizers.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
-			'conditional' => ( Tribe__Settings_Manager::get_option( 'organizer_venue_amalgamation', 0 ) < 1 ),
 		),
 		'tribeEventsMiscellaneousTitle' => array(
 			'type' => 'html',


### PR DESCRIPTION
This change allows the usage of `featured_color_scheme_custom` over `featured_color_scheme` if present, this will use the
color selected by the user instead of the default color scheme.

See https://central.tri.be/issues/96821