### PR TITLE
Fix warning in redirect_past_upcoming_view_urls()

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2416,7 +2416,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// Prep strings so we can compare paths sans any leading/trailing slashes
-			$requested_path = trim( $requested_path, '/' );
+			$requested_path['path'] = trim( $requested_path, '/' );
 			$legacy_past_events_url = $this->getRewriteSlug() . '/' . $this->pastSlug;
 			$legacy_upcoming_events_url = $this->getRewriteSlug() . '/' . $this->upcomingSlug;
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -548,7 +548,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			add_filter( 'nav_menu_items_' . self::POSTTYPE, array( $this, 'add_events_checkbox_to_menu' ), null, 3 );
 			add_filter( 'wp_nav_menu_objects', array( $this, 'add_current_menu_item_class_to_events' ), null, 2 );
 
-			add_filter( 'template_redirect', array( $this, 'redirect_past_upcoming_view_urls' ), 9 );
+			add_action( 'template_redirect', array( $this, 'redirect_past_upcoming_view_urls' ), 9 );
 
 			/* Setup Tribe Events Bar */
 			add_filter( 'tribe-events-bar-views', array( $this, 'setup_listview_in_bar' ), 1, 1 );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2416,7 +2416,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// Prep strings so we can compare paths sans any leading/trailing slashes
-			$requested_path['path'] = trim( $requested_path, '/' );
+			$requested_path         = trim( $requested_path['path'], '/' );
 			$legacy_past_events_url = $this->getRewriteSlug() . '/' . $this->pastSlug;
 			$legacy_upcoming_events_url = $this->getRewriteSlug() . '/' . $this->upcomingSlug;
 


### PR DESCRIPTION
The `Tribe::redirect_past_upcoming_view_urls()` method incorrectly calls `trim()` on the result of `wp_parse_url()`, which is an array or `false`.