### PR TITLE
Making sure that wp_query is not empty to prevent potential fatals from occurring

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1691,7 +1691,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
 		// If the reading option has an events page as front page and we are on that page is on the home of events.
 		return (
-			!empty($wp_query)
+			! empty( $wp_query )
 			&& $wp_query->is_main_query()
 			&& $events_as_front_page
 			&& $wp_query->tribe_is_event

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1691,7 +1691,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
 		// If the reading option has an events page as front page and we are on that page is on the home of events.
 		return (
-			$wp_query->is_main_query()
+			!empty($wp_query)
+			&& $wp_query->is_main_query()
 			&& $events_as_front_page
 			&& $wp_query->tribe_is_event
 			&& true === get_query_var( 'tribe_events_front_page' )


### PR DESCRIPTION
I keep getting a fatal when using this plugin from this file. Adding a check to make sure that the object is not empty before actually attempting to use