### PR TITLE
Display the exact search term in the "no results" notice on the events page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,6 +215,10 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
+= [4.6.20] TBD =
+
+* Fix - Display the exact search term in the "no results" notice on the events page [106991]
+
 = [4.6.19] 2018-06-20 =
 
 * Feature - CSV importer now supports a featured event column [72376]

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -454,7 +454,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 			if ( ! empty( $search_term ) ) {
 				Tribe__Notices::set_notice( 'event-search-no-results', sprintf( esc_html__( 'There were no results found for %s this month. Try searching next month.', 'the-events-calendar' ),
-					'<strong>"' . esc_html( $search_term ) . '"</strong>' ) );
+					'<strong>"' . esc_html( urldecode( $search_term ) ) . '"</strong>' ) );
 			} // if attempting to view a category archive.
 			elseif ( ! empty( $tax_term ) ) {
 				Tribe__Notices::set_notice( 'events-not-found', sprintf( esc_html__( 'No matching %1$s listed under %2$s. Please try viewing the full calendar for a complete list of events.', 'the-events-calendar' ), $events_label_plural_lowercase, $tax_term ) );


### PR DESCRIPTION
🎫 https://central.tri.be/issues/106991

When there was a search, the "No results" notice was not decoding the complete search, so it was displaying something like:

`There were no results found for "your+awesome+search" this month. Try searching next month.`