### PR TITLE
Remove Facebook records and notices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -228,6 +228,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Tweak - Added the `tribe_events_month_daily_events` filter to the Month view [114041]
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 * Tweak - Accept 0 as an argument in tribe_get_events() so that `'post_parent' => 0` works, thanks Cy for the detailed report [111518]
+* Fix - handle left-over Facebook scheduled imports and notices [114831]
 
 = [4.6.23] 2018-09-12 =
 

--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -115,9 +115,6 @@ class Tribe__Events__Aggregator {
 		if ( ! $this->api( 'origins' )->is_oauth_enabled( 'facebook' ) ) {
 			return;
 		}
-
-		tribe_notice( 'tribe-aggregator-facebook-token-expired', array( $this, 'notice_facebook_token_expired' ), 'type=error' );
-		tribe_notice( 'tribe-aggregator-facebook-oauth-feedback', array( $this, 'notice_facebook_oauth_feedback' ), 'type=success' );
 	}
 
 	/**
@@ -378,75 +375,6 @@ class Tribe__Events__Aggregator {
 	 */
 	private function daily_limit_transient_key() {
 		return 'tribe-aggregator-limit-used_' . date( 'Y-m-d' );
-	}
-
-	public function notice_facebook_oauth_feedback() {
-		if ( empty( $_GET['ea-auth'] ) || 'facebook' !== $_GET['ea-auth'] ) {
-			return false;
-		}
-
-		$html = '<p>' . esc_html__( 'Successfully connected Event Aggregator to Facebook', 'the-events-calendar' ) . '</p>';
-
-		return Tribe__Admin__Notices::instance()->render( 'tribe-aggregator-facebook-oauth-feedback', $html );
-	}
-
-	public function notice_facebook_token_expired() {
-		if ( ! Tribe__Admin__Helpers::instance()->is_screen() ) {
-			return false;
-		}
-
-		$expires = tribe_get_option( 'fb_token_expires' );
-
-		// Empty Token
-		if ( empty( $expires ) ) {
-			return false;
-		}
-
-		/**
-		 * Allow developers to filter how many seconds they want to be warned about FB token expiring
-		 * @param int
-		 */
-		$boundary = apply_filters( 'tribe_aggregator_facebook_token_expire_notice_boundary', 4 * DAY_IN_SECONDS );
-
-		// Creates a Boundary for expire warning to appear, before the actual expiring of the token
-		$boundary = $expires - $boundary;
-
-		if ( time() < $boundary ) {
-			return false;
-		}
-
-		$diff = human_time_diff( time(), $boundary );
-		$passed = ( time() - $expires );
-		$original = date( 'Y-m-d H:i:s', $expires );
-
-		$time[] = '<span title="' . esc_attr( $original ) . '">';
-		if ( $passed > 0 ) {
-			$time[] = sprintf( esc_html_x( 'about %s ago', 'human readable time ago', 'the-events-calendar' ), $diff );
-		} else {
-			$time[] = sprintf( esc_html_x( 'in about %s', 'in human readable time', 'the-events-calendar' ), $diff );
-		}
-		$time[] = '</span>';
-		$time = implode( '', $time );
-
-		ob_start();
-		?>
-		<p>
-			<?php
-			if ( $passed > 0 ) {
-				echo sprintf( __( 'Your Event Aggregator Facebook token expired %s.', 'the-events-calendar' ), $time );
-			} else {
-				echo sprintf( __( 'Your Event Aggregator Facebook token will expire %s.', 'the-events-calendar' ), $time );
-			}
-			?>
-		</p>
-		<p>
-			<a href="<?php echo esc_url( Tribe__Settings::instance()->get_url( array( 'tab' => 'addons' ) ) ); ?>" class="tribe-license-link"><?php esc_html_e( 'Renew your Event Aggregator Facebook token', 'the-events-calendar' ); ?></a>
-		</p>
-		<?php
-
-		$html = ob_get_clean();
-
-		return Tribe__Admin__Notices::instance()->render( 'tribe-aggregator-facebook-token-expired', $html );
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -314,12 +314,12 @@ class Tribe__Events__Aggregator__Cron {
 				continue;
 			}
 
-			if ( null === $record ) {
+			if ( $record instanceof Tribe__Events__Aggregator__Record__Unsupported ) {
 				/**
 				 * This means the record post exists but the origin is not currently supported.
 				 * To avoid re-looping on this let's trash this post and continue.
 				 */
-				wp_delete_post( $post->ID );
+				$record->delete( );
 				continue;
 			}
 

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -314,6 +314,15 @@ class Tribe__Events__Aggregator__Cron {
 				continue;
 			}
 
+			if ( null === $record ) {
+				/**
+				 * This means the record post exists but the origin is not currently supported.
+				 * To avoid re-looping on this let's trash this post and continue.
+				 */
+				wp_delete_post( $post->ID );
+				continue;
+			}
+
 			if ( ! $record->is_schedule_time() ) {
 				tribe( 'logger' )->log_debug( sprintf( 'Record (%d) skipped, not scheduled time', $record->id ), 'EA Cron' );
 				continue;

--- a/src/Tribe/Aggregator/Record/Unsupported.php
+++ b/src/Tribe/Aggregator/Record/Unsupported.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Models a record for a no longer, or not still, supported origin.
+ *
+ * Passing around an instance of an unsupported origin record should not break the code.
+ *
+ * @since TBD
+ */
+
+/**
+ * Class Tribe__Events__Aggregator__Record__Unsupported
+ *
+ * @since TBD
+ */
+class Tribe__Events__Aggregator__Record__Unsupported extends Tribe__Events__Aggregator__Record__Abstract {
+	/**
+	 * Tribe__Events__Aggregator__Record__Unsupported constructor.
+	 *
+	 * Overrides the base method to play along nicely for the request context
+	 * that builds this post and then remove it, if clean is allowed, on `shutdown`.
+	 *
+	 * @param int|WP_Post|null $post The record post or post ID.
+	 */
+	public function __construct( $post = null ) {
+		parent::__construct( $post );
+
+		/**
+		 * Whether unsupported origin records should be removed or not.
+		 *
+		 * If set to `true` then the post will be deleted on shutdown.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_delete Whether the unsupported post should be deleted or not; defaults
+		 *                            to `true`.
+		 * @param self $this          This record object.
+		 * @param WP_Post This record post object.
+		 */
+		$should_delete = apply_filters( 'tribe_aggregator_clean_unsupported', true, $this, $post );
+
+		if ( $should_delete ) {
+			/*
+			 * Let's delay the deletion to avoid client code from relying on
+			 * a deleted post for this request.
+			 */
+			add_action( 'shutdown', array( $this, 'delete_post' ) );
+		}
+	}
+
+	/**
+	 * Public facing Label for this Origin
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return __( 'Unsupported', 'the-events-calendar' );
+	}
+
+	/**
+	 * Overrides the base method short-circuiting the check for the
+	 * schedule time to return false.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool An indication that it's never time for an unsupported record to run.
+	 */
+	public function is_schedule_time() {
+		// It's never time for an unsupported record to run.
+		return false;
+	}
+
+	/**
+	 * Returns the unsupported record hash.
+	 *
+	 * The hash is usually built from the record meta; in the case
+	 * of an unsupported record that's skipped and a default string
+	 * is returned. Since the hash is usually compared to strings built
+	 * the same way the returned fixed hash will never match.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The record fixed hash.
+	 */
+	public function get_data_hash() {
+		return 'unsupported';
+	}
+
+	/**
+	 * Deletes the base post for this record.
+	 *
+	 * @since TBD
+	 */
+	public function delete_post() {
+		$this->delete();
+	}
+}

--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -290,11 +290,14 @@ Tribe__Events__Aggregator__Records {
 	}
 
 	/**
-	 * Returns an appropriate Record object for the given origin
+	 * Returns an appropriate Record object for the given origin.
 	 *
-	 * @param string $origin Import origin
+	 * @param string $origin The record import origin.
+	 * @param int|WP_Post The record post or post ID.
 	 *
-	 * @return Tribe__Events__Aggregator__Record__Abstract|null
+	 * @return Tribe__Events__Aggregator__Record__Abstract An instance of the correct record class
+	 *                                                     for the origin or an unsupported record
+	 *                                                     instance.
 	 */
 	public function get_by_origin( $origin, $post = null ) {
 		$record = null;
@@ -327,6 +330,10 @@ Tribe__Events__Aggregator__Records {
 			case 'url':
 			case 'ea/url':
 				$record = new Tribe__Events__Aggregator__Record__Url( $post );
+				break;
+			default:
+				// If there is no match then the record type is unsupported.
+				$record = new Tribe__Events__Aggregator__Record__Unsupported( $post );
 				break;
 		}
 

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -36,6 +36,7 @@ class CronTest extends \Codeception\TestCase\WPTestCase {
 		$record_post = $this->factory()->post->create( [
 			'post_type'      => Records::$post_type,
 			'post_status'    => Records::$status->schedule,
+			'ping_status'    => 'schedule',
 			'post_mime_type' => 'ea/foo-bar'
 		] );
 

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tribe\Events\Aggregator;
+
+use Tribe__Events__Aggregator__Cron as Cron;
+use Tribe__Events__Aggregator__Records as Records;
+
+class CronTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( Cron::class, $sut );
+	}
+
+	/**
+	 * @return Cron
+	 */
+	private function make_instance() {
+		return new class extends Cron {
+			public function __construct() {
+				// no side-effects constructor
+			}
+		};
+	}
+
+	/**
+	 * It should trash record posts not belonging to a supported origin
+	 *
+	 * @test
+	 */
+	public function should_trash_record_posts_not_belonging_to_a_supported_origin() {
+		$record_post = $this->factory()->post->create( [
+			'post_type'      => Records::$post_type,
+			'post_status'    => Records::$status->schedule,
+			'post_mime_type' => 'ea/foo-bar'
+		] );
+
+		$this->assertEquals( Records::$status->schedule, get_post_status( $record_post ) );
+
+		$cron = $this->make_instance();
+		add_filter( 'tribe_aggregator_api', function ( $api ) {
+			$api->key = 'foo-bar';
+
+			return $api;
+		} );
+		$cron->verify_child_record_creation();
+
+		$this->assertEmpty( get_post( $record_post ) );
+	}
+}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/UnsupportedTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/UnsupportedTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tribe\Events\Aggregator\Record;
+
+use Tribe__Events__Aggregator__Record__Unsupported as Unsupported;
+
+class UnsupportedTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( Unsupported::class, $sut );
+	}
+
+	/**
+	 * @return Unsupported
+	 */
+	private function make_instance() {
+		return new Unsupported();
+	}
+
+	/**
+	 * It should remove the unsupported record on shutdown
+	 *
+	 * @test
+	 */
+	public function should_remove_the_unsupported_record_on_shutdown() {
+		add_filter('tribe_aggregator_clean_unsupported','__return_true');
+
+		$record = $this->make_instance();
+
+		$this->assertTrue( (bool)has_action( 'shutdown', [ $record, 'delete_post' ] ) );
+	}
+
+	/**
+	 * It should allow preventing deletion with filter
+	 *
+	 * @test
+	 */
+	public function should_allow_preventing_deletion_with_filter() {
+		add_filter('tribe_aggregator_clean_unsupported','__return_false');
+
+		$record = $this->make_instance();
+
+		$this->assertFalse( has_action( 'shutdown', [ $record, 'delete_post' ] ) );
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/114831

This PR:
1. removes FB notices
2. adds the `Unsupported` type record to allow code to keep using a record object and avoid fatals
3. adds an auto-clean method to the `Unsupported` record class to delete the record post on `shutdown`.