### PR TITLE
Fix Google Map API giving console error when no API key present

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [4.6.21] TBD =
 
+* Fix - Ensure no console errors are being displayed if there's no Google Maps API key present. Thanks Greg for flagging this [95312]
 
 = [4.6.20] 2018-07-09 =
 

--- a/src/Tribe/Embedded_Maps.php
+++ b/src/Tribe/Embedded_Maps.php
@@ -164,7 +164,12 @@ class Tribe__Events__Embedded_Maps {
 		$api_url = 'https://maps.google.com/maps/api/js';
 		$api_key = tribe_get_option( 'google_maps_js_api_key' );
 
-		if ( ! empty( $api_key ) && is_string( $api_key ) ) {
+		// bail if we don't have an API key
+		if ( empty( $api_key ) ) {
+			return;
+		}
+
+		if ( is_string( $api_key ) ) {
 			$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s', trim( $api_key ) );
 		}
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/95312

Don't enqueue the Google Maps scripts if no API Key present. (prevent errors from being displayed in the console)

