### PR TITLE
⌗107821 Use Scott's Regex to Support More Eventbrite Domains

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Fixed the "Full Styles" mobile view. Thanks Matthew, Laura and others for flagging this! [112301]
 * Fix - Modify resource url function to work in mu-plugin directory, thanks to Doug for reporting it  [86104]
 * Fix - Remove references to and settings for Facebook importing in Event Aggregator [112432]
+* Fix - Ensure Event Aggregator allows for importing events from Eventbrite sites other than eventbrite.com, including but not limited to eventbrite.ca, .co.uk, and .co.nz [107821]
 * Tweak - Add the WordPress Custom Fields Metabox show|hide settings from the Events Calendar Pro [109815]
 * Deprecated - `Tribe__Events__Aggregator__Record__Facebook`
 * Fix - Allow venue location fields to be intentionally empty on Venue Singular REST API calls [108834]

--- a/src/Tribe/Aggregator/Record/Eventbrite.php
+++ b/src/Tribe/Aggregator/Record/Eventbrite.php
@@ -27,7 +27,7 @@ class Tribe__Events__Aggregator__Record__Eventbrite extends Tribe__Events__Aggre
 	 * @return string
 	 */
 	public static function get_source_regexp() {
-		return '^(https?:\/\/)?(www\.)?eventbrite\.com(\.[a-z]{2})?\/';
+		return '^(https?:\/\/)?(www\.)?eventbrite\.[a-z]{2,3}(\.[a-z]{2})?\/';
 	}
 
 	/**


### PR DESCRIPTION
**Ticket:** [**⌗107821**](http://central.tri.be/issues/107821)

Scott has a very good brain and used it to make this regex. This regex now lets folks import Eventbrite events from more domains than just `eventbrite.com`. Thanks Scott!