### PR TITLE
Handle the case where CSV file column headers are empty

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -228,6 +228,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Tweak - Added the `tribe_events_month_daily_events` filter to the Month view [114041]
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 * Tweak - Accept 0 as an argument in tribe_get_events() so that `'post_parent' => 0` works, thanks Cy for the detailed report [111518]
+* Fix - Ensure columns without headers are handled in CSV imports [114199]
 
 = [4.6.23] 2018-09-12 =
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -91,7 +91,20 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$this->update_meta( 'source_name', basename( $file_path ) );
 
 		$rows    = $importer->do_import_preview();
+
 		$headers = array_shift( $rows );
+
+		/*
+		 * To avoid empty columns from collapsing onto each other we provide
+		 * each column without an header a generated one.
+		 */
+		$empty_counter = 1;
+		foreach ( $headers as $key => &$header ) {
+			if ( empty( $header ) ) {
+				$header = __( 'Empty header ', 'the-events-calendar' ) . $empty_counter ++;
+			}
+		}
+
 		$data    = array();
 
 		foreach ( $rows as $row ) {

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -101,7 +101,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$empty_counter = 1;
 		foreach ( $headers as $key => &$header ) {
 			if ( empty( $header ) ) {
-				$header = __( 'Empty header ', 'the-events-calendar' ) . $empty_counter ++;
+				$header = __( 'Unknown Column ', 'the-events-calendar' ) . $empty_counter ++;
 			}
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/114199

Screencast: http://p.tri.be/MZsePs

This PR adds support, in CSV import, for empty column headers.
What would happen with empty column headers is that those would be collapsed into one thus hiding the column entirely and messing up the column indexes; this would result in broken imports and hidden results.