### PR TITLE
Allow event categories and tags to be provided as empty for saving

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -228,6 +228,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
   * `tribe_get_linked_posts_by_post_type()` no longer returns empty in error
   * Editing an existing event no longer loses the linked posts just because they were not part of the submission. Example: If organizers are editable in the wp-admin event edit screen but not on the Community Events "event edit" form (via template override or other custom code), all pre-existing organizers were removed in error.
 * Add - Added WPML metadata improvements for Organizers and Venue. Thanks to David Garcia Watkins and the entire WPML team for their contribution [106798]
+* Fix - Sending empty 'categories' and 'tags' for the REST API event endpoints when inserting and updating events [109627]
 
 = [4.6.20.1] 2018-07-10 =
 

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -560,11 +560,26 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 			'EventCurrencySymbol'   => tribe( 'cost-utils' )->parse_currency_symbol( $request['cost'] ),
 			'EventURL'              => filter_var( $request['website'], FILTER_SANITIZE_URL ),
 			// Taxonomies
-			'tax_input'             => array_filter( array(
-				$events_cat => Tribe__Terms::translate_terms_to_ids( $request['categories'], $events_cat ),
-				'post_tag'  => Tribe__Terms::translate_terms_to_ids( $request['tags'], 'post_tag' ),
-			) ),
+			'tax_input'             => array(),
 		);
+
+		// Check if categories is provided (allowing for empty array to remove categories).
+		if ( isset( $request['categories'] ) ) {
+			$postarr[ $events_cat ] = array();
+
+			if ( ! empty( $request['categories'] ) ) {
+				$postarr[ $events_cat ] = Tribe__Terms::translate_terms_to_ids( $request['categories'], $events_cat );
+			}
+		}
+
+		// Check if tags is provided (allowing for empty array to remove tags).
+		if ( isset( $request['tags'] ) ) {
+			$postarr['post_tag'] = array();
+
+			if ( ! empty( $request['tags'] ) ) {
+				$postarr['post_tag'] = Tribe__Terms::translate_terms_to_ids( $request['tags'], 'post_tag' );
+			}
+		}
 
 		// If an empty EventTimezone was passed, lets unset it so it can be unset during event meta save
 		if ( empty( $postarr['EventTimezone'] ) ) {

--- a/tests/restv1/EventInsertionCest.php
+++ b/tests/restv1/EventInsertionCest.php
@@ -1044,6 +1044,30 @@ class EventInsertionCest extends BaseRestCest {
 	}
 
 	/**
+	 * It should allow no event categories while inserting an event
+	 *
+	 * @test
+	 */
+	public function it_should_allow_no_event_categories_while_inserting_an_event( Tester $I ) {
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$params = [
+			'title'       => 'An event',
+			'description' => 'An event content',
+			'start_date'  => 'tomorrow 9am',
+			'end_date'    => 'tomorrow 11am',
+			'categories'  => '',
+		];
+
+		$I->sendPOST( $this->events_url, $params );
+
+		$I->seeResponseCodeIs( 201 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertEmpty( $response['categories'] );
+	}
+
+	/**
 	 * It should allow assigning existing categories and creating new categories while inserting an event
 	 *
 	 * @test
@@ -1128,6 +1152,30 @@ class EventInsertionCest extends BaseRestCest {
 		$response = json_decode( $I->grabResponse(), true );
 		$I->assertNotEmpty( $response['tags'] );
 		$I->assertCount( 2, $response['tags'] );
+	}
+
+	/**
+	 * It should allow no event tags while inserting an event
+	 *
+	 * @test
+	 */
+	public function it_should_allow_no_event_tags_while_inserting_an_event( Tester $I ) {
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$params = [
+			'title'       => 'An event',
+			'description' => 'An event content',
+			'start_date'  => 'tomorrow 9am',
+			'end_date'    => 'tomorrow 11am',
+			'tags'        => '',
+		];
+
+		$I->sendPOST( $this->events_url, $params );
+
+		$I->seeResponseCodeIs( 201 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertEmpty( $response['tags'] );
 	}
 
 	/**

--- a/tests/restv1/EventUpdateCest.php
+++ b/tests/restv1/EventUpdateCest.php
@@ -1183,6 +1183,36 @@ class EventUpdateCest extends BaseRestCest
 	}
 
 	/**
+	 * It should allow no event categories while inserting an event
+	 *
+	 * @test
+	 */
+	public function it_should_allow_no_event_categories_while_inserting_an_event( Tester $I ) {
+		$event_id = $I->haveEventInDatabase( [
+			'tax_input' => [
+				'tribe_events_cat' => [ 'category-1', 'category-2' ],
+			],
+		] );
+
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$params = [
+			'title'       => 'An event',
+			'description' => 'An event content',
+			'start_date'  => 'tomorrow 9am',
+			'end_date'    => 'tomorrow 11am',
+			'categories'  => '',
+		];
+
+		$I->sendPOST( $this->events_url . "/{$event_id}", $params );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertEmpty( $response['categories'] );
+	}
+
+	/**
 	 * It should allow assigning existing categories and creating new categories while inserting an event
 	 *
 	 * @test
@@ -1273,6 +1303,36 @@ class EventUpdateCest extends BaseRestCest
 		$response = json_decode( $I->grabResponse(), true );
 		$I->assertNotEmpty( $response['tags'] );
 		$I->assertCount( 2, $response['tags'] );
+	}
+
+	/**
+	 * It should allow no event tags while inserting an event
+	 *
+	 * @test
+	 */
+	public function it_should_allow_no_event_tags_while_inserting_an_event( Tester $I ) {
+		$event_id = $I->haveEventInDatabase( [
+			'tax_input' => [
+				'post_tag' => [ 'tag-1', 'tag-2' ],
+			],
+		] );
+
+		$I->generate_nonce_for_role( 'administrator' );
+
+		$params = [
+			'title'       => 'An event',
+			'description' => 'An event content',
+			'start_date'  => 'tomorrow 9am',
+			'end_date'    => 'tomorrow 11am',
+			'tags'        => '',
+		];
+
+		$I->sendPOST( $this->events_url . "/{$event_id}", $params );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->seeResponseIsJson();
+		$response = json_decode( $I->grabResponse(), true );
+		$I->assertEmpty( $response['tags'] );
 	}
 
 	/**


### PR DESCRIPTION
https://central.tri.be/issues/109627

Adds tests for empty categories/tags