### PR TITLE
Fix empty string used as event start date when generating adjacent links

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -311,6 +311,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 = [4.6.13] TBD =
 
 * Tweak - Added Gutenberg compatibility for the Extension
+* Fix - Prevent Adjacent Events links failing due to wrong meta key been used (props to @jeremyfelt for fixing this) [101757]
 
 = [4.6.12] 2018-03-08 =
 

--- a/src/Tribe/Adjacent_Events.php
+++ b/src/Tribe/Adjacent_Events.php
@@ -216,7 +216,7 @@ class Tribe__Events__Adjacent_Events {
 			'meta_query'     => array(
 				array(
 					'key'     => '_EventStartDate',
-					'value'   => $post_obj->EventStartDate,
+					'value'   => $post_obj->_EventStartDate,
 					'type'    => 'DATETIME',
 					'compare' => $direction,
 				),


### PR DESCRIPTION
**Ticket:** [**#101757**](http://central.tri.be/issues/101757)

---
When building the query used to lookup adjacent links, it appears that an empty string is always used for the `_EventStartDate` value and unexpected events are used in the previous/next links
on single event pages.

When `$post_obj->EventStartDate` is called, post meta is checked for a meta key that does not exist. Adjusting this to the correct meta key, `$post_obj->_EventStartDate` provides a correct date and results in properly generated links.

The README mentions a `develop` branch, but I don't see on on this repo. I took a guess that this is the development branch for the upcoming release. Let me know if I should submit the PR against something else.