### PR TITLE
Add a warning when the site Timezone is set to UTC

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.6.16] TBD =
 
 * Tweak - Add tribe_redirected parameter to enable a visitor to select another view after default mobile redirect, thanks to Marcella for notifying us [102743]
+* Fix - Add a warning when the site Timezone is set to UTC [105217]
 
 = [4.6.15] 2018-05-09 =
 

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -45,7 +45,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 		$gmt_offset      = get_option( 'gmt_offset' );
 
 		// If the site is using UTC or UTC manual offset
-		return 'UTC' === $timezone_string || ('' === $timezone_string && '' !== $gmt_offset );
+		return 'UTC' === $timezone_string || ( '' === $timezone_string && '' !== $gmt_offset );
 	}
 
 	/**

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Shows an admin notice for Timezones
+ * (When using UTC and on TEC Pages or WordPress > General Settings)
+ */
+class Tribe__Events__Admin__Notice__Timezones {
+
+	public function __construct() {
+
+		// Bail if the site isn't using UTC
+		if ( ! $this->is_utc_timezone() ) {
+			return;
+		}
+
+		// Bail if we're not on TEC pages or WordPress General Settings
+		if ( ! $this->should_display() ) {
+			return;
+		}
+
+		tribe_notice(
+			'tribe-events-utc-timezone',
+			array( $this, 'notice' ),
+			array(
+				'type'    => 'warning',
+				'dismiss' => 1,
+				'wrap'    => 'p',
+			)
+		);
+
+	}
+
+	/**
+	 * Checks if the site is using UTC Timezone Options
+	 *
+	 * @since  TBD
+	 *
+	 * @return boolean
+	 */
+	public function is_utc_timezone() {
+
+		// timezone_string
+		$timezone_string = get_option( 'timezone_string' );
+
+		// GMT offset
+		$gmt_offset      = get_option( 'gmt_offset' );
+
+		// If the site is using UTC or UTC manual offset
+		if (
+			'UTC' === $timezone_string
+			|| ( '' === $timezone_string && '' !== $gmt_offset )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if we are in an TEC page or over
+	 * the WordPress > Settings > General
+	 *
+	 * @since  TBD
+	 *
+	 * @return boolean
+	 */
+	public function should_display() {
+		global $pagenow;
+
+		$admin_helpers = Tribe__Admin__Helpers::instance();
+
+		// It should display if we're on a TEC page or
+		// over Settings > General
+		if (
+			! $admin_helpers->is_screen()
+			|| 'options-general.php' === $pagenow
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * HTML for the notice for sites using UTC Timezones.
+	 *
+	 * @since  TBD
+	 *
+	 * @return string
+	 */
+	public function notice() {
+		// Bail if the user is not admin or can manage plugins
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return false;
+		}
+
+		$url = 'https://theeventscalendar.com/knowledgebase/time-zones/';
+		$link = sprintf(
+			'<a href="%1$s" target="_blank">%2$s</a>',
+			esc_url( $url ),
+			esc_html__( 'Read more', 'the-events-calendar' )
+		);
+		$text = __( 'When using The Events Calendar, we recommend that you choose a city in your timezone and avoid using a UTC timezone offset. Choosing a UTC timezone may cause problems when importing events or with Day Light Savings time. %1$s', 'the-events-calendar' );
+
+		return sprintf( $text, $link );
+
+	}
+
+
+}

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -38,14 +38,8 @@ class Tribe__Events__Admin__Notice__Timezones {
 	 */
 	public function is_utc_timezone() {
 
-		// timezone_string
-		$timezone_string = get_option( 'timezone_string' );
-
-		// GMT offset
-		$gmt_offset      = get_option( 'gmt_offset' );
-
 		// If the site is using UTC or UTC manual offset
-		return 'UTC' === $timezone_string || ( '' === $timezone_string && '' !== $gmt_offset );
+		return strpos( Tribe__Timezones::wp_timezone_string(), 'UTC' ) !== false;
 	}
 
 	/**

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -5,7 +5,7 @@
  */
 class Tribe__Events__Admin__Notice__Timezones {
 
-	public function __construct() {
+	public function hook() {
 
 		// Bail if the site isn't using UTC
 		if ( ! $this->is_utc_timezone() ) {

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -45,14 +45,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 		$gmt_offset      = get_option( 'gmt_offset' );
 
 		// If the site is using UTC or UTC manual offset
-		if (
-			'UTC' === $timezone_string
-			|| ( '' === $timezone_string && '' !== $gmt_offset )
-		) {
-			return true;
-		}
-
-		return false;
+		return 'UTC' === $timezone_string || ('' === $timezone_string && '' !== $gmt_offset );
 	}
 
 	/**
@@ -70,14 +63,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 
 		// It should display if we're on a TEC page or
 		// over Settings > General
-		if (
-			! $admin_helpers->is_screen()
-			|| 'options-general.php' === $pagenow
-		) {
-			return true;
-		}
-
-		return false;
+		return ! $admin_helpers->is_screen() || 'options-general.php' === $pagenow;
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -453,7 +453,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe_singleton( 'tec.gutenberg', 'Tribe__Events__Gutenberg', array( 'hook' ) );
 
 			// Admin Notice for Timezones
-			tribe_singleton( 'tec.admin.notice.timezones', 'Tribe__Events__Admin__Notice__Timezones' );
+			tribe_singleton( 'tec.admin.notice.timezones', 'Tribe__Events__Admin__Notice__Timezones', array( 'hook' ) );
 
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -452,6 +452,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Gutenberg Extension
 			tribe_singleton( 'tec.gutenberg', 'Tribe__Events__Gutenberg', array( 'hook' ) );
 
+			// Admin Notice for Timezones
+			tribe_singleton( 'tec.admin.notice.timezones', 'Tribe__Events__Admin__Notice__Timezones' );
+
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.
 			 */
@@ -724,6 +727,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe( 'tec.iCal' );
 			tribe( 'tec.rest-v1.main' );
 			tribe( 'tec.gutenberg' );
+			tribe( 'tec.admin.notice.timezones' );
 		}
 
 		/**


### PR DESCRIPTION
https://central.tri.be/issues/105217

Add a notice to admin if the site timezone is set to UTC, when in "TEC Pages" or WordPress General Settings.