### PR TITLE
Expose and support UI to select import process system

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,8 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Tweak - Add the WordPress Custom Fields Metabox show|hide settings from the Events Calendar Pro [109815]
 * Deprecated - `Tribe__Events__Aggregator__Record__Facebook`
 * Fix - Allow venue location fields to be intentionally empty on Venue Singular REST API calls [108834]
+* Tweak - Allow changing Event Aggregator import process system between the asynchronous and the cron-based one; previously only available as a filter [113418, 113475]
+* Tweak - Allow stopping and clearing asynchronous queue processes from the admin UI [113418, 113475]
 
 = [4.6.22.1] 2018-08-27 =
 

--- a/src/Tribe/Aggregator/Processes/Queue_Control.php
+++ b/src/Tribe/Aggregator/Processes/Queue_Control.php
@@ -7,6 +7,8 @@
  */
 class Tribe__Events__Aggregator__Processes__Queue_Control {
 
+	const CLEAR_PROCESSES = 'tribe_clear_ea_processes';
+
 	/**
 	 * Clears the queues, in whatever state they are, related to Event Aggregator imports
 	 * and redirects the user to the current page or a specified location.
@@ -17,7 +19,7 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 	 *                              to use the current location.
 	 */
 	public function clear_queues_and_redirect( $location = null ) {
-		$clear_queues = tribe_get_request_var( 'clear_queues', false );
+		$clear_queues = tribe_get_request_var( self::CLEAR_PROCESSES, false );
 
 		if ( empty( $clear_queues ) ) {
 			return;
@@ -25,7 +27,7 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 
 		$this->clear_queues();
 
-		$location = null !== $location ? $location : remove_query_arg( 'clear_queues' );
+		$location = null !== $location ? $location : remove_query_arg( self::CLEAR_PROCESSES );
 
 		wp_redirect( $location );
 		tribe_exit();
@@ -37,6 +39,6 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 	 * @since 4.6.22
 	 */
 	public function clear_queues() {
-		Tribe__Process__Queue::delete_all_queues( 'tribe_queue_ea_import_events' );
+		Tribe__Process__Queue::delete_all_queues( 'ea_import_events' );
 	}
 }

--- a/src/Tribe/Aggregator/Processes/Queue_Control.php
+++ b/src/Tribe/Aggregator/Processes/Queue_Control.php
@@ -8,6 +8,7 @@
 class Tribe__Events__Aggregator__Processes__Queue_Control {
 
 	const CLEAR_PROCESSES = 'tribe_clear_ea_processes';
+	const CLEAR_RESULT = 'tribe_clear_ea_processes_result';
 
 	/**
 	 * Clears the queues, in whatever state they are, related to Event Aggregator imports
@@ -25,9 +26,13 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 			return;
 		}
 
-		$this->clear_queues();
+		$cleared = $this->clear_queues();
 
-		$location = null !== $location ? $location : remove_query_arg( self::CLEAR_PROCESSES );
+		$location = null !== $location
+			? $location
+			: remove_query_arg( self::CLEAR_PROCESSES );
+
+		$location = add_query_arg( array( self::CLEAR_RESULT => $cleared ), $location );
 
 		wp_redirect( $location );
 		tribe_exit();
@@ -37,8 +42,10 @@ class Tribe__Events__Aggregator__Processes__Queue_Control {
 	 * Clears the queues, in whatever state they are, related to Event Aggregator imports.
 	 *
 	 * @since 4.6.22
+	 *
+	 * @return int The number of cleared queue processes.
 	 */
 	public function clear_queues() {
-		Tribe__Process__Queue::delete_all_queues( 'ea_import_events' );
+		return Tribe__Process__Queue::delete_all_queues( 'ea_import_events' );
 	}
 }

--- a/src/Tribe/Aggregator/Processes/Service_Provider.php
+++ b/src/Tribe/Aggregator/Processes/Service_Provider.php
@@ -19,14 +19,9 @@ class Tribe__Events__Aggregator__Processes__Service_Provider extends tad_DI52_Se
 
 		add_filter( 'tribe_process_queues', array( $this, 'filter_tribe_process_queues' ) );
 
-		if (
-			tribe_get_request_var( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES, false )
-			&& is_admin()
-			&& current_user_can( 'manage_options' )
-		) {
-			$clear_queues = tribe_callback( 'events-aggregator.queue-control', 'clear_queues_and_redirect' );
-			add_action( 'admin_init', $clear_queues, 9, 0 );
-		}
+		$this->handle_clear_request();
+		$this->handle_clear_result();
+
 	}
 
 	/**
@@ -42,5 +37,50 @@ class Tribe__Events__Aggregator__Processes__Service_Provider extends tad_DI52_Se
 		$queues[] = 'Tribe__Events__Aggregator__Processes__Import_Events';
 
 		return $queues;
+	}
+
+	/**
+	 * Handles requests to clear queue processes.
+	 *
+	 * @since TBD
+	 */
+	protected function handle_clear_request() {
+		if (
+			tribe_get_request_var( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES, false )
+			&& is_admin()
+			&& current_user_can( 'manage_options' )
+		) {
+			$clear_queues = tribe_callback( 'events-aggregator.queue-control', 'clear_queues_and_redirect' );
+			add_action( 'admin_init', $clear_queues, 9, 0 );
+		}
+	}
+
+	/**
+	 * Handles requests to show the queue processes clearing results.
+	 *
+	 * @since TBD
+	 */
+	protected function handle_clear_result() {
+		// `0` removed queue processes is still something we would want to notify users about
+		$clear_result = tribe_get_request_var( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_RESULT, false );
+
+		if ( false !== $clear_result ) {
+			$message = 0 === (int) $clear_result
+				? sprintf( esc_html__( 'No queue processes to clear.', 'the-events-calendar' ), $clear_result )
+				: sprintf( esc_html(
+					_n(
+						'Successfully stopped and cleared 1 queue process.',
+						'Successfully stopped and cleared %d queue processes.',
+						(int) $clear_result,
+						'the-events-calendar'
+					)
+				), $clear_result );
+
+			tribe_notice(
+				'ea-clear-queues-result',
+				'<p>' . $message . '</p>',
+				array( 'type' => 'success' )
+			);
+		}
 	}
 }

