### PR TITLE
Add CLI command to run imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,8 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [4.6.15] TBD =
 
+* Feature - added wp-cli command to import events from a source with Events Aggregator, see `wp event-aggregator import-from --help` to know more [104426]
+* Feature - added wp-cli command to run scheduled imports with Events Aggregator, see `wp event-aggregator run-import --help` to know more [104426]
 * Fix - Remove organizers when an event has multiple organizers [103715]
 * Fix - Fixed the `[tribe_events]` month view pagination without the bar, and when using plain permalinks [95720]
 * Fix - Prevent `url_to_postid` to run if on the main events page to avoid query conflicts. [94328]

--- a/src/Tribe/Aggregator/CLI/Command.php
+++ b/src/Tribe/Aggregator/CLI/Command.php
@@ -204,7 +204,7 @@ class Tribe__Events__Aggregator__CLI__Command {
 			'limit' => $limit_type ? Tribe__Utils__Array::get( $assoc_args, 'limit' ) : null,
 			'source' => $source,
 			'preview' => false,
-			'category' => $category_id
+			'category' => $category_id,
 		);
 
 		if ( $is_csv ) {
@@ -293,8 +293,8 @@ class Tribe__Events__Aggregator__CLI__Command {
 	 *
 	 * @return Tribe__Events__Aggregator__Record__Activity
 	 */
-	protected function import_csv_file( $queue_result, $record ): Tribe__Events__Aggregator__Record__Activity {
-		WP_CLI::log( "Reading the file..." );
+	protected function import_csv_file( $queue_result, $record ) {
+		WP_CLI::log( 'Reading the file...' );
 
 		$data = array(
 			'action' => 'new',
@@ -376,7 +376,7 @@ class Tribe__Events__Aggregator__CLI__Command {
 	 *
 	 * @return Tribe__Events__Aggregator__Record__Activity
 	 */
-	protected function import_from_service( $queue_result, $record ): Tribe__Events__Aggregator__Record__Activity {
+	protected function import_from_service( $queue_result, $record ) {
 		$item_name = 'event';
 		WP_CLI::log( 'Creating import on the service...' );
 
@@ -399,7 +399,7 @@ class Tribe__Events__Aggregator__CLI__Command {
 					sleep( $this->polling_interval );
 				}
 
-				WP_CLI::log( "Polling service to get data..." );
+				WP_CLI::log( 'Polling service to get data...' );
 
 				$response = $record->get_import_data();
 				$first    = false;
@@ -437,7 +437,9 @@ class Tribe__Events__Aggregator__CLI__Command {
 			WP_CLI::error( 'Empty data; response was ' . wp_json_encode( $response ) );
 		}
 
-		$progress = WP_CLI\Utils\make_progress_bar( "Inserting posts", $events_count, $interval = 100 );
+		$progress = WP_CLI\Utils\make_progress_bar( 'Inserting posts', $events_count, $interval = 100 );
+
+		// here we use the filter as an action to tick the progress
 		add_action( 'tribe_aggregator_before_save_event', function ( array $event ) use ( $progress ) {
 			$progress->tick();
 

--- a/src/Tribe/Aggregator/CLI/Command.php
+++ b/src/Tribe/Aggregator/CLI/Command.php
@@ -1,0 +1,383 @@
+<?php
+
+class Tribe__Events__Aggregator__CLI__Command {
+	/**
+	 * @var int The polling interval timeout in seconds.
+	 */
+	protected $polling_timeout = 30;
+
+	/**
+	 * @var int The polling interval in seconds.
+	 */
+	protected $polling_interval = 2;
+
+	/**
+	 * Run an import of the specified type from a specified source.
+	 *
+	 * The command will use the API and licenses set for the site if required.
+	 *
+	 * <origin>
+	 * : the import origin type
+	 * ---
+	 * options:
+	 *   - ical
+	 *   - gcal
+	 *   - csv
+	 *   - ics
+	 *   - facebook
+	 *   - meetup
+	 *   - url
+	 * ---
+	 *
+	 * <source>
+	 * : The source to import events from; a URL or a file path for .ics and CSV files.
+	 *
+	 * [--keywords=<keywords>]
+	 * : Optionally filter events by these keywords.
+	 *
+	 * [--location=<location>]
+	 * : Filter events by this location, not supported by all origin types; not supported by all origin types.
+	 *
+	 * [--radius=<radius>]
+	 * : Only fetch events in this mile radius around the location.
+	 * Will be ignored if the `--location` parameter is not set.
+	 *
+	 * [--start=<start>]
+	 * : Only fetch events starting after this date.
+	 * This should be a valid date string or a value supported by the `strtotime` PHP function.
+	 * Not supported by all origin types.
+	 *
+	 * [--end=<end>]
+	 * : Only fetch events starting before this date.
+	 * This should be a valid date string or a value supported by the `strtotime` PHP function.
+	 * Not supported by all origin types.
+	 * Defaults the range set in the import settings for this origin type.
+	 *
+	 * [--limit_type=<limit_type>]
+	 * : The type of limit that should be used to limit the number of fetched events.
+	 * ---
+	 * options:
+	 *   - count
+	 *   - range
+	 *   - no_limit
+	 * ---
+	 *
+	 * [--limit=<limit>]
+	 * : The value of the limit that should be applied; ignored if `--limit_type` is not set or set to `no_limit`.
+	 * Either a value in seconds if the `--limit_type` is range or a number if `--limit_type` is set to `count`.
+	 * When importing CSV files this limit will NOT apply.
+	 *
+	 *
+	 * [--timeout=<timeout>]
+	 * : How long should the command wait for the data from EA Service in seconds
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--post_status=<post_status>]
+	 * : The post status that should be assigned to the imported events; default to the one set in Import options.
+	 * ---
+	 * options:
+	 *   - publish
+	 *   - draft
+	 *   - pending
+	 *   - private
+	 * ---
+	 *
+	 * [--category=<category>]
+	 * : An optional category that should be assigned to the imported events.
+	 *
+	 * [--content_type=<content_type>]
+	 * : The type of import for CSV files.
+	 * The column mapping must match exactly, in order and naming, the one used by the UI to import this content type.
+	 * ---
+	 * default: events
+	 * options:
+	 *   - events
+	 *   - venues
+	 *   - organizers
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : The results output format
+	 * ---
+	 *
+	 * ## Examples
+	 *
+	 *      wp event-aggregator import-from ical https://some-ical-source/feed.ics
+	 *      wp event-aggregator import-from ical https://some-ical-source/feed.ics --start=tomorrow --end="+3 weeks"
+	 *      wp event-aggregator import-from ical https://some-ical-source/feed.ics --limit_type=count --limit=20
+	 *      wp event-aggregator import-from ical https://some-ical-source/feed.ics --location="Toronto" --radius=50
+	 *      wp event-aggregator import-from ical https://some-ical-source/feed.ics --keywords=Party
+	 *      wp event-aggregator import-from facebook https://www.facebook.com/ModernTribeInc/
+	 *      wp event-aggregator import-from meetup https://www.meetup.com/wordpress-ile-de-france/
+	 *      wp event-aggregator import-from gcal https://calendar.google.com/calendar/ical/me/public/basic.ics
+	 *      wp event-aggregator import-from csv /Users/moi/events.csv
+	 *      wp event-aggregator import-from ics /Users/moi/events.ics
+	 *
+	 *
+	 * @since      TBD
+	 *
+	 * @subcommand import-from
+	 *
+	 * @when       after_wp_load
+	 */
+	public function import_from_source( array $args, array $assoc_args = array() ) {
+		if ( isset( $assoc_args['timeout'] ) && ! is_numeric( $assoc_args['timeout'] ) ) {
+			WP_CLI::error( 'The timeout should be a numeric value.' );
+		}
+
+		list( $origin, $source ) = $args;
+
+		$types = array(
+			'ical' => 'Tribe__Events__Aggregator__Record__iCal',
+			'gcal' => 'Tribe__Events__Aggregator__Record__gCal',
+			'csv' => 'Tribe__Events__Aggregator__Record__CSV',
+			'ics' => 'Tribe__Events__Aggregator__Record__ICS',
+			'facebook' => 'Tribe__Events__Aggregator__Record__Facebook',
+			'meetup' => 'Tribe__Events__Aggregator__Record__Meetup',
+			'url' => 'Tribe__Events__Aggregator__Record__Url',
+		);
+
+		$record_class = Tribe__Utils__Array::get( $types, $origin, reset( $types ) );
+
+		/** @var Tribe__Events__Aggregator__Record__Abstract $record */
+		$record = new $record_class;
+
+		$record_args = array();
+
+		$location   = Tribe__Utils__Array::get( $assoc_args, 'location' );
+		$limit_type = Tribe__Utils__Array::get( $assoc_args, 'limit_type' );
+
+		$category = Tribe__Utils__Array::get( $assoc_args, 'category', '' );
+		$category_id = '';
+
+		if ( is_numeric( $category ) ) {
+			$category_id = $category;
+		} elseif ( ! empty( $category ) ) {
+			$term = get_term_by( 'slug', $category, Tribe__Events__Main::TAXONOMY );
+			if ( ! $term instanceof WP_Term ) {
+				WP_CLI::error( "$category is not a valid category ID or slug." );
+			}
+			$category_id = $term->term_id;
+		}
+
+		$record_meta = array(
+			'origin' => $origin,
+			'type' => 'manual',
+			'keywords' => Tribe__Utils__Array::get( $assoc_args, 'keywords', '' ),
+			'location' => $location,
+			'start' => Tribe__Utils__Array::get( $assoc_args, 'start' ),
+			'end' => Tribe__Utils__Array::get( $assoc_args, 'end' ),
+			'radius' => $location ? Tribe__Utils__Array::get( $assoc_args, 'radius' ) : null,
+			'limit_type' => $limit_type,
+			'limit' => $limit_type ? Tribe__Utils__Array::get( $assoc_args, 'limit' ) : null,
+			'source' => $source,
+			'preview' => false,
+			'category' => $category_id
+		);
+
+		$is_csv = 'csv' === $origin;
+
+		if ( $is_csv ) {
+			$record_meta['file']         = $source;
+			$record_meta['content_type'] = Tribe__Utils__Array::get( $assoc_args, 'content_type', 'events' );
+		}
+
+		if ( 'ics' === $origin ) {
+			$record_meta['file'] = array(
+				'name' => $source,
+				'tmp_name' => $source,
+			);
+		}
+
+		if ( empty( $assoc_args['post_status'] ) ) {
+			$record_meta['post_status'] = tribe( 'events-aggregator.settings' )->default_post_status( $origin );
+		} else {
+			$record_meta['post_status'] = $assoc_args['post_status'];
+		}
+
+		WP_CLI::log( 'Creating record post...' );
+
+		$created = $record->create( 'manual', $record_args, $record_meta );
+
+		if ( $created instanceof WP_Error ) {
+			WP_CLI::error( 'There was an error while creating the import: ' . $created->get_error_message() );
+		}
+
+		WP_CLI::log( "Record created with post ID {$record->id}." );
+
+		$queue_result = $record->queue_import();
+
+		$record->finalize();
+
+		$this->polling_timeout = (float) $assoc_args['timeout'];
+
+		if ( $is_csv ) {
+			$activity = $this->import_csv_file( $queue_result, $record );
+		} else {
+			$activity = $this->import_from_service( $queue_result, $record );
+		}
+
+		$assoc_args['format'] = ! empty( $assoc_args['format'] ) ? $assoc_args['format'] : 'yaml';
+
+		WP_CLI::print_value( $activity->get(), $assoc_args );
+
+		WP_CLI::success( 'Import done!' );
+	}
+
+	/**
+	 * @param $record
+	 * @param $record_meta
+	 * @param $category
+	 * @param $queue_result
+	 *
+	 * @return Tribe__Events__Aggregator__Record__Activity
+	 */
+	protected function import_csv_file( $queue_result, $record ): Tribe__Events__Aggregator__Record__Activity {
+		WP_CLI::log( "Reading the file..." );
+
+		$data = array(
+			'action' => 'new',
+			'import_id' => $record->id,
+			'origin' => 'csv',
+			'csv' =>
+				array(
+					'content_type' => 'tribe_' . $record->meta['content_type'],
+					'file' => $record->meta['file'],
+				),
+			'column_map' =>
+				array(
+					0 => 'event_name',
+					1 => 'event_description',
+					2 => 'event_start_date',
+					3 => 'event_start_time',
+					4 => 'event_end_date',
+					5 => 'event_end_time',
+					6 => '',
+					7 => 'event_venue_name',
+					8 => 'event_organizer_name',
+					9 => 'event_show_map_link',
+					10 => 'event_show_map',
+					11 => 'event_cost',
+					12 => 'event_category',
+					13 => 'event_website',
+				),
+			'post_status' => $record->meta['post_status'],
+			'category' => $record->meta['category'],
+			'selected_rows' => 'all',
+		);
+
+		$response = $queue_result;
+
+		if ( $response instanceof WP_Error ) {
+			WP_CLI::error( 'There was an error while reading the file: ' . $response->get_error_message() );
+		}
+
+		if ( isset( $response['data']['items'] ) && $response['data']['items'] instanceof WP_Error ) {
+			WP_CLI::error( $response['data']['items']->get_error_message() );
+		}
+
+		$item_name = rtrim( $record->meta['content_type'], 's' );
+		$items     = $response['data']['items'];
+
+		if ( empty( $items ) ) {
+			WP_CLI::success( 'No items found matching the query.' );
+		}
+
+		$items_count = count( $items );
+
+		WP_CLI::log( "Read data for {$items_count} {$item_name}(s) from the file." );
+
+		add_filter( 'tribe_aggregator_batch_size', function () use ( $items_count ) {
+			return $items_count + 1;
+		} );
+
+		/** @var Tribe__Events__Aggregator__Record__Queue $result */
+		$result = $record->process_posts( $data );
+
+		if ( $result instanceof WP_Error ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$activity = $result->activity();
+
+		return $activity;
+	}
+
+	/**
+	 * @param array $assoc_args
+	 * @param $queue_result
+	 * @param $record
+	 *
+	 * @return Tribe__Events__Aggregator__Record__Activity
+	 */
+	protected function import_from_service( $queue_result, $record ): Tribe__Events__Aggregator__Record__Activity {
+		$item_name = 'event';
+		WP_CLI::log( 'Creating import on the service...' );
+
+		if ( $queue_result instanceof WP_Error ) {
+			WP_CLI::error( 'There was an error while queueing the import on the service: ' . $queue_result->get_error_message() );
+		}
+
+		WP_CLI::log( "Import was assigned ID  {$record->meta['import_id']} from the service." );
+
+		$start_time = microtime( true );
+		$response   = null;
+
+		if ( $record->is_polling() ) {
+
+			WP_CLI::log( "Data will be fetched polling the service, timeout is {$this->polling_timeout} seconds." );
+
+			$first = true;
+			do {
+				if ( ! $first ) {
+					sleep( $this->polling_interval );
+				}
+
+				WP_CLI::log( "Polling service to get data..." );
+
+				$response = $record->get_import_data();
+				$first    = false;
+			} while (
+				( $response instanceof stdClass && 'fetching' === $response->status )
+				&& microtime( true ) - $start_time <= $this->polling_timeout
+			);
+		} else {
+			WP_CLI::error( 'Batch data pushing is not supported in the CLI yet!' );
+		}
+
+		if ( null === $response ) {
+			WP_CLI::error( 'Run out of time  while waiting for the data, check the source or explicitly set the `--timeout` parameter to a higher value and retry.' );
+		}
+
+		if ( $response instanceof WP_Error ) {
+			WP_CLI::error( 'There was an error while fetching the data from the service: ' . $response->get_error_message() );
+		}
+
+		if ( ! property_exists( $response->data, 'events' ) ) {
+			WP_CLI::error( 'Empty event data; response was ' . wp_json_encode( $response ) );
+		}
+
+		$items = $response->data->events;
+
+		if ( empty( $items ) ) {
+			WP_CLI::success( "No {$item_name}s found matching the query." );
+		}
+
+		$events_count = count( $items );
+
+		WP_CLI::log( "Received data for {$events_count} event(s) from the service." );
+
+		if ( empty( $response->data ) ) {
+			WP_CLI::error( 'Empty data; response was ' . wp_json_encode( $response ) );
+		}
+
+		WP_CLI::log( "Inserting posts..." );
+
+		/** @var Tribe__Events__Aggregator__Record__Activity $activity */
+		$activity = $record->insert_posts( $items );
+
+		return $activity;
+	}
+}

--- a/src/Tribe/Aggregator/CLI/Command.php
+++ b/src/Tribe/Aggregator/CLI/Command.php
@@ -235,7 +235,7 @@ class Tribe__Events__Aggregator__CLI__Command {
 
 		WP_CLI::log( "Record created with post ID {$record->id}." );
 
-		$record;
+		return $record;
 	}
 
 	/**

--- a/src/Tribe/Aggregator/CLI/Service_Provider.php
+++ b/src/Tribe/Aggregator/CLI/Service_Provider.php
@@ -1,0 +1,26 @@
+<?php
+
+class Tribe__Events__Aggregator__CLI__Service_Provider extends tad_DI52_ServiceProvider {
+
+	/**
+	 * Binds and sets up implementations.
+	 */
+	public function register() {
+		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			return;
+		}
+
+		/**
+		 * While using wp-cli PHP version will be 5.3.29 or later but this file might still be parsed from PHP 5.2
+		 * so we must avoid PHP 5.3+ syntax here.
+		 */
+		WP_CLI::add_command(
+			'event-aggregator',
+			'Tribe__Events__Aggregator__CLI__Command',
+			array(
+				'shortdesc' => __( 'Crete, run and manage Event Aggregator imports.', 'the-events-calendar' ),
+				'longdesc' => __( 'If required the commands will use the API keys and licenses set for the current site.' ),
+			)
+		);
+	}
+}

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -777,6 +777,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		return $response;
 	}
 
+	/**
+	 * Returns the record import data either fetching it locally or trying to retrieve
+	 * it from EA Service.
+	 *
+	 * @return stdClass|WP_Error An object containing the response data or a `WP_Error` on failure.
+	 */
 	public function get_import_data() {
 		/** @var \Tribe__Events__Aggregator $aggregator */
 		$aggregator = tribe( 'events-aggregator.main' );
@@ -1271,7 +1277,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	 *
 	 * @param array $data Dummy data var to allow children to optionally react to passed in data
 	 *
-	 * @return array|WP_Error
+	 * @return Tribe__Events__Aggregator__Record__Activity The import activity record.
 	 */
 	public function insert_posts( $items = array() ) {
 		add_filter( 'tribe-post-origin', array( Tribe__Events__Aggregator__Records::instance(), 'filter_post_origin' ), 10 );
@@ -2571,6 +2577,18 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		 * @param Tribe__Events__Aggregator__Record__Abstract $this
 		 */
 		return apply_filters( 'tribe_aggregator_scheduled_records_retry_interval', $retry_time, $this );
+	}
+
+	/**
+	 * Whether the record will try to fetch the import data polling EA Service or
+	 * expecting batches of data being pushed to it by EA Service.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_polling() {
+		return empty( $this->meta['allow_batch_push'] ) || false === (bool) $this->meta['allow_batch_push'];
 	}
 }
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -78,14 +78,13 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 	public function get_csv_data() {
 		if (
 			empty( $this->meta['file'] )
-			|| ! is_numeric( $this->meta['file'] )
+			|| ! $file_path = $this->get_file_path()
 		) {
 			return $this->set_status_as_failed( tribe_error( 'core:aggregator:invalid-csv-file' ) );
 		}
 
 		$content_type = str_replace( 'tribe_', '', $this->meta['content_type'] );
 
-		$file_path   = get_attached_file( absint( $this->meta['file'] ) );
 		$file_reader = new Tribe__Events__Importer__File_Reader( $file_path );
 		$importer    = Tribe__Events__Importer__File_Importer::get_importer( $content_type, $file_reader );
 
@@ -215,7 +214,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		if ( ! $this->importer ) {
 			$content_type = $this->get_csv_content_type();
 
-			$file_path      = get_attached_file( absint( $this->meta['file'] ) );
+			$file_path      = $this->get_file_path();
 			$file_reader    = new Tribe__Events__Importer__File_Reader( $file_path );
 			$this->importer = Tribe__Events__Importer__File_Importer::get_importer( $content_type, $file_reader );
 
@@ -281,6 +280,23 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		 * @param array $post_types Array of post type objects
 		 */
 		return apply_filters( 'tribe_aggregator_csv_post_types', $post_types );
+	}
+
+	/**
+	 * Returns the path to the CSV file.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool|false|string Either the absolute path to the CSV file or `false` on failure.
+	 */
+	protected function get_file_path() {
+		if ( is_numeric( $this->meta['file'] ) ) {
+			$file_path = get_attached_file( absint( $this->meta['file'] ) );
+		} else {
+			$file_path = realpath( $this->meta['file'] );
+		}
+
+		return $file_path && file_exists( $file_path ) ? $file_path : false;
 	}
 
 	private function begin_import() {

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -410,6 +410,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe_singleton( 'events-aggregator.main', 'Tribe__Events__Aggregator', array( 'load', 'hook' ) );
 			tribe_singleton( 'events-aggregator.service', 'Tribe__Events__Aggregator__Service' );
 			tribe_singleton( 'events-aggregator.settings', 'Tribe__Events__Aggregator__Settings' );
+			tribe_singleton( 'events-aggregator.records', 'Tribe__Events__Aggregator__Records', array( 'hook' ) );
+			tribe_register_provider( 'Tribe__Events__Aggregator__CLI__Service_Provider' );
 
 			// Shortcodes
 			tribe_singleton( 'tec.shortcodes.event-details', 'Tribe__Events__Shortcode__Event_Details', array( 'hook' ) );


### PR DESCRIPTION
Ticket: #104426

This PR adds the first version of the command to run imports, or scheduled imports, using wp-cli.

```shell
`wp event-aggregator import-from ical http://foo.bar/ical.ics`
```

is the (sudo) syntax to run imports; while scheduled imports can be ran using the import post ID:

```shell
wp event-aggregator run-import 2389
```