### PR TITLE
Handle exceptions thrown during EA imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,8 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.6.19] TBD =
 
 * Fix - More robust handling of errors and exceptions during Event Aggregator imports [107929]
+* Tweak - Add the `tribe_aggregator_async_insert_event` filter to allow overriding the Event Aggregator asynchronous event insertion [107929]
+* Tweak - Add the `'tribe_aggregator_async_import_event_task` filter to allow overriding the Event Aggregator asynchronous import task [107929]
 * Tweak - Added venue google map link to events in Day view [91610]
 * Feature - CSV importer now supports a featured event column [72376]
 

--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [4.6.19] TBD =
 
+* Fix - More robust handling of errors and exceptions during Event Aggregator imports [107929]
 * Tweak - Added venue google map link to events in Day view [91610]
 * Feature - CSV importer now supports a featured event column [72376]
 


### PR DESCRIPTION
Ticket:  107929

This PR:
* adds two filters in the async queue EA import code to allow overriding the whole import task (`tribe_aggregator_async_import_event_task`) or just the event insertion step (`tribe_aggregator_async_insert_event`)
* wraps the event insertion step in a `try/catch` block to orderly handle the case where the event insertion will generate an error/exception