### PR TITLE
#111518 - fix tribe_get_events to accept 0 as an argument

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Added checks to prevent JS Type Error in mobile view. Thanks szenenight, agrilife and others for flagging this! [113524]
 * Tweak - Added the `tribe_events_month_daily_events` filter to the Month view [114041]
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
+* Tweak - Accept 0 as an argument in tribe_get_events() so that `'post_parent' => 0` works, thanks Cy for the detailed report [111518]
 
 = [4.6.23] 2018-09-12 =
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1217,7 +1217,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * @return bool
 		 **/
 		private static function filter_args( $arg ) {
-			if ( empty( $arg ) && $arg !== false ) {
+			if ( empty( $arg ) && $arg !== false && 0 !== $arg ) {
 				return false;
 			}
 


### PR DESCRIPTION
_Ref:_ [C#111518](https://central.tri.be/issues/111518)