### PR TITLE
Add venue name to full address string

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2837,7 +2837,14 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function fullAddressString( $postId = null ) {
 			$address = '';
+			if ( tribe_get_venue( $postId ) ) {
+				$address .= tribe_get_venue( $postId );
+			}
+
 			if ( tribe_get_address( $postId ) ) {
+				if ( $address != '' ) {
+					$address .= ', ';
+				}
 				$address .= tribe_get_address( $postId );
 			}
 


### PR DESCRIPTION
This allows iCal exports to generate some location info and aids the end-user into more easily recognising where exactly they should be when they're close to the event location. It also makes sure that there is at least some location info in the iCal export, to prevent confusion both for the WordPress webmaster (why isn't the location showing up?) as to the end-user (what is the name of the place I need to be).

My username on WordPress.org is sylviavanos.

_Ref:_ [C#110464](http://central.tri.be/issues/110464)