### PR TITLE
Fix a php notice

### DIFF
--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -269,8 +269,10 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 		} elseif ( ! empty( $_REQUEST['tribe-bar-geoloc'] ) ) {
 			$geographic_term = $_REQUEST['tribe-bar-geoloc'];
 		}
-		if ( is_tax( $tribe->get_event_taxonomy() ) ) {
-			$tax_term = get_term_by( 'slug', get_query_var( 'term' ), $tribe->get_event_taxonomy() );
+
+		$maybe_term = get_query_var( 'term' );
+		if ( is_tax( $tribe->get_event_taxonomy() ) && ! empty( $maybe_term ) ) {
+			$tax_term = get_term_by( 'slug', $maybe_term, $tribe->get_event_taxonomy() );
 			$tax_term = esc_html( $tax_term->name );
 		}
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/61888

This does not address the issue in the ticket (can't reproduce it) but does fix a php warning when the expected query var isn't available.