### PR TITLE
Fix: to drop the order from the query we need to unset orderby, not order.

### DIFF
--- a/src/Tribe/Integrations/WPML/Linked_Posts.php
+++ b/src/Tribe/Integrations/WPML/Linked_Posts.php
@@ -126,7 +126,7 @@ class Tribe__Events__Integrations__WPML__Linked_Posts {
 		}
 
 		// IDs only and drop the order to avoid wasting time on something we'll account for later
-		$sub_query_args = array_merge( $args, array( 'fields' => 'ids', 'order' => false ) );
+		$sub_query_args = array_merge( $args, array( 'fields' => 'ids', 'orderby' => false ) );
 
 		$linked_posts_ids = $this->get_current_language_linked_posts_ids( $sub_query_args );
 


### PR DESCRIPTION
I double checked this change works by looking at the queries with "Query Monitor"

- Before this change I could see the "order by" which we are trying to remove.
- And after this change I could see the same query without the "order by" as intended.