### PR TITLE
Allow venue and organizer fields to be intentionally empty on Event Singular REST API calls

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.6.20] TBD =
 
 * Fix - Display the exact search term in the "no results" notice on the events page [106991]
+* Fix - Allow venue and organizer fields to be intentionally empty on Event Singular REST API calls [109482]
 * Tweak - Added event ID parameter to `tribe_events_event_classes` filter to make it more useful [64807]
 
 = [4.6.19] 2018-06-20 =

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -326,14 +326,14 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 			// Linked Posts
 			'venue'              => array(
 				'required'          => false,
-				'validate_callback' => array( $this->validator, 'is_venue_id_or_entry' ),
+				'validate_callback' => array( $this->validator, 'is_venue_id_or_entry_or_empty' ),
 				'swagger_type'      => 'array',
 				'items'             => array( 'type' => 'integer' ),
 				'description'       => __( 'The event venue ID or data', 'the-events-calendar' ),
 			),
 			'organizer'          => array(
 				'required'          => false,
-				'validate_callback' => array( $this->validator, 'is_organizer_id_or_entry' ),
+				'validate_callback' => array( $this->validator, 'is_organizer_id_or_entry_or_empty' ),
 				'swagger_type'      => 'array',
 				'items'             => array( 'type' => 'integer' ),
 				'description'       => __( 'The event organizer IDs or data', 'the-events-calendar' ),

--- a/src/Tribe/REST/V1/Validator/Base.php
+++ b/src/Tribe/REST/V1/Validator/Base.php
@@ -5,6 +5,23 @@ class Tribe__Events__REST__V1__Validator__Base
 	extends Tribe__Events__Validator__Base
 	implements Tribe__Events__REST__V1__Validator__Interface {
 
+	/**
+	 * Determine if a value is a Venue ID, entry, or empty.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array $venue Venue ID or entry.
+	 *
+	 * @return bool Whether a value is a Venue ID, entry, or empty.
+	 */
+	public function is_venue_id_or_entry_or_empty( $venue ) {
+		if ( empty( $venue ) ) {
+			return true;
+		}
+
+		return $this->is_venue_id_or_entry( $venue );
+	}
+
 	public function is_venue_id_or_entry( $venue ) {
 		if ( ! is_array( $venue ) ) {
 			return tribe_is_venue( $venue );
@@ -26,6 +43,31 @@ class Tribe__Events__REST__V1__Validator__Base
 		$has_valid_params = $request->has_valid_params();
 
 		return true === $has_valid_params ? true : false;
+	}
+
+	/**
+	 * Determine if a value is a Organizer ID, entry, or empty.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array $organizer Organizer ID or entry.
+	 *
+	 * @return bool Whether a value is a Organizer ID, entry, or empty.
+	 */
+	public function is_organizer_id_or_entry_or_empty( $organizer ) {
+		if ( empty( $organizer ) ) {
+			return true;
+		}
+
+		if ( is_array( $organizer ) ) {
+			$check_if_empty = array_filter( $organizer );
+
+			if ( empty( $check_if_empty ) ) {
+				return true;
+			}
+		}
+
+		return $this->is_organizer_id_or_entry( $organizer );
 	}
 
 	public function is_organizer_id_or_entry( $organizer ) {


### PR DESCRIPTION
https://central.tri.be/issues/109482