### PR TITLE
Fix version number over `@since` docblocks for M18.08

### DIFF
--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -6,7 +6,7 @@ class Tribe__Events__Admin__Notice__Marketing {
 	/**
 	 * Register marketing notices.
 	 *
-	 * @since 4.6.16
+	 * @since 4.6.17
 	 */
 	public function hook() {
 		tribe_notice(
@@ -22,7 +22,7 @@ class Tribe__Events__Admin__Notice__Marketing {
 	}
 
 	/**
-	 * @since 4.6.16
+	 * @since 4.6.17
 	 *
 	 * @return bool
 	 */
@@ -37,7 +37,7 @@ class Tribe__Events__Admin__Notice__Marketing {
 	/**
 	 * HTML for the notice for sites using UTC Timezones.
 	 *
-	 * @since 4.6.16
+	 * @since 4.6.17
 	 *
 	 * @return string
 	 */

--- a/src/Tribe/Admin/Notice/Timezones.php
+++ b/src/Tribe/Admin/Notice/Timezones.php
@@ -24,7 +24,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 	 * Checks if we are in an TEC page or over
 	 * the WordPress > Settings > General
 	 *
-	 * @since  4.6.16
+	 * @since  4.6.17
 	 *
 	 * @return boolean
 	 */
@@ -44,7 +44,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 	/**
 	 * Checks if the site is using UTC Timezone Options
 	 *
-	 * @since  4.6.16
+	 * @since  4.6.17
 	 *
 	 * @return boolean
 	 */
@@ -57,7 +57,7 @@ class Tribe__Events__Admin__Notice__Timezones {
 	/**
 	 * HTML for the notice for sites using UTC Timezones.
 	 *
-	 * @since  4.6.16
+	 * @since  4.6.17
 	 *
 	 * @return string
 	 */

--- a/tests/integration/Unticketed_Cost_Formatting_Test.php
+++ b/tests/integration/Unticketed_Cost_Formatting_Test.php
@@ -9,7 +9,7 @@ class Unticketed_Cost_Formatting_Test extends Events_TestCase {
 	/**
 	 * Set some default/common event meta to be used across test events.
 	 *
-	 * @since 4.6.16
+	 * @since 4.6.17
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -18,7 +18,7 @@ class Unticketed_Cost_Formatting_Test extends Events_TestCase {
 	/**
 	 * Teardown upon test completion.
 	 *
-	 * @since 4.6.16
+	 * @since 4.6.17
  	 */
 	public function tearDown() {
 		parent::tearDown();
@@ -58,7 +58,7 @@ class Unticketed_Cost_Formatting_Test extends Events_TestCase {
 	/**
 	 * Formatting methods rely on Cost Utils heavily, so ensure it exists.
 	 *
-	 * @since 4.6.16
+	 * @since 4.6.17
 	 */
 	public function test_cost_utils_exists() {
 		$this->assertTrue( class_exists( 'Tribe__Events__Cost_Utils' ), 'Check that Tribe__Events__Cost_Utils exists' );


### PR DESCRIPTION
Fix version number to `4.6.17` after fix with master.