### PR TITLE
State and Province Data in Create Venue form

### DIFF
--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -142,7 +142,7 @@ if ( ! $_POST && is_admin() ) {
 			type='text'
 			name=''
 			size='25'
-			value='<?php echo esc_attr( $_VenueProvince ); ?>'
+			value='<?php echo isset( $_VenueProvince ) ? esc_attr( $_VenueProvince ) : ''; ?>'
 			aria-label="<?php esc_html_e( 'Venue State', 'the-events-calendar' ); ?>"
 		 />
 		<select
@@ -155,7 +155,7 @@ if ( ! $_POST && is_admin() ) {
 			<option value=""><?php esc_html_e( 'Select a State:', 'the-events-calendar' ); ?></option>
 			<?php
 			foreach ( Tribe__View_Helpers::loadStates() as $abbr => $fullname ) {
-				$selected = selected( ( $_VenueState === $abbr || $_VenueState === $fullname ), true, false );
+				$selected = selected( ( isset( $_VenueState ) && ( $_VenueState === $abbr || $_VenueState === $fullname ) ), true, false );
 				echo '<option value="' . esc_attr( $abbr ) . '" ' . $selected . '>' . esc_html( $fullname ) . '</option>';
 			}
 			?>


### PR DESCRIPTION
Task: https://central.tri.be/issues/106415

When Community Events and TEC are enabled, the Province and State fields break. This PR conditionally checks these vars are in use before attempting to use them. They are traditionally only in use when editing an existing event or after the event has been created and do not exist when an empty "Add event" form is present.