### PR TITLE
Allow the usage of `featured_color_scheme_custom`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -319,6 +319,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Tweak - Made the "/page/" component of some views' URL string translatable [40976]
 * Fix - Make sure the date for past events is set to the current date not the end of the day of the current date [71936]
 * Tweak - Button "Merge Duplicates" is always visible from now on [75208]
+* Fix - Use `featured_color_scheme_custom` if present as mechanism to overwrite the default color scheme for highlight color [96821]
 
 = [4.6.9] 2018-01-10 =
 

--- a/src/Tribe/Customizer/General_Theme.php
+++ b/src/Tribe/Customizer/General_Theme.php
@@ -121,36 +121,42 @@ final class Tribe__Events__Customizer__General_Theme extends Tribe__Customizer__
 		}
 
 		if ( $customizer->has_option( $this->ID, 'featured_color_scheme' ) ) {
-			$template .= '
+			$featured_bg = '<%= general_theme.button_bg %>';
+
+			if ( $customizer->has_option( $this->ID, 'featured_color_scheme_custom' ) ) {
+				$featured_bg = '<%= general_theme.featured_color_scheme_custom %>';
+			}
+
+			$template .= "
 				.tribe-events-list .tribe-events-loop .tribe-event-featured,
 				.tribe-events-list #tribe-events-day.tribe-events-loop .tribe-event-featured,
 				.type-tribe_events.tribe-events-photo-event.tribe-event-featured .tribe-events-photo-event-wrap,
 				.type-tribe_events.tribe-events-photo-event.tribe-event-featured .tribe-events-photo-event-wrap:hover {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				#tribe-events-content table.tribe-events-calendar .type-tribe_events.tribe-event-featured {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-events-list-widget .tribe-event-featured,
 				.tribe-events-venue-widget .tribe-event-featured,
 				.tribe-mini-calendar-list-wrapper .tribe-event-featured,
 				.tribe-events-adv-list-widget .tribe-event-featured .tribe-mini-calendar-event {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-grid-body .tribe-event-featured.tribe-events-week-hourly-single {
 					background-color: rgba(<%= general_theme.button_bg_hex_red %>,<%= general_theme.button_bg_hex_green %>,<%= general_theme.button_bg_hex_blue %>, .7 );
-					border-color: <%= general_theme.button_bg %>;
+					border-color: {$featured_bg};
 				}
 
 				.tribe-grid-body .tribe-event-featured.tribe-events-week-hourly-single:hover {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 				}
 
 				.tribe-button {
-					background-color: <%= general_theme.button_bg %>;
+					background-color: {$featured_bg};
 					color: <%= general_theme.button_color %>;
 				}
 
@@ -163,7 +169,7 @@ final class Tribe__Events__Customizer__General_Theme extends Tribe__Customizer__
 				#tribe-events .tribe-event-featured .tribe-button:hover {
 					color: <%= general_theme.button_color_hover %>;
 				}
-			';
+			";
 
 			if ( $background_color_obj->isLight() ) {
 				$template .= '


### PR DESCRIPTION
If present, this will use the color selected by the user instead of the default color scheme.

See https://central.tri.be/issues/96821