### PR TITLE
Fix redirection on mobile if Yoast is active

### DIFF
--- a/src/resources/js/tribe-events.js
+++ b/src/resources/js/tribe-events.js
@@ -776,10 +776,7 @@ Date.prototype.format = function( mask, utc ) {
 				! tribe_ev.state.view ||
 
 				// We are on the default mobile view
-				tribe_ev.data.default_mobile_view == tribe_ev.state.view ||
-
-				// We are with an defined view
-				tribe_ev.data.cur_url == tribe_ev.data.base_url
+				tribe_ev.data.default_mobile_view == tribe_ev.state.view
 			) {
 				return false;
 			}
@@ -1375,7 +1372,9 @@ Date.prototype.format = function( mask, utc ) {
 
 			var $header = $( document.getElementById( 'tribe-events-header' ) );
 			var $canonical = $( 'link[rel="canonical"]' );
+			$canonical = [];
 			var url = null;
+
 
 			if ( $canonical.length ) {
 				// use the canonical URL if it is available (it should be)


### PR DESCRIPTION
In this particular case if Yoast is active it will create a conflict as Yoast will setup a caninical URL that might be the same as the current URL in which case the conditions will return early.

Under that scenario this condition is not required as is a false positive and not only Yoast can set this attribute it can be set by the author or any other plugin, in which case the conditions above and below ensure the proper redirection if current URL and base URL are different.