### PR TITLE
#105176 & #113141 - fix list widget saving of jsonld and standard saving

### DIFF
--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -206,7 +206,7 @@ class Tribe__Events__List_Widget extends WP_Widget {
 		$instance['limit']                = $new_instance['limit'];
 		$instance['no_upcoming_events']   = isset( $new_instance['no_upcoming_events'] ) && $new_instance['no_upcoming_events'] ? true : false;
 		$instance['featured_events_only'] = isset( $new_instance['featured_events_only'] ) && $new_instance['featured_events_only'] ? true : false;
-		$instance['jsonld_enable']        = ( ! empty( $new_instance['jsonld_enable'] ) ? 1 : 0 );
+		$instance['jsonld_enable']        = ! empty( $new_instance['jsonld_enable'] ) ? 1 : 0;
 
 		return $instance;
 	}

--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -206,7 +206,7 @@ class Tribe__Events__List_Widget extends WP_Widget {
 		$instance['limit']                = $new_instance['limit'];
 		$instance['no_upcoming_events']   = isset( $new_instance['no_upcoming_events'] ) && $new_instance['no_upcoming_events'] ? true : false;
 		$instance['featured_events_only'] = isset( $new_instance['featured_events_only'] ) && $new_instance['featured_events_only'] ? true : false;
-		$instance['jsonld_enable']        = $new_instance['jsonld_enable'];
+		$instance['jsonld_enable']        = ( ! empty( $new_instance['jsonld_enable'] ) ? 1 : 0 );
 
 		return $instance;
 	}

--- a/src/admin-views/widget-admin-list.php
+++ b/src/admin-views/widget-admin-list.php
@@ -35,8 +35,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<label for="<?php echo esc_attr( $this->get_field_id( 'featured_events_only' ) ); ?>"><?php echo esc_html_x( 'Limit to featured events only', 'events list widget setting', 'the-events-calendar' ); ?></label>
 </p>
 <p>
-	<input id="<?php echo esc_attr( $this->get_field_id( 'jsonld_enable' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'jsonld_enable' ) ); ?>" type="checkbox" <?php checked( $instance['jsonld_enable'], 1 ); ?> value="1" />
-	<label for="<?php echo esc_attr( $this->get_field_id( 'jsonld_enable' ) ); ?>"><?php esc_html_e( 'Generate JSON-LD data', 'the-events-calendar' ); ?></label>
+	<input class="checkbox" type="checkbox" value="1" <?php checked( $instance['jsonld_enable'], true ); ?>
+	       id="<?php echo esc_attr( $this->get_field_id( 'jsonld_enable' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'jsonld_enable' ) ); ?>"/>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'jsonld_enable' ) ); ?>"><?php esc_html_e( 'Generate JSON-LD data', 'the-events-calendar-pro' ); ?></label>
 </p>
 
 <br>


### PR DESCRIPTION
This standardizes the saving process as well as fixing a notice error that could occur.  The readme entry is already merged. 

_Ref:_ [C#105176](https://central.tri.be/issues/105176)
_Ref:_ [C#113141](https://central.tri.be/issues/113141)

Relates to:
https://github.com/moderntribe/events-pro/pull/1008