### PR TITLE
Honor the return type on defined filters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -313,7 +313,8 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Fix - Add version parameter to _doing_it_wrong to prevent PHP notices in date utils (props to @sharewisdom for pointing this out) [99117]
 * Fix - Prevent error on the admin during the generation of the columns [99266]
 * Fix - If the canonical attribute is set on the page make sure does not affect the redirection on mobile if desktop view is different from mobile [68716]
-* Fix - Ensure "Main Events Page" exists as an option in the dropdown menu of available static front pages in the Customizer's "Homepage Settings" screen [97978] 
+* Fix - Ensure "Main Events Page" exists as an option in the dropdown menu of available static front pages in the Customizer's "Homepage Settings" screen [97978]
+* Fix - When a protected event is created make sure the tooltip does not create any console error [99089]
 * Tweak - Rename 'Use Javascript to control date filtering' option to 'Enable live refresh' and modify explanatory copy [98022]
 * Tweak - Prevent the `tribe_get_prev_event_link()` and `tribe_get_next_event_link()` queries from running more times than necessary on single-event views, which improves performance [94587]
 

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -464,19 +464,19 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 	 **/
 	public function manage_sensitive_info( $post ) {
 		if ( post_password_required( $post ) ) {
-			add_filter( 'tribe_events_event_schedule_details', '__return_null' );
-			add_filter( 'tribe_events_recurrence_tooltip', '__return_null' );
-			add_filter( 'tribe_event_meta_venue_name', '__return_null' );
-			add_filter( 'tribe_event_meta_venue_address', '__return_null' );
-			add_filter( 'tribe_event_featured_image', '__return_null' );
-			add_filter( 'tribe_get_venue', '__return_null' );
+			add_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
+			add_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
+			add_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
+			add_filter( 'tribe_event_meta_venue_address', '__return_empty_string' );
+			add_filter( 'tribe_event_featured_image', '__return_empty_string' );
+			add_filter( 'tribe_get_venue', '__return_empty_string' );
 		} else {
-			remove_filter( 'tribe_events_event_schedule_details', '__return_null' );
-			remove_filter( 'tribe_events_recurrence_tooltip', '__return_null' );
-			remove_filter( 'tribe_event_meta_venue_name', '__return_null' );
-			remove_filter( 'tribe_event_meta_venue_address', '__return_null' );
-			remove_filter( 'tribe_event_featured_image', '__return_null' );
-			remove_filter( 'tribe_get_venue', '__return_null' );
+			remove_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
+			remove_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
+			remove_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
+			remove_filter( 'tribe_event_meta_venue_address', '__return_empty_string' );
+			remove_filter( 'tribe_event_featured_image', '__return_empty_string' );
+			remove_filter( 'tribe_get_venue', '__return_empty_string' );
 		}
 	}
 


### PR DESCRIPTION
**Ticket** https://central.tri.be/issues/99089

Make sure that return type on original functions are honored based on
docblock to create objects specially on JS as `null` is different from
empty string.