### PR TITLE
100914 Remove Unnecessary tribe_get_start|end_date() Calls in Month View

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -311,7 +311,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 = [M18.05] TBD =
 
 * Fix - Save order of organizers as displayed in the admin (thanks to JobInfo and others for report) [79126]
-
+* Tweak - Remove some unnecessary calls of `tribe_get_start_date()` and `tribe_get_end_date()` from the Month View [100914]
 
 = [4.6.12] TBD =
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -716,15 +716,16 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 						}
 					}
 
-					$event_start = strtotime( tribe_get_start_date( $event->ID, true, Tribe__Date_Utils::DBDATETIMEFORMAT ) );
-					$event_end   = strtotime( tribe_get_end_date( $event->ID, true, Tribe__Date_Utils::DBDATETIMEFORMAT ) );
+					$event_start = strtotime( $event->EventStartDate );
+					$event_end   = strtotime( $event->EventEndDate );
+
 					$order = get_post_field( 'menu_order', $event->ID );
 
 					// Builds the Index to allow a better ordering of events
 					$order_index = $order . ':' . $event_start . ':' . $event->ID;
 
 					$start = date( 'Y-m-d', $event_start );
-					$end = date( 'Y-m-d', $event_end );
+					$end   = date( 'Y-m-d', $event_end );
 
 					$beginning_of_start           = $this->get_cutoff_details( $start, 'beginning' );
 					$beginning_of_start_timestamp = $this->get_cutoff_details( $start, 'beginning_timestamp' );


### PR DESCRIPTION
**Ticket:** [**#100914**](http://central.tri.be/issues/100914)

**Code Review Note:** There are not "props" for this ticket.