### PR TITLE
Revert "Fix warning in redirect_past_upcoming_view_urls()"

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -558,7 +558,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			add_filter( 'nav_menu_items_' . self::POSTTYPE, array( $this, 'add_events_checkbox_to_menu' ), null, 3 );
 			add_filter( 'wp_nav_menu_objects', array( $this, 'add_current_menu_item_class_to_events' ), null, 2 );
 
-			add_action( 'template_redirect', array( $this, 'redirect_past_upcoming_view_urls' ), 9 );
+			add_filter( 'template_redirect', array( $this, 'redirect_past_upcoming_view_urls' ), 9 );
 
 			/* Setup Tribe Events Bar */
 			add_filter( 'tribe-events-bar-views', array( $this, 'setup_listview_in_bar' ), 1, 1 );
@@ -2278,7 +2278,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			// Prep strings so we can compare paths sans any leading/trailing slashes
-			$requested_path         = trim( $requested_path['path'], '/' );
+			$requested_path = trim( $requested_path, '/' );
 			$legacy_past_events_url = $this->getRewriteSlug() . '/' . $this->pastSlug;
 			$legacy_upcoming_events_url = $this->getRewriteSlug() . '/' . $this->upcomingSlug;
 


### PR DESCRIPTION
Reverts moderntribe/the-events-calendar#1880

After testing I found we do not return an array as we use the functions to return only the component we want.

_Ref:_ [C#110463](https://central.tri.be/issues/110463)

We pass the component we want to:
https://developer.wordpress.org/reference/functions/wp_parse_url/

Which then uses this function to return only that:
https://developer.wordpress.org/reference/functions/_get_component_from_parsed_url_array/

I plan to change the add_filter back to the correct add_action in another PR