### PR TITLE
#106869 - venue and organizer not importing after 18.07 release

### DIFF
--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -707,16 +707,25 @@ class Tribe__Events__Linked_Posts {
 			return;
 		}
 
-		if ( ! isset( $submission[ $linked_post_type_id_field ] ) ) {
-			$submission[ $linked_post_type_id_field ] = array();
-		}
-
 		$temp_submission = $submission;
 		$submission = array();
 
 		// make sure all elements are arrays
 		foreach ( $temp_submission as $key => $value ) {
 			$submission[ $key ] = is_array( $value ) ? $value : array( $value );
+		}
+
+		// setup key(s) if all new post(s)
+		if ( ! isset( $submission[ $linked_post_type_id_field ] ) ) {
+			$first_item                               = current( $submission );
+			$multiple_posts                           = is_array( $first_item ) ? count( $first_item ) - 1 : 0;
+			$submission[ $linked_post_type_id_field ] = array();
+			$post_count                               = 0;
+
+			do {
+				$submission[ $linked_post_type_id_field ][] = '';
+				$post_count ++;
+			} while ( $multiple_posts > $post_count );
 		}
 
 		$fields = array_keys( $submission );


### PR DESCRIPTION
_Ref:_ [C#106869](https://central.tri.be/issues/106869)

This resolves the above issue while maintaining the fix from:

https://central.tri.be/issues/103715

It is a PR against Master as I am not clear on where to merge it. After that is clear I can add a readme. 

Adding it to the ETR branch is too late for the Legacy Import is not available to use the coding from there. 

18.08 might be to far along at this point to test, but that looks like the best branch to add it. 

This way TEC 4.6.17 will be the last branch that works with EB 4.4.8 or lower. 

Otherwise we need to tell people to use 4.6.15