### PR TITLE
Fix - Error being displayed when navigating through the month view calendar

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,9 +215,10 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
-= [4.6.20.1] TBD =
+= [4.6.20.1] 2018-07-10 =
 
 * Fix - Fix an issue where Event Aggregator imports might get blocked at 1% progress [110258]
+* Fix - Fix the error displayed when navigating the month view via shortcode. Thanks Lam, @ltcalendar, Disk and others for flagging this! [109589]
 
 = [4.6.20] 2018-07-09 =
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -397,7 +397,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				$args = array(
 					'post_type'    => Tribe__Events__Main::POSTTYPE,
 					'eventDisplay' => 'month',
-					'eventDate'    => $_POST['eventDate'],
+					'eventDate'    => is_array( $_POST['eventDate'] ) ? Tribe__Utils__Array::get( $_POST, array( 'eventDate', 0 ) ) : $_POST['eventDate'],
 					'post_status'  => $post_status,
 					'featured'     => tribe( 'tec.featured_events' )->featured_events_requested(),
 				);


### PR DESCRIPTION
🎫 https://central.tri.be/issues/109589

Pushing this hotfix. The real problem is related to the calendar nav (baseurl, etc) when using the shortcode.