### PR TITLE
add tests and code to return single and archive checksums

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -12,6 +12,12 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 	class Tribe__Events__Query {
 
 		/**
+		 * @var array The WP_Query arguments used in the last `getEvents` method
+		 *            query.
+		 */
+		protected static $last_query_args;
+
+		/**
 		 * Initialize The Events Calendar query filters and post processing.
 		 */
 		public static function init() {
@@ -1121,6 +1127,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			$args = array_filter( $args, array( __CLASS__, 'filter_args' ) );
 			ksort( $args );
 
+			self::$last_query_args = $args;
+
 			$cache     = new Tribe__Cache();
 			$cache_key = 'get_events_' . get_current_user_id() . serialize( $args );
 
@@ -1193,6 +1201,31 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			}
 
 			return $postmeta_table;
+		}
+
+		/**
+		 * Reruns the last query used to `getEvents` to fetch
+		 * all the found IDs.
+		 *
+		 * Pagination is ignored; this methods provides a way to
+		 * not only count the found posts but to get their ID too.
+		 *
+		 * @since TBD
+		 *
+		 * @return array
+		 */
+		public static function last_found_ids() {
+			$last_query_args = self::$last_query_args;
+
+			if ( empty( $last_query_args ) ) {
+				return null;
+			}
+
+			$last_query_args['fields'] = 'ids';
+			$last_query_args['posts_per_page'] = '-1';
+			$query = new WP_Query( $last_query_args );
+
+			return $query->get_posts();
 		}
 
 		/**

--- a/src/Tribe/REST/V1/Documentation/Event_Definition_Provider.php
+++ b/src/Tribe/REST/V1/Documentation/Event_Definition_Provider.php
@@ -23,6 +23,10 @@ class Tribe__Events__REST__V1__Documentation__Event_Definition_Provider
 					'type' => 'integer',
 					'description' => __( 'The event WordPress post ID', 'the-events-calendar' ),
 				),
+				'checksum'=> array(
+					'type' => 'string',
+					'description' => __( 'The event checksum', 'the-events-calendar' ),
+				),
 				'global_id' => array(
 					'type' => 'string',
 					'description' => __( 'The event ID used to globally identify in Event Aggregator', 'the-events-calendar' ),

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -139,6 +139,7 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 		}
 
 		$events = tribe_get_events( $args );
+		$found_events = Tribe__Events__Query::last_found_ids();
 
 		$page = $this->parse_page( $request ) ? $this->parse_page( $request ) : 1;
 
@@ -166,6 +167,8 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 
 		$data['total'] = $total = $this->get_total( $args );
 		$data['total_pages'] = $this->get_total_pages( $total, $args['posts_per_page'] );
+		$data['page_checksum'] = tribe_posts_checksum( $events );
+		$data['request_checksum'] = tribe_posts_checksum( $found_events );
 
 		/**
 		 * Filters the data that will be returned for an events archive request.

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -76,6 +76,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 
 		$data = array(
 			'id'                     => $event_id,
+			'checksum'               => tribe_post_checksum( $event_id ),
 			'global_id'              => false,
 			'global_id_lineage'      => array(),
 			'author'                 => $event->post_author,

--- a/tests/restv1/RequestChecksumCest.php
+++ b/tests/restv1/RequestChecksumCest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Step\Restv1\RestGuy as Tester;
+
+class RequestChecksumCest extends BaseRestCest{
+
+	/**
+	 * It should return the single event checksum when getting the single event
+	 *
+	 * @test
+	 */
+	public function should_return_the_single_event_checksum_when_getting_the_single_event( Tester $I ) {
+		$event = $I->haveEventInDatabase();
+
+		$expected_checksum = tribe_post_checksum( $event );
+
+		$I->sendGET( $this->events_url . "/{$event}" );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->canSeeResponseIsJson();
+		$I->canSeeResponseContainsJson( [
+			'checksum' => $expected_checksum,
+		] );
+	}
+
+	/**
+	 * It should return archive checksums
+	 *
+	 * @test
+	 */
+	public function should_return_archive_checksums( Tester $I ) {
+		$all_ids = $I->haveManyEventsInDatabase( 10 );
+		$expected_request_checksum = tribe_posts_checksum( $all_ids );
+
+		$I->sendGET( $this->events_url, [ 'per_page' => 2 ] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->canSeeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+		$page_ids = array_column( $response['events'], 'id' );
+		$req_1_pg_checksum = tribe_posts_checksum( $page_ids );
+
+		$I->canSeeResponseContainsJson( [
+			'request_checksum' => $expected_request_checksum,
+			'page_checksum'    => $req_1_pg_checksum,
+		] );
+
+		$I->sendGET( $this->events_url, [ 'per_page' => 5, ] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->canSeeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+		$page_ids = array_column( $response['events'], 'id' );
+
+		$req_2_pg_checksum = tribe_posts_checksum( $page_ids );
+		$I->canSeeResponseContainsJson( [
+			'request_checksum' => $expected_request_checksum,
+			'page_checksum'    => $req_2_pg_checksum,
+		] );
+
+		$I->assertNotEquals( $req_1_pg_checksum, $req_2_pg_checksum );
+
+		$I->sendGET( $this->events_url, [ 'per_page' => 5, 'page' => 2 ] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->canSeeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+		$page_ids = array_column( $response['events'], 'id' );
+
+		$req_3_pg_checksum = tribe_posts_checksum( $page_ids );
+
+		$I->canSeeResponseContainsJson( [
+				'request_checksum' => $expected_request_checksum,
+				'page_checksum'    => $req_3_pg_checksum,
+			]
+		);
+
+		$I->assertNotEquals( $req_1_pg_checksum, $req_3_pg_checksum );
+		$I->assertNotEquals( $req_2_pg_checksum, $req_3_pg_checksum );
+	}
+
+	/**
+	 * It should return empty checksum if archive does not contain any results
+	 *
+	 * @test
+	 */
+	public function should_return_empty_checksum_if_archive_does_not_contain_any_results( Tester $I ) {
+		update_option( 'tribe_disable_shindig', true );
+
+		$I->sendGET( $this->events_url, [ 'search' => 'sljdlsdkdjflskjdfsdffjd' ] );
+
+		$I->seeResponseCodeIs( 200 );
+		$I->canSeeResponseIsJson();
+
+		$response = json_decode( $I->grabResponse(), true );
+
+		$I->canSeeResponseContainsJson( [
+			'request_checksum' => null,
+			'page_checksum'    => null,
+		] );
+	}
+}


### PR DESCRIPTION
Ticket: n/a

This PR leverages the work done in https://github.com/moderntribe/tribe-common/pull/747 to return checksums in Event REST API responses:
* for single events the checksum is the checksum of the event itself
* for archive two checksums are returned `page_checksum` for the checksum of the current page, and `request_checksum` for the checksum relative to the whole request; the two could have the same values if no pagination is involved

I've added some logic in the `Tribe__Events__Query` class and the `last_found_ids` method.