### PR TITLE
Display a failed Scheduled record retry time

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -313,7 +313,9 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 * Fix - Prevent warnings on retrival of posts if "Include events in main blog loop" is checked (thanks to Colin Carmichael for report this problem) [97667]
 * Fix - Make the `tribe-ea-record` custom post type (used to store Event Aggregator record information) private [99106]
 * Fix - Expand the size of the TimeZone input on the admin to allow better visibility for long names [100363]
+* Fix - Prevent Event Aggregator scheduled imports that failed from re-attempting the import too soon [102489]
 * Tweak - Added the `tribe_aggregator_find_matching_organizer` and `tribe_aggregator_find_matching_venue` filters in Events Aggregator code to allow the definition of custom Venue and Organizer match criteria [97292]
+* Tweak - Display the retry time for a failed Event Aggregator scheduled import in the Scheduled tab [102489]
 
 = [4.6.12] 2018-03-08 =
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -2515,7 +2515,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 *
 	 * @return int
 	 */
-	protected function get_retry_interval() {
+	public function get_retry_interval() {
 		if ( $this->frequency->interval === DAY_IN_SECONDS ) {
 			$retry_interval = 6 * HOUR_IN_SECONDS;
 		} elseif ( $this->frequency->interval < DAY_IN_SECONDS ) {
@@ -2530,10 +2530,42 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		 *
 		 * @since TBD
 		 *
-		 * @param int An interval in seconds; defaults to the record frequency / 2.
+		 * @param int $retry_interval An interval in seconds; defaults to the record frequency / 2.
 		 * @param Tribe__Events__Aggregator__Record__Abstract $this
 		 */
 		return apply_filters( 'tribe_aggregator_scheduled_records_retry_interval', $retry_interval, $this );
+	}
+
+	/**
+	 * Returns the record retry timestamp.
+	 *
+	 * @since TBD
+	 *
+	 * @return int|bool Either the record retry timestamp or `false` if the record will
+	 *                  not retry to import.
+	 */
+	public function get_retry_time() {
+		$retry_interval = $this->get_retry_interval();
+
+		if ( empty( $retry_interval ) ) {
+			return false;
+		}
+
+		$retry_time = strtotime( $this->post->post_modified_gmt ) + (int) $retry_interval;
+
+		if ( $retry_time < time() ) {
+			$retry_time = false;
+		}
+
+		/**
+		 * Filters the retry timestamp for a scheduled record.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $retry_time A timestamp.
+		 * @param Tribe__Events__Aggregator__Record__Abstract $this
+		 */
+		return apply_filters( 'tribe_aggregator_scheduled_records_retry_interval', $retry_time, $this );
 	}
 }
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -2551,7 +2551,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 			return false;
 		}
 
-		$retry_time = strtotime( $this->post->post_modified_gmt ) + (int) $retry_interval;
+		if ( ! $this->get_last_import_status( 'error', true ) ) {
+			return false;
+		}
+
+		$last_attempt_time = strtotime( $this->last_child()->post->post_modified_gmt );
+		$retry_time        = $last_attempt_time + (int) $retry_interval;
 
 		if ( $retry_time < time() ) {
 			$retry_time = false;

--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -541,6 +541,11 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		$time = strtotime( $original );
 		$now = current_time( 'timestamp', true );
 
+		$retry_time = false;
+		if ( $last_import_error ) {
+		    $retry_time = $record->get_retry_time();
+		}
+
 		$html[] = '<span title="' . esc_attr( $original ) . '">';
 		if ( ( $now - $time ) <= DAY_IN_SECONDS ) {
 			$diff = human_time_diff( $time, $now );
@@ -552,8 +557,19 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		} else {
 			$html[] = date( tribe_get_date_format( true ), $time ) . '<br>' . date( Tribe__Date_Utils::TIMEFORMAT, $time );
 		}
-
 		$html[] = '</span>';
+
+		if ( $retry_time ) {
+			$html[] = '<div title="' . esc_attr( $original ) . '-retry">';
+			if ( ( $retry_time - $now ) <= DAY_IN_SECONDS ) {
+				$diff   = human_time_diff( $retry_time, $now );
+				$html[] = sprintf( esc_html_x( 'retrying in about %s', 'in human readable time', 'the-events-calendar' ), $diff );
+			} else {
+				$html[] = date( tribe_get_date_format( true ), $retry_time ) . '<br>' . date( Tribe__Date_Utils::TIMEFORMAT, $time );
+			}
+			$html[] = '</div>';
+		}
+
 		return $this->render( $html );
 	}
 

--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -565,7 +565,10 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 				$diff   = human_time_diff( $retry_time, $now );
 				$html[] = sprintf( esc_html_x( 'retrying in about %s', 'in human readable time', 'the-events-calendar' ), $diff );
 			} else {
-				$html[] = date( tribe_get_date_format( true ), $retry_time ) . '<br>' . date( Tribe__Date_Utils::TIMEFORMAT, $time );
+				$html[] = sprintf(
+					esc_html_x( 'retrying at %s', 'when the retry will happen, a date', 'the-events-calendar' ),
+					date( tribe_get_date_format( true ), $retry_time )
+				);
 			}
 			$html[] = '</div>';
 		}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -34,10 +34,12 @@ class AbstractTest extends Events_TestCase {
 	 */
 	private function make_scheduled_record_instance( $frequency_id = 'weekly', $modified = 'now', $schedule_day = 1, $schedule_time = '09:00:00' ) {
 		$supported_frequencies = [
-			'on_demand' => 0,
-			'daily'     => 1 * DAY_IN_SECONDS,
-			'weekly'    => 7 * DAY_IN_SECONDS,
-			'monthly'   => 30 * DAY_IN_SECONDS,
+			'on_demand'   => 0,
+			'every30mins' => .5 * HOUR_IN_SECONDS,
+			'hourly'      => HOUR_IN_SECONDS,
+			'daily'       => 1 * DAY_IN_SECONDS,
+			'weekly'      => 7 * DAY_IN_SECONDS,
+			'monthly'     => 30 * DAY_IN_SECONDS,
 		];
 
 		if ( ! array_key_exists( $frequency_id, $supported_frequencies ) ) {
@@ -45,7 +47,7 @@ class AbstractTest extends Events_TestCase {
 			throw new \InvalidArgumentException( "Frequency id should be one among [{$frequencies}]" );
 		}
 
-		$modified = strtotime( $modified );
+		$modified = is_numeric($modified) ? $modified : strtotime( $modified );
 
 		if ( 0 >= $modified ) {
 			throw new \InvalidArgumentException( 'Modified should be a string parseable by the strtotime function' );
@@ -538,5 +540,34 @@ class AbstractTest extends Events_TestCase {
 		$failed = $this->add_failed_children_to( $scheduled_record, $second_child_failed_at );
 
 		$this->assertTrue( $scheduled_record->is_schedule_time() );
+	}
+
+	public function frequencies_and_expected_retry_times() {
+		return [
+			[ 'on_demand', false ],
+			[ 'every30mins', false ],
+			[ 'hourly', false ],
+			[ 'daily', 6 * 3600 ],
+			[ 'weekly', 24 * 3600 ],
+			[ 'monthly', 24 * 3600 ],
+		];
+	}
+
+	/**
+	 * It should correctly return a record retry timestamp
+	 *
+	 * @test
+	 *
+	 * @dataProvider frequencies_and_expected_retry_times
+	 */
+	public function should_correctly_return_a_record_retry_timestamp( $frequency_id, $expected_interval ) {
+		$modified_time = strtotime( '-1 hour' );
+		$record        = $this->make_scheduled_record_instance( $frequency_id, $modified_time );
+
+		if ( false !== $expected_interval ) {
+			$this->assertEquals( $modified_time + $expected_interval, $record->get_retry_time() );
+		} else {
+			$this->assertFalse( $record->get_retry_time() );
+		}
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/102489

This PR adds a method to the Record class to return the timestamp of the record next retry (modified in PR https://github.com/moderntribe/the-events-calendar/pull/1886) to display it, for failed Scheduled records only, in the Scheduled tab: https://cl.ly/0G0R2M3c2L1g