### PR TITLE
spotfix | $beginning_of_day should be midnight, not 1 sec after

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -287,7 +287,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 						case 'day':
 							$event_date = $query->get( 'eventDate' ) != '' ? $query->get( 'eventDate' ) : date( 'Y-m-d', current_time( 'timestamp' ) );
 							$query->set( 'eventDate', $event_date );
-							$beginning_of_day = strtotime( tribe_beginning_of_day( $event_date ) ) + 1;
+							$beginning_of_day = strtotime( tribe_beginning_of_day( $event_date ) );
 							$query->set( 'start_date', date_i18n( Tribe__Date_Utils::DBDATETIMEFORMAT, $beginning_of_day ) );
 							$query->set( 'end_date', tribe_end_of_day( $event_date ) );
 							$query->set( 'posts_per_page', - 1 ); // show ALL day posts


### PR DESCRIPTION
`00:00:00` is the beginning of the day, not `00:00:01`

Note that this makes it the same as Month View's logic a few lines above