### PR TITLE
Merge Duplicates button is always visible

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -317,6 +317,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Fix - Remove the errant `div.tribe-events-single-section` on the single event view when there is no venue [97615]
 * Tweak - Improve performance on Event Admin List Count by removing JOIN and use cached results [63567]
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
+* Tweak - Button "Merge Duplicates" is always visible from now on [75208]
 
 = [4.6.9] 2018-01-10 =
 

--- a/src/Tribe/Amalgamator.php
+++ b/src/Tribe/Amalgamator.php
@@ -32,7 +32,6 @@ class Tribe__Events__Amalgamator {
 		$this->merge_identical_venues();
 
 		$events = Tribe__Events__Main::instance();
-		$events->setOption( 'organizer_venue_amalgamation', 1 );
 		wp_cache_flush();
 	}
 

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -159,7 +159,6 @@ $general_tab_fields = Tribe__Main::array_insert_before_key(
 		'amalgamateDuplicates'          => array(
 			'type'        => 'html',
 			'html'        => '<fieldset class="tribe-field tribe-field-html"><legend>' . esc_html__( 'Duplicate Venues &amp; Organizers', 'the-events-calendar' ) . '</legend><div class="tribe-field-wrap">' . Tribe__Events__Amalgamator::migration_button( esc_html__( 'Merge Duplicates', 'the-events-calendar' ) ) . '<p class="tribe-field-indent description">' . esc_html__( 'You might find duplicate venues and organizers when updating The Events Calendar from a pre-3.0 version. Click this button to automatically merge identical venues and organizers.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
-			'conditional' => ( Tribe__Settings_Manager::get_option( 'organizer_venue_amalgamation', 0 ) < 1 ),
 		),
 		'tribeEventsMiscellaneousTitle' => array(
 			'type' => 'html',


### PR DESCRIPTION
Remove option value not required on the conditional in favor of the default `true` that will show the field all the time.

See https://central.tri.be/issues/75208