### PR TITLE
Add 2018 survey message/link | #106817

### DIFF
--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @internal This class may be removed or changed without notice
+ */
+class Tribe__Events__Admin__Notice__Marketing {
+	/**
+	 * Register marketing notices.
+	 *
+	 * @since TBD
+	 */
+	public function hook() {
+		tribe_notice(
+			'tribe-events-upcoming-survey',
+			array( $this, 'notice' ),
+			array(
+				'dismiss' => 1,
+				'type'    => 'info',
+				'wrap'    => 'p',
+			),
+			array( $this, 'should_display' )
+		);
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_display() {
+		return tribe( 'admin.helpers' )->is_screen()
+			&& date_create()->format( 'Y-m-d' ) < '2018-06-08';
+	}
+
+	/**
+	 * HTML for the notice for sites using UTC Timezones.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function notice() {
+		$link = sprintf(
+			'<a href="%1$s" target="_blank">%2$s</a>',
+			esc_url( 'https://m.tri.be/1a3l' ),
+			esc_html_x( 'take the survey now', '2018 user survey', 'the-events-calendar' )
+		);
+
+		return sprintf(
+			_x( '<strong>The Events Calendar Annual Survey:</strong> share your feedback with our team—%1$s!', '2018 user survey', 'the-events-calendar' ),
+			$link
+		);
+	}
+}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -452,8 +452,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Gutenberg Extension
 			tribe_singleton( 'tec.gutenberg', 'Tribe__Events__Gutenberg', array( 'hook' ) );
 
-			// Admin Notice for Timezones
+			// Admin Notices
 			tribe_singleton( 'tec.admin.notice.timezones', 'Tribe__Events__Admin__Notice__Timezones', array( 'hook' ) );
+			tribe_singleton( 'tec.admin.notice.marketing', 'Tribe__Events__Admin__Notice__Marketing', array( 'hook' ) );
 
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.
@@ -728,6 +729,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe( 'tec.rest-v1.main' );
 			tribe( 'tec.gutenberg' );
 			tribe( 'tec.admin.notice.timezones' );
+			tribe( 'tec.admin.notice.marketing' );
 		}
 
 		/**


### PR DESCRIPTION
Adds a dismissable, time-bound admin notice that will appear on event admin screens up until 2018-06-08. 

:ticket: [#106817](https://central.tri.be/issues/106817)