### PR TITLE
Restore filter name probably unintentionnally modified

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2934,7 +2934,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				 * @var $meta
 				 * @var $single
 				 */
-				$value = apply_filters( "tribe_get_meta_default_value_{ $filter }", $default, $id, $meta, $single );
+				$value = apply_filters( "tribe_get_meta_default_value_{$filter}", $default, $id, $meta, $single );
 			}
 			return $value;
 		}


### PR DESCRIPTION
In 1173c0a16f8db03155a35fe86acf88ff956bc67c, the filter `'tribe_get_meta_default_value_' . $filter` has been modified to `"tribe_get_meta_default_value_{ $filter }"`. This breaks all the 3rd party code using the filter (in my case, this breaks part of the compatibility made with Polylang Pro). I propose to restore the filter name to its initial value.