### PR TITLE
#112221 - move Google Maps API loading to tribe_assets and only load …

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.6.24] TBD =
 
 * Fix - Only load widget assets when widget is active on the page [113141]
+* Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first first reporting [112221]
 
 = [4.6.23] 2018-09-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -218,7 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.6.24] TBD =
 
 * Fix - Only load widget assets when widget is active on the page [113141]
-* Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first first reporting [112221]
+* Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 
 = [4.6.23] 2018-09-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 * Fix - Only load widget assets when widget is active on the page [113141]
 * Fix - Ensure that venue, organizer, and meta information doesn't show on password-protected events [102643]
+* Fix - Correct the Google Maps API link in the Settings help text to point to the correct API page [112322]
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 
 = [4.6.23] 2018-09-12 =

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -160,6 +160,43 @@ class Tribe__Events__Assets {
 		);
 
 		// FrontEnd
+		$api_url = 'https://maps.google.com/maps/api/js';
+		$api_key = tribe_get_option( 'google_maps_js_api_key' );
+
+		if ( ! empty( $api_key ) && is_string( $api_key ) ) {
+			$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s', trim( $api_key ) );
+		}
+
+		/**
+		 * Allows for filtering the embedded Google Maps API URL.
+		 *
+		 * @param string $api_url The Google Maps API URL.
+		 */
+		$google_maps_js_url = apply_filters( 'tribe_events_google_maps_api', $api_url );
+		tribe_asset(
+			$plugin,
+			'tribe-events-google-maps',
+			$google_maps_js_url,
+			null,
+			null,
+			array(
+				'type' => 'js',
+			)
+		);
+
+		// Setup our own script used to initialize each map
+		$embedded_map_url = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'embedded-map.js' ), true );
+		tribe_asset(
+			$plugin,
+			Tribe__Events__Embedded_Maps::MAP_HANDLE,
+			$embedded_map_url,
+			array( 'tribe-events-google-maps' ),
+			null,
+			array(
+				'type' => 'js',
+			)
+		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-events-dynamic',

--- a/src/Tribe/Embedded_Maps.php
+++ b/src/Tribe/Embedded_Maps.php
@@ -161,7 +161,6 @@ class Tribe__Events__Embedded_Maps {
 
 	protected function enqueue_map_scripts() {
 
-		$api_url = 'https://maps.google.com/maps/api/js';
 		$api_key = tribe_get_option( 'google_maps_js_api_key' );
 
 		// bail if we don't have an API key
@@ -169,22 +168,8 @@ class Tribe__Events__Embedded_Maps {
 			return;
 		}
 
-		if ( is_string( $api_key ) ) {
-			$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s', trim( $api_key ) );
-		}
-
-		/**
-		 * Allows for filtering the embedded Google Maps API URL.
-		 *
-		 * @param string $api_url The Google Maps API URL.
-		 */
-		$url = apply_filters( 'tribe_events_google_maps_api', $api_url );
-
-		wp_enqueue_script( 'tribe_events_google_maps_api', $url, array(), false, true );
-
-		// Setup our own script used to initialize each map
-		$url = Tribe__Events__Template_Factory::getMinFile( tribe_events_resource_url( 'embedded-map.js' ), true );
-		wp_enqueue_script( self::MAP_HANDLE, $url, array( 'tribe_events_google_maps_api' ), false, true );
+		tribe_asset_enqueue( 'tribe_events_google_maps_api' );
+		tribe_asset_enqueue(  self::MAP_HANDLE );
 
 		$this->map_script_enqueued = true;
 	}


### PR DESCRIPTION
…once on single views and Map View when PRO is active

_Ref:_ [C#112221](https://central.tri.be/issues/112221)

https://github.com/moderntribe/events-pro/pull/1003