### PR TITLE
WPML compatibility for Venues and Organizers fix

### DIFF
--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -25,7 +25,7 @@ class Tribe__Events__Integrations__WPML__Meta {
 	 */
 	public function translate_post_id( $value, $object_id, $meta_key ) {
 
-		if ( isset( $_POST ) ) {
+		if ( isset( $_POST ) && ! empty( $_POST ) ) {
 			return $value;
 		}
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/106798

Only return when $_POST is set and there's something in it.