### PR TITLE
Marketing notice should appear on tag screen

### DIFF
--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -27,7 +27,10 @@ class Tribe__Events__Admin__Notice__Marketing {
 	 * @return bool
 	 */
 	public function should_display() {
-		return tribe( 'admin.helpers' )->is_screen()
+		/** @var Tribe__Admin__Helpers */
+		$admin_helpers = tribe( 'admin.helpers' );
+
+		return ( $admin_helpers->is_screen() || $admin_helpers->is_post_type_screen() )
 			&& date_create()->format( 'Y-m-d' ) < '2018-06-08';
 	}
 

--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -27,7 +27,7 @@ class Tribe__Events__Admin__Notice__Marketing {
 	 * @return bool
 	 */
 	public function should_display() {
-		/** @var Tribe__Admin__Helpers */
+		/** @var Tribe__Admin__Helpers $admin_helpers */
 		$admin_helpers = tribe( 'admin.helpers' );
 
 		return ( $admin_helpers->is_screen() || $admin_helpers->is_post_type_screen() )


### PR DESCRIPTION
Marketing notice should also appear on the (events) tag admin screen. Previously it appeared on all our screens except for this one.

:ticket: [#106817](https://central.tri.be/issues/106817)