### PR TITLE
Change the check to avoid PHP notices

### DIFF
--- a/src/Tribe/Aggregator/Record/List_Table.php
+++ b/src/Tribe/Aggregator/Record/List_Table.php
@@ -542,8 +542,9 @@ class Tribe__Events__Aggregator__Record__List_Table extends WP_List_Table {
 		$now = current_time( 'timestamp', true );
 
 		$retry_time = false;
-		if ( $last_import_error ) {
-		    $retry_time = $record->get_retry_time();
+
+		if ( ! empty( $last_import_error ) ) {
+			$retry_time = $record->get_retry_time();
 		}
 
 		$html[] = '<span title="' . esc_attr( $original ) . '">';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/99106#note-12

Since the `last_import_error` variable might not be defined use `empty` to check it.