### PR TITLE
Avoid notice trying to count un-countables

### DIFF
--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -178,7 +178,7 @@ class Tribe__Events__Aggregator__Record__Queue {
 	 * @return int
 	 */
 	public function count() {
-		return count( $this->items );
+		return is_array( $this->items ) ? count( $this->items ) : 0;
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98015

Avoid trying to count something that is not an array.