### PR TITLE
#111198 - fix 'tec.bar' is not a bound alias error

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -433,6 +433,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe_singleton( 'tec.customizer.single-event', new Tribe__Events__Customizer__Single_Event() );
 			tribe_singleton( 'tec.customizer.widget', new Tribe__Events__Customizer__Widget() );
 
+			// Tribe Bar
+			tribe_singleton( 'tec.bar', 'Tribe__Events__Bar', array( 'hook' ) );
+
 			// iCal
 			tribe_singleton( 'tec.iCal', 'Tribe__Events__iCal', array( 'hook' ) );
 


### PR DESCRIPTION
_Ref:_ [C#111198](https://central.tri.be/issues/111198)