### PR TITLE
Fix the pagination in list view when a keyword is being searched

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 * Fix - Make the date picker respect the "Start of the week" Setting. Thanks to @websource, @dsb and others for flagging this! [76320]
 * Fix - Correct the "View All" link when using the events month view and plain permalinks. props to Kay and Robert for notifying us [72544]
+* Fix - Correct the pagination in list view when a keyword is being searched. Thanks to @versi, @akr and Mary for reporting this! [94613]
 
 = [4.6.17] 2018-05-29 =
 

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -106,6 +106,7 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 			$hash['paged']      = null;
 			$hash['start_date'] = null;
 			$hash['end_date']   = null;
+			$hash['search_orderby_title'] = null;
 			$hash_str           = md5( maybe_serialize( $hash ) );
 
 			if ( ! empty( $_POST['hash'] ) && $hash_str !== $_POST['hash'] ) {

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -82,10 +82,10 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 
 			// check & set display
 			if ( isset( $_POST['tribe_event_display'] ) ) {
-				if ( $_POST['tribe_event_display'] == 'past' ) {
+				if ( 'past' === $_POST['tribe_event_display'] ) {
 					$args['eventDisplay'] = 'past';
 					$args['order'] = 'DESC';
-				} elseif ( 'all' == $_POST['tribe_event_display'] ) {
+				} elseif ( 'all' === $_POST['tribe_event_display'] ) {
 					$args['eventDisplay'] = 'all';
 				}
 			}

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 
 			Tribe__Events__Main::instance()->displaying = apply_filters( 'tribe_events_listview_ajax_event_display', 'list', $args );
 
-			if ( ! empty( $_POST['tribe_event_display'] ) && $_POST['tribe_event_display'] == 'past' ){
+			if ( ! empty( $_POST['tribe_event_display'] ) && 'past' === $_POST['tribe_event_display'] ) {
 				$response['view'] = 'past';
 			}
 


### PR DESCRIPTION
https://central.tri.be/issues/94613

The problem with the hash had to do with the `search_orderby_title` LIKE delimiters being hashed as well and changing every time it was being requested.