### PR TITLE
Make sure the `/events` page is not hardcoded

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -309,7 +309,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 == Changelog ==
 
 = [4.6.10.1] 2018-01-25 =
-* Fix - Make sure rewrite rule for `/events` is not hardcoded and is based on dynamic option field [98463]
+* Fix - Make sure rewrite rule for `/events` is not hardcoded and is based on dynamic option field (thanks to @earnjam and others for flagging this problem) [98463]
 
 = [4.6.10] 2018-01-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -309,8 +309,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 == Changelog ==
 
 = [4.6.10.1] 2018-01-25 =
-
-
+* Fix - Make sure rewrite rule for `/events` is not hardcoded and is based on dynamic option field [98463]
 
 = [4.6.10] 2018-01-23 =
 

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -255,10 +255,11 @@ class Tribe__Events__Rewrite extends  Tribe__Rewrite {
 			'tag' => array( 'tag', $tec->tag_slug ),
 			'tax' => array( 'category', $tec->category_slug ),
 			'page'     => array( 'page', esc_html_x( 'page', 'The "/page/" URL string component.', 'the-events-calendar' ) ),
-			'single' => array( 'event', $tec->rewriteSlugSingular ),
-			'archive' => array( 'events', $tec->rewriteSlug ),
+			'single' => array( Tribe__Settings_Manager::get_option( 'singleEventSlug', 'event' ), $tec->rewriteSlugSingular ),
+			'archive' => array( Tribe__Settings_Manager::get_option( 'eventsSlug', 'events' ), $tec->rewriteSlug ),
 			'featured' => array( 'featured', $tec->featured_slug ),
 		) );
+
 
 		// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)
 		$bases = array_map( 'array_unique', $bases );

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -245,6 +245,13 @@ class Tribe__Events__Rewrite extends  Tribe__Rewrite {
 		 * way if the forms are altered (whether through i18n or other custom mods) *after* links
 		 * have already been promulgated, there will be less chance of visitors hitting 404s.
 		 *
+		 * The term "original" here for:
+		 * - events
+		 * - event
+		 *
+		 * Means that is a value that can be overwritten and relies on the user value entered on the
+		 * options page.
+		 *
 		 * @var array $bases
 		 */
 		$bases = apply_filters( 'tribe_events_rewrite_base_slugs', array(


### PR DESCRIPTION
🎟  https://central.tri.be/issues/98463
The URL might change due a different slug based on the options page,
make sure this URL is not hardcoded.