### PR TITLE
Allow Organizer insert/update REST API arguments to be empty so that values can be set as empty

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -310,6 +310,7 @@ The plugin is made with love by [Modern Tribe Inc](http://m.tri.be/2s).
 
 = TBD =
 
+* Tweak - Allow REST API arguments for Organizers to be empty so that fields can be set as empty values [106026]
 * Tweak - Sending an empty `timezone` parameter to the REST API for an event no longer results in an error response and now properly clears the timezone for the event [100274]
 * Tweak - Introduced the `tribe_events_event_insert_args` filter to allow changing arguments used for insert an event with the API [102545]
 * Tweak - Introduced the `tribe_events_event_update_args` filter to allow changing arguments used for updating an event with the API [102545]

--- a/src/Tribe/REST/V1/Endpoints/Single_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Organizer.php
@@ -57,7 +57,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 		 */
 		$avoid_duplicates = apply_filters( 'tribe_events_rest_organizer_insert_avoid_duplicates', true, $postarr );
 
-		$id = Tribe__Events__Organizer::instance()->create( array_filter( $postarr ), $postarr['post_status'], $avoid_duplicates );
+		$id = Tribe__Events__Organizer::instance()->create( $postarr, $postarr['post_status'], $avoid_duplicates );
 
 		if ( empty( $id ) ) {
 			$message = $this->messages->get_message( 'could-not-create-organizer' );
@@ -223,36 +223,42 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_user_id' ),
 				'type'              => 'integer',
+				'default'           => null,
 				'description'       => __( 'The organizer author ID', 'the-events-calendar' ),
 			),
 			'date'        => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_time' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer publication date', 'the-events-calendar' ),
 			),
 			'date_utc'    => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_time' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer publication date (UTC time zone)', 'the-events-calendar' ),
 			),
 			'organizer'   => array(
 				'required'          => true,
 				'validate_callback' => array( $this->validator, 'is_string_not_empty' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer name', 'the-events-calendar' ),
 			),
 			'description' => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer description', 'the-events-calendar' ),
 			),
 			'status'      => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_post_status' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer post status', 'the-events-calendar' ),
 			),
 			// Organizer meta fields
@@ -260,24 +266,28 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer phone number', 'the-events-calendar' ),
 			),
 			'website'     => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_url' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer website', 'the-events-calendar' ),
 			),
 			'email'       => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_string' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer e-mail address', 'the-events-calendar' ),
 			),
 			'image'       => array(
 				'required'          => false,
 				'validate_callback' => array( $this->validator, 'is_image' ),
 				'type'              => 'string',
+				'default'           => null,
 				'description'       => __( 'The organizer featured image ID or URL', 'the-events-calendar' ),
 			),
 		);
@@ -333,6 +343,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 		 * @since 4.6.9
 		 */
 		$postarr = apply_filters( 'tribe_events_rest_organizer_prepare_postarr', $postarr, $request );
+
+		$postarr = array_filter( $postarr, array( $this->validator, 'is_not_null' ) );
 
 		return $postarr;
 	}
@@ -440,7 +452,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Organizer
 	public function update( WP_REST_Request $request ) {
 		$postarr = $this->prepare_postarr( $request );
 
-		$id = Tribe__Events__Organizer::instance()->update( $request['id'], array_filter( $postarr ) );
+		$id = Tribe__Events__Organizer::instance()->update( $request['id'], $postarr );
 
 		if ( empty( $id ) ) {
 			$message = $this->messages->get_message( 'could-not-update-organizer' );

--- a/tests/restv1/OrganizerUpdateCest.php
+++ b/tests/restv1/OrganizerUpdateCest.php
@@ -156,6 +156,61 @@ class OrganizerUpdateCest extends BaseRestCest {
 	}
 
 	/**
+	 * It should allow updating optional meta as empty along with the organizer
+	 *
+	 * @test
+	 */
+	public function it_should_allow_updating_optional_meta_as_empty_along_with_the_organizer( Tester $I ) {
+		$organizer_id = $I->haveOrganizerInDatabase();
+
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$I->sendPOST( $this->organizers_url . "/{$organizer_id}", [
+			'organizer' => 'A organizer',
+			'email'     => '',
+			'phone'     => '',
+			'website'   => '',
+		] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertArrayHasKey( 'id', $response );
+		$I->assertArrayHasKey( 'organizer', $response );
+		$I->assertArrayNotHasKey( 'email', $response );
+		$I->assertArrayNotHasKey( 'phone', $response );
+		$I->assertArrayNotHasKey( 'website', $response );
+
+		$I->assertEquals( 'A organizer', $response['organizer'] );
+	}
+
+	/**
+	 * It should allow updating without optional meta along with the organizer
+	 *
+	 * @test
+	 */
+	public function it_should_allow_updating_without_optional_meta_along_with_the_organizer( Tester $I ) {
+		$organizer_id = $I->haveOrganizerInDatabase();
+
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$I->sendPOST( $this->organizers_url . "/{$organizer_id}", [
+			'organizer' => 'A organizer',
+		] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertArrayHasKey( 'id', $response );
+		$I->assertArrayHasKey( 'organizer', $response );
+		$I->assertArrayHasKey( 'email', $response );
+		$I->assertArrayHasKey( 'phone', $response );
+		$I->assertArrayHasKey( 'website', $response );
+
+		$I->assertEquals( 'A organizer', $response['organizer'] );
+	}
+
+	/**
 	 * It should allow updating the image as an attachment ID along with the organizer
 	 *
 	 * @test


### PR DESCRIPTION
https://central.tri.be/issues/106026