### PR TITLE
Apply `the_title` filter to each event title

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 = [4.6.10] TBD =
 
+* New - Add `the_title` filter to events called by `tribe_events_template_data` [38237]
 * New - Made the "events" and "event" slugs translatable by WPML and other multilingual plugins [95026]
 * New - Introduced the `tribe_events_query_force_local_tz` filter to allow for forcing non-UTC event start and end times in Tribe__Events__Query [92948]
 * Fix - Allow The Events Calendar REST API to be disabled using the `tribe_events_rest_api_enabled` filter [97209]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1165,7 +1165,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 				$category_classes = tribe_events_event_classes( $event->ID, false );
 
 				$json['eventId']         = $event->ID;
-				$json['title']           = wp_kses_post( $event->post_title );
+				$json['title']           = wp_kses_post( apply_filters( 'the_title', $event->post_title, $event->ID ) );
 				$json['permalink']       = tribe_get_event_link( $event->ID );
 				$json['imageSrc']        = $image_src;
 				$json['dateDisplay']     = $date_display;


### PR DESCRIPTION
Allow to filter the title of the events generated by
`tribe_events_template_data()`

See https://central.tri.be/issues/38237