### PR TITLE
Prevent errors during the generation of the columns

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 = [4.6.12] TBD =
 
+* Fix - Prevent error on the admin during the generation of the columns [99266]
 * Tweak - Rename 'Use Javascript to control date filtering' option to 'Enable live refresh' and modify explanatory copy [98022]
 
 = [4.6.11] 2018-02-14 =

--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -295,8 +295,14 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 		public static function custom_columns( $column_id, $post_id ) {
 			switch ( $column_id ) {
 				case 'events-cats':
-					$event_cats = get_the_term_list( $post_id, Tribe__Events__Main::TAXONOMY, '', ', ', '' );
-					echo ( $event_cats ) ? strip_tags( $event_cats ) : '—';
+					$event_cats = wp_get_post_terms( $post_id, Tribe__Events__Main::TAXONOMY, array(
+						'fields' => 'names',
+					) );
+					$categories_list = '-';
+					if ( is_array( $event_cats ) ) {
+						$categories_list = implode( ', ', $event_cats );
+					}
+					echo $categories_list;
 				break;
 
 				case 'start-date':

--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -302,7 +302,7 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 					if ( is_array( $event_cats ) ) {
 						$categories_list = implode( ', ', $event_cats );
 					}
-					echo $categories_list;
+					echo esc_html( $categories_list );
 				break;
 
 				case 'start-date':


### PR DESCRIPTION
**Ticket** https://central.tri.be/issues/99266

Make sure columns are generated without error, and prevent the PHP
notice: "Trying to get property of non-object".