--- a/src/Tribe/Aggregator/Processes/Service_Provider.php
+++ b/src/Tribe/Aggregator/Processes/Service_Provider.php
@@ -19,9 +19,13 @@ class Tribe__Events__Aggregator__Processes__Service_Provider extends tad_DI52_Se
 
 		add_filter( 'tribe_process_queues', array( $this, 'filter_tribe_process_queues' ) );
 
-		if ( tribe_get_request_var( 'clear_queues', false ) ) {
+		if (
+			tribe_get_request_var( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES, false )
+			&& is_admin()
+			&& current_user_can( 'manage_options' )
+		) {
 			$clear_queues = tribe_callback( 'events-aggregator.queue-control', 'clear_queues_and_redirect' );
-			add_action( 'tribe_aggregator_page_request', $clear_queues, 9, 0 );
+			add_action( 'admin_init', $clear_queues, 9, 0 );
 		}
 	}
 

--- a/src/Tribe/Aggregator/Processes/Service_Provider.php
+++ b/src/Tribe/Aggregator/Processes/Service_Provider.php
@@ -20,7 +20,7 @@ class Tribe__Events__Aggregator__Processes__Service_Provider extends tad_DI52_Se
 		add_filter( 'tribe_process_queues', array( $this, 'filter_tribe_process_queues' ) );
 		add_filter( 'tribe_settings_save_field_value', array(
 			$this,
-			'filter_tribe_settings_save_field_value'
+			'filter_tribe_settings_save_field_value',
 		), 10, 2 );
 
 		$this->handle_clear_request();

--- a/src/Tribe/Aggregator/Record/Queue.php
+++ b/src/Tribe/Aggregator/Record/Queue.php
@@ -302,6 +302,16 @@ class Tribe__Events__Aggregator__Record__Queue implements Tribe__Events__Aggrega
 				$batch_size = apply_filters( 'tribe_aggregator_batch_size', Tribe__Events__Aggregator__Record__Queue_Processor::$batch_size );
 			}
 
+			/*
+			 * If the queue system is switched mid-imports this might happen.
+			 * In that case we conservatively stop (kill) the queue process.
+			 */
+			if ( ! is_array( $this->items ) ) {
+				$this->kill_queue();
+
+				return $this;
+			}
+
 			// Every time we are about to process we reset the next var
 			$this->next = array_splice( $this->items, 0, $batch_size );
 

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -288,7 +288,9 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 			return new Tribe__Events__Aggregator__Record__Void_Queue( __( 'There was an error building the record queue: ' . print_r( $record, true ) ) );
 		}
 
-		$class = 'Tribe__Events__Aggregator__Record__Async_Queue';
+		/** @var Tribe__Events__Aggregator__Settings $settings */
+		$settings = tribe( 'events-aggregator.settings' );
+		$class    = $settings->get_import_process_class();
 
 		// Force the use of the Legacy Queue for CSV Imports
 		if ( $record instanceof Tribe__Events__Aggregator__Record__CSV || $use_legacy ) {
@@ -302,9 +304,11 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 		 *
 		 * @since 4.6.16
 		 *
-		 * @param string $class
-		 * @param Tribe__Events__Aggregator__Record__Abstract $record
-		 * @param array|string $items
+		 * @param string $class                                       The import process class that will be used to process
+		 *                                                            import records.
+		 * @param Tribe__Events__Aggregator__Record__Abstract $record The current record being processed.
+		 * @param array|string $items                                 Either an array of the record items to process or a string
+		 *                                                            to indicate pre-process states like fetch or on-hold.
 		 */
 		$class = apply_filters( 'tribe_aggregator_queue_class', $class, $record, $items );
 

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -136,7 +136,7 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		 * @var \Tribe__Events__Aggregator__Record__Queue_Interface $current_queue
 		 */
 		$current_queue = $this->queue_processor->current_queue;
-		$done          = $current_queue->is_empty();
+		$done = $current_queue->is_empty() && empty( $current_queue->is_fetching );
 		$percentage    = $current_queue->progress_percentage();
 
  		$this->ajax_operations->exit_data( $this->get_progress_message_data( $current_queue, $percentage, $done ) );

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -118,7 +118,7 @@ $global = $ical = $ics = $gcal = $meetup = $url = $eb_fields = array();
 if ( Tribe__Events__Aggregator::is_service_active() ) {
 
 	$stop_running_processes_message = sprintf(
-		__( 'If you want to stop current asynchronous import processes or remove them %1$s.', 'the-events-calendar' ),
+		__( 'If you want to stop and clear current asynchronous import processes %1$s.', 'the-events-calendar' ),
 		sprintf( '<a href="' . add_query_arg( array( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES => 1 ) ) . '">%s</a>',
 			esc_html__( 'click here', 'the-events-calendar' )
 		)
@@ -226,7 +226,7 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'priority' => 5.8,
 		),
 		'tribe_aggregator_import_process_control'=> array(
-			'type' => 'html',
+			'type' => 'wrapped_html',
 			'label' => esc_html__( 'Stop current processes', 'the-events-calendar' ),
 			'html' => $stop_running_processes_message,
 			'priority' => 5.9,

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -116,7 +116,15 @@ $ea_disable = array(
 $global = $ical = $ics = $gcal = $meetup = $url = $eb_fields = array();
 // if there's an Event Aggregator license key, add the Global settings, iCal, and Meetup fields
 if ( Tribe__Events__Aggregator::is_service_active() ) {
-	$global = array(
+
+	$stop_running_processes_message = sprintf(
+		__( 'If you want to stop current import processes or remove them %1$s.', 'the-events-calendar' ),
+		sprintf( '<a href="' . add_query_arg( array( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES => 1 ) ) . '">%s</a>',
+			esc_html__( 'click here', 'the-events-calendar' )
+		)
+	);
+
+	$global                 = array(
 		'import-defaults' => array(
 			'type' => 'html',
 			'html' => '<h3 id="tribe-import-global-settings">' . esc_html__( 'Global Import Settings', 'the-events-calendar' ) . '</h3>',
@@ -217,6 +225,12 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'options' => tribe( 'events-aggregator.settings' )->get_import_process_options( true ),
 			'priority' => 5.8,
 		),
+		'tribe_aggregator_import_process_control'=> array(
+			'type' => 'html',
+			'label' => esc_html__( 'Stop current processes', 'the-events-calendar' ),
+			'html' => $stop_running_processes_message,
+			'priority' => 5.9,
+		)
 	);
 
 	$ical = array(

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -205,6 +205,18 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			),
 			'priority' => 5.7,
 		),
+		'tribe_aggregator_import_process_system'=> array(
+			'type' => 'dropdown',
+			'label' => esc_html__( 'Import Process System', 'the-events-calendar' ),
+			'tooltip' => esc_html__( 'The Asynchronous import process is faster and does not rely on WordPress Cron but might not work correctly in all WordPress installations, try switching to the Cron-based process for maximum compatibility.', 'the-events-calendar' ),
+			'size' => 'medium',
+			'validation_type' => 'options',
+			'default' => tribe( 'events-aggregator.settings' )->get_import_process_default( false ),
+			'can_be_empty' => false,
+			'parent_option' => Tribe__Events__Main::OPTIONNAME,
+			'options' => tribe( 'events-aggregator.settings' )->get_import_process_options( true ),
+			'priority' => 5.8,
+		),
 	);
 
 	$ical = array(

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -213,7 +213,7 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			),
 			'priority' => 5.7,
 		),
-		'tribe_aggregator_import_process_system'=> array(
+		'tribe_aggregator_import_process_system' => array(
 			'type' => 'dropdown',
 			'label' => esc_html__( 'Import Process System', 'the-events-calendar' ),
 			'tooltip' => esc_html__( 'The Asynchronous import process is faster and does not rely on WordPress Cron but might not work correctly in all WordPress installations, try switching to the Cron-based process for maximum compatibility.', 'the-events-calendar' ),
@@ -225,12 +225,12 @@ if ( Tribe__Events__Aggregator::is_service_active() ) {
 			'options' => tribe( 'events-aggregator.settings' )->get_import_process_options( true ),
 			'priority' => 5.8,
 		),
-		'tribe_aggregator_import_process_control'=> array(
+		'tribe_aggregator_import_process_control' => array(
 			'type' => 'wrapped_html',
 			'label' => esc_html__( 'Stop current processes', 'the-events-calendar' ),
 			'html' => $stop_running_processes_message,
 			'priority' => 5.9,
-		)
+		),
 	);
 
 	$ical = array(

--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -118,7 +118,7 @@ $global = $ical = $ics = $gcal = $meetup = $url = $eb_fields = array();
 if ( Tribe__Events__Aggregator::is_service_active() ) {
 
 	$stop_running_processes_message = sprintf(
-		__( 'If you want to stop current import processes or remove them %1$s.', 'the-events-calendar' ),
+		__( 'If you want to stop current asynchronous import processes or remove them %1$s.', 'the-events-calendar' ),
 		sprintf( '<a href="' . add_query_arg( array( Tribe__Events__Aggregator__Processes__Queue_Control::CLEAR_PROCESSES => 1 ) ) . '">%s</a>',
 			esc_html__( 'click here', 'the-events-calendar' )
 		)


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/113418
* https://central.tri.be/issues/113475

Screencast: http://p.tri.be/qTnJfj
Switching queue system while importing: http://p.tri.be/8mdhK0

This PR:

* exposes, via UI, a way for users to select which import process to use (asynchronous or cron-based)
* adds a link, and supports, stopping and removing async queues, be them in a working or stuck status
* supports (handles) the case where the system is switched mid-import; cron->async will finish "speeding up" (see second screencast); async -> cron will stop the async process