### PR TITLE
Fix: Load frontend assets when using shortcode

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -394,11 +394,14 @@ class Tribe__Events__Assets {
 	 * @return bool
 	 */
 	public function should_enqueue_frontend() {
+		global $post;
+
 		$should_enqueue = (
 			tribe_is_event_query()
 			|| tribe_is_event_organizer()
 			|| tribe_is_event_venue()
 			|| is_active_widget( false, false, 'tribe-events-list-widget' )
+			|| ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'tribe_events' ) )
 		);
 
 		/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -401,7 +401,7 @@ class Tribe__Events__Assets {
 			|| tribe_is_event_organizer()
 			|| tribe_is_event_venue()
 			|| is_active_widget( false, false, 'tribe-events-list-widget' )
-			|| ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'tribe_events' ) )
+			|| ( $post instanceof WP_Post && has_shortcode( $post->post_content, 'tribe_events' ) )
 		);
 
 		/**


### PR DESCRIPTION
🎫 https://central.tri.be/issues/40267

Make sure that the frontend assets are loaded when using the `[tribe_events]` shortcode