### PR TITLE
Check the Events Aggregator license each time the EA page is accessed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Ensure that the "Export Events" button is properly displayed in month view when paginating. Thanks to @linpleva, Steven, Will and others for flagging this! [104751]
 * Fix - Month view pagination for datepicker formats: YYYY.MM.DD, MM.DD.YYYY, and DD.MM.YYYY. Thanks @netzwerk, @wdburgdorf, @oliverwick and others for notifying us! [105443]
 * Fix - Resolved customizer inconsistencies with month/week views and full styles [69758]
+* Fix - Check the Events Aggregator license each time the page is accessed [67864]
 * Tweak - Add the `tribe_aggregator_async_insert_event` filter to allow overriding the Event Aggregator asynchronous event insertion [107929]
 * Tweak - Add the `'tribe_aggregator_async_import_event_task` filter to allow overriding the Event Aggregator asynchronous import task [107929]
 * Tweak - Added venue google map link to events in Day view [91610]

--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -55,6 +55,9 @@ class Tribe__Events__Aggregator__Page {
 		add_action( 'current_screen', array( $this, 'action_request' ) );
 		add_action( 'init', array( $this, 'init' ) );
 
+		// check if the license is valid each time the page is accessed
+		add_action( 'tribe_aggregator_page_request', array( $this, 'check_for_updates' ) );
+
 		// filter the plupload default settings to remove mime type restrictions
 		add_filter( 'plupload_default_settings', array( $this, 'filter_plupload_default_settings' ) );
 
@@ -198,6 +201,21 @@ class Tribe__Events__Aggregator__Page {
 	 */
 	public function is_screen() {
 		return ! empty( $this->ID ) && Tribe__Admin__Helpers::instance()->is_screen( $this->ID );
+	}
+
+	/**
+	 * Checks if the license is still valid once the aggregator page
+	 * is accessed.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function check_for_updates() {
+
+		$aggregator = tribe( 'events-aggregator.main' );
+		$aggregator->pue_checker->check_for_updates();
+
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -56,7 +56,7 @@ class Tribe__Events__Aggregator__Page {
 		add_action( 'init', array( $this, 'init' ) );
 
 		// check if the license is valid each time the page is accessed
-		add_action( 'tribe_aggregator_page_request', array( $this, 'check_for_updates' ) );
+		add_action( 'tribe_aggregator_page_request', array( $this, 'check_for_license_updates' ) );
 
 		// filter the plupload default settings to remove mime type restrictions
 		add_filter( 'plupload_default_settings', array( $this, 'filter_plupload_default_settings' ) );
@@ -211,7 +211,7 @@ class Tribe__Events__Aggregator__Page {
 	 *
 	 * @return void
 	 */
-	public function check_for_updates() {
+	public function check_for_license_updates() {
 
 		$aggregator = tribe( 'events-aggregator.main' );
 		$aggregator->pue_checker->check_for_updates();


### PR DESCRIPTION
https://central.tri.be/issues/67864

Add this check, so users with expired licenses cannot add new "premium" imports.