### PR TITLE
Plugin path will have trailing slash already

### DIFF
--- a/src/Tribe/Integrations/WPML/Defaults.php
+++ b/src/Tribe/Integrations/WPML/Defaults.php
@@ -93,7 +93,7 @@ class Tribe__Events__Integrations__WPML__Defaults {
 	 * @return string
 	 */
 	protected function get_config_file_path() {
-		return Tribe__Events__Main::instance()->pluginPath . DIRECTORY_SEPARATOR . 'wpml-config.xml';
+		return Tribe__Events__Main::instance()->pluginPath . 'wpml-config.xml';
 	}
 
 	/**


### PR DESCRIPTION
Avoids creating a path with a double slash (plugin path is passed through `trailingslashit()` in `Tribe__Events__Main::__construct()`).