### PR TITLE
Add more checks and fallbacks to handle queues

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -230,6 +230,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Add - Enable future event display to get all events in the future that have not started [70769]
 * Fix - Prevent subsequent CSV imports from duplicating events in some instances [102745]
 * Fix - The "Import events but preserve local changes to event fields" Event Aggregator change authority setting will now behave as expected [87443]
+* Fix - Handle the case where Event Aggregator import queues might get stuck when deleting import records [111856]
 
 = [4.6.21] 2018-08-01 =
 

--- a/src/Tribe/Aggregator/Processes/Queue_Control.php
+++ b/src/Tribe/Aggregator/Processes/Queue_Control.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Class Tribe__Events__Aggregator__Processes__Queue_Control
+ *
+ * @since TBD
+ */
+class Tribe__Events__Aggregator__Processes__Queue_Control {
+
+	/**
+	 * Clears the queues, in whatever state they are, related to Event Aggregator imports
+	 * and redirects the user to the current page or a specified location.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|string $location The location the user should be redirected to or null
+	 *                              to use the current location.
+	 */
+	public function clear_queues_and_redirect( $location = null ) {
+		if ( empty( tribe_get_request_var( 'clear_queues', false ) ) ) {
+			return;
+		}
+
+		$this->clear_queues();
+
+		$location = null !== $location ? $location : remove_query_arg( 'clear_queues' );
+
+		wp_redirect( $location );
+		tribe_exit();
+	}
+
+	/**
+	 * Clears the queues, in whatever state they are, related to Event Aggregator imports.
+	 *
+	 * @since TBD
+	 */
+	public function clear_queues() {
+		Tribe__Process__Queue::delete_all_queues( 'tribe_queue_ea_import_events' );
+	}
+}

--- a/src/Tribe/Aggregator/Processes/Queue_Control.php
+++ b/src/Tribe/Aggregator/Processes/Queue_Control.php
@@ -17,7 +17,9 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 	 *                              to use the current location.
 	 */
 	public function clear_queues_and_redirect( $location = null ) {
-		if ( empty( tribe_get_request_var( 'clear_queues', false ) ) ) {
+		$clear_queues = tribe_get_request_var( 'clear_queues', false );
+
+		if ( empty( $clear_queues ) ) {
 			return;
 		}
 

--- a/src/Tribe/Aggregator/Processes/Service_Provider.php
+++ b/src/Tribe/Aggregator/Processes/Service_Provider.php
@@ -15,8 +15,14 @@ class Tribe__Events__Aggregator__Processes__Service_Provider extends tad_DI52_Se
 	public function register() {
 		tribe_register( 'events-aggregator.record-items', 'Tribe__Events__Aggregator__Record__Items' );
 		tribe_register( 'events-aggregator.processes.import-events', 'Tribe__Events__Aggregator__Processes__Import_Events' );
+		tribe_singleton( 'events-aggregator.queue-control', 'Tribe__Events__Aggregator__Processes__Queue_Control' );
 
 		add_filter( 'tribe_process_queues', array( $this, 'filter_tribe_process_queues' ) );
+
+		if ( tribe_get_request_var( 'clear_queues', false ) ) {
+			$clear_queues = tribe_callback( 'events-aggregator.queue-control', 'clear_queues_and_redirect' );
+			add_action( 'tribe_aggregator_page_request', $clear_queues, 9, 0 );
+		}
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -235,7 +235,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 			return false;
 		}
 
-		if ( $this->current_queue->is_stuck() ) {
+		if ( $this->current_queue->is_stuck() || $this->current_queue->has_errors() ) {
 			$this->current_queue->kill_queue();
 
 			return false;
@@ -279,6 +279,14 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 
 		if ( is_numeric( $record ) ) {
 			$record = tribe( 'events-aggregator.records' )->get_by_post_id( $record );
+		}
+
+		if ( ! $record instanceof Tribe__Events__Aggregator__Record__Abstract ) {
+			if ( $record instanceof WP_Error ) {
+				return new Tribe__Events__Aggregator__Record__Void_Queue( $record );
+			}
+
+			return new Tribe__Events__Aggregator__Record__Void_Queue( __( 'There was an error building the record queue: ' . print_r( $record, true ) ) );
 		}
 
 		$class = 'Tribe__Events__Aggregator__Record__Async_Queue';

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -181,7 +181,6 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 			),
 		);
 
-
 		if ( $interactive_only ) {
 			$args['meta_query'][] = array(
 				'key' => Tribe__Events__Aggregator__Record__Abstract::$meta_key_prefix . 'interactive',

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -119,22 +119,21 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		$this->ajax_operations->verify_or_exit( $_POST['check'], $this->get_ajax_nonce_action(), $this->get_unable_to_continue_processing_data() );
 
 		// Load the queue
+		/** @var \Tribe__Events__Aggregator__Record__Queue_Interface $queue */
 		$queue = $this->queue ? $this->queue : Tribe__Events__Aggregator__Record__Queue_Processor::build_queue( $this->record_id );
 
 		// We always need to setup the Current Queue
 		$this->queue_processor->set_current_queue( $queue );
 
-		// Only if it's not empty that we care about proccesing.
+		// Only if it's not empty that we care about processing.
 		if ( ! $queue->is_empty() ) {
 			$this->queue_processor->process_batch( $this->record_id );
 		}
 
-		/** @var \Tribe__Events__Aggregator__Record__Queue_Interface $current_queue */
-		$current_queue = $this->queue_processor->current_queue;
-		$done          = $current_queue->is_empty();
-		$percentage    = $current_queue->progress_percentage();
+		$done       = $queue->is_empty();
+		$percentage = $queue->progress_percentage();
 
-		$this->ajax_operations->exit_data( $this->get_progress_message_data( $current_queue, $percentage, $done ) );
+		$this->ajax_operations->exit_data( $this->get_progress_message_data( $queue, $percentage, $done ) );
 	}
 
 	/**
@@ -219,11 +218,11 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 			),
 		);
 
+		$messages = Tribe__Events__Aggregator__Tabs__New::instance()->get_result_messages( $queue );
+
 		if ( $error ) {
-			$messages           = Tribe__Events__Aggregator__Tabs__New::instance()->get_result_messages( $queue );
 			$data['error_text'] = '<p>' . implode( ' ', $messages['error'] ) . '</p>';
 		} elseif ( $done ) {
-			$messages              = Tribe__Events__Aggregator__Tabs__New::instance()->get_result_messages( $queue );
 			$data['complete_text'] = '<p>' . implode( ' ', $messages['success'] ) . '</p>';
 		}
 

--- a/src/Tribe/Aggregator/Record/Void_Queue.php
+++ b/src/Tribe/Aggregator/Record/Void_Queue.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Class Tribe__Events__Aggregator__Record__Void_Queue
+ *
+ * @since TBD
+ */
+class Tribe__Events__Aggregator__Record__Void_Queue
+	implements Tribe__Events__Aggregator__Record__Queue_Interface {
+
+	/**
+	 * The error string for the queue.
+	 *
+	 * @var string
+	 */
+	protected $error;
+
+	/**
+	 * The WP_Error instance used to build the void queue, if any.
+	 *
+	 * @var WP_Error
+	 */
+	protected $wp_error;
+
+	/**
+	 * Tribe__Events__Aggregator__Record__Void_Queue constructor.
+	 *
+	 * @param string|WP_Error $error The reason, in form of a string or
+	 *                               `WP_Error` object, why this queue
+	 *                               is void.
+	 */
+	public function __construct( $error ) {
+		if ( $error instanceof WP_Error ) {
+			$this->error    = $error->get_error_message();
+			$this->wp_error = $error;
+
+			return;
+		}
+
+		$this->error = $error;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function activity() {
+		return new Tribe__Events__Aggregator__Record__Activity();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function count() {
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function is_empty() {
+		// A void queue is not empty, it's void.
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function process( $batch_size = null ) {
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function progress_percentage() {
+		// return a 0% progress percentage to make sure the queue processor will process it.
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function set_in_progress_flag() {
+		// no-op
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function clear_in_progress_flag() {
+		// no-op
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function is_in_progress() {
+		// mark the queue as in progress to make the queue processor process it.
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_queue_type() {
+		// not really important, still let's maintain coherence.
+		return Tribe__Events__Main::POSTTYPE;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function is_stuck() {
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function kill_queue() {
+		if ( empty( $this->error ) ) {
+			$this->error = __( 'Unable to process this import - a breakage or conflict may have resulted in the import halting.', 'the-events-calendar' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function has_errors() {
+		return null !== $this->error;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_error_message() {
+		return $this->error;
+	}
+
+	/**
+	 * Returns the `WP_Error` instance used to build this void queue, if any.
+	 *
+	 * @since TBD
+	 *
+	 * @return WP_Error|null The `WP_Error` used to build this void queue or `null`
+	 *                       if no `WP_Error` object was used to build this void queue.
+	 */
+	public function get_wp_error() {
+		return $this->wp_error;
+	}
+}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/Queue_ProcessorTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/Queue_ProcessorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tribe\Events\Aggregator\Record;
+
+use Tribe__Events__Aggregator__Record__Abstract as Record;
+use Tribe__Events__Aggregator__Record__Async_Queue as Async_Queue;
+use Tribe__Events__Aggregator__Record__Queue_Processor as Processor;
+use Tribe__Events__Aggregator__Record__Void_Queue as Void_Queue;
+
+class Queue_ProcessorTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * It should return an Async_Queue instance when passing valid record
+	 *
+	 * @test
+	 */
+	public function should_return_an_async_queue_instance_when_passing_valid_record() {
+		$record = $this->prophesize( Record::class );
+
+		$queue = Processor::build_queue( $record->reveal(), [ 'foo' => 'bar' ], false );
+
+		$this->assertInstanceOf( Async_Queue::class, $queue );
+	}
+
+	/**
+	 * It should return a void queue when the passed record ID is invalid
+	 *
+	 * @test
+	 */
+	public function should_return_a_void_queue_when_the_passed_record_id_is_invalid() {
+		$record = 23;
+		$items  = [ 'foo' => 'bar' ];
+		$queue  = Processor::build_queue( $record, $items, false );
+
+		$this->assertNotInstanceOf( Async_Queue::class, $queue );
+		$this->assertInstanceOf( Void_Queue::class, $queue );
+	}
+}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/Queue_RealtimeTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/Queue_RealtimeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tribe\Events\Aggregator\Record;
+
+use Tribe__Events__Aggregator__Record__Abstract as Record;
+use Tribe__Events__Aggregator__Record__Queue_Processor as Processor;
+use Tribe__Events__Aggregator__Record__Queue_Realtime as Realtime;
+use Tribe__Events__Ajax__Operations as Ajax;
+
+class Queue_RealtimeTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * It should correctly handle a void queue due to non-existing record
+	 *
+	 * @test
+	 */
+	public function should_correctly_handle_a_void_queue_due_to_non_existing_record() {
+		$this->setup_request( 23 );
+		$ajax = $this->make_ajax_operations();
+
+		$realtime = new Realtime( null, $ajax, new Processor() );
+		$realtime->ajax();
+
+		$output_data = json_decode( $ajax->data, true );
+		$this->assertArrayHasKey( 'error', $output_data );
+		$this->assertTrue( $output_data['error'] );
+		$this->assertArrayHasKey( 'counts', $output_data );
+		$this->assertEmpty( array_sum( $output_data['counts'] ) );
+		$this->assertArrayHasKey( 'error_text', $output_data );
+		$expected_error = tribe_error( 'core:aggregator:invalid-record-object' )->get_error_message();
+		$this->assertEquals( '<p>' . $expected_error . '</p>', $output_data['error_text'] );
+	}
+
+	protected function setup_request( $record_id ) {
+		$_POST['record'] = $record_id;
+		$_POST['check']  = 'spoofed-by-anonymous-ajax-class';
+	}
+
+	protected function make_ajax_operations() {
+		$ajax = new class extends Ajax {
+			public $data;
+
+			public function verify_or_exit( $nonce, $action, $exit_data = array() ) {
+				return true;
+			}
+
+			public function exit_data( $data = array() ) {
+				$this->data = $data;
+			}
+		};
+
+		return $ajax;
+	}
+
+	/**
+	 * It should correctly handle a valid queue
+	 *
+	 * @test
+	 */
+	public function should_correctly_handle_a_valid_queue() {
+		$record = $this->make_record();
+		$this->setup_request( $record->id );
+		$ajax = $this->make_ajax_operations();
+
+		$realtime = new Realtime( null, $ajax, new Processor() );
+		$realtime->ajax();
+
+		$output_data = json_decode( $ajax->data, true );
+		$this->assertArrayHasKey( 'error', $output_data );
+		$this->assertFalse( $output_data['error'] );
+		$this->assertArrayHasKey( 'complete', $output_data );
+		$this->assertTrue( $output_data['complete'] );
+	}
+
+	protected function make_record() {
+		$id = $this->factory()->post->create( [
+			'post_type'      => 'tribe-ea-record',
+			'post_mime_type' => 'ea/gcal',
+			'meta_input'     => [
+				Record::$meta_key_prefix . 'origin'       => 'gcal',
+				Record::$meta_key_prefix . 'content_type' => 'tribe_events',
+			],
+			'ping_status'    => 'manual',
+		] );
+
+		$record = new class( $id ) extends Record {
+			public $origin = 'gcal';
+
+			public function __construct( $id ) {
+				$this->id = $id;
+			}
+
+			public function get_label() {
+				return 'test';
+			}
+		};
+
+		return $record;
+	}
+}


### PR DESCRIPTION
Ticket:  https://central.tri.be/issues/111856
Builds on: https://github.com/moderntribe/tribe-common/pull/751

This PR adds the following (w/ tests):
* make it so that queues "orphaned" of a Records will be graciously handled and removed
* refine some Queue_Processor and Queue_Realtime code
* add a listener, on Event Aggregator > Import pages to allow users to clear all import queues appending the `clear_queues=1` query variable to the URL