### PR TITLE
Fix fatal issue when trying to save new scheduled imports.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 * Tweak - Accept 0 as an argument in tribe_get_events() so that `'post_parent' => 0` works, thanks Cy for the detailed report [111518]
 * Fix - handle left-over Facebook scheduled imports and notices [114831]
+* Fix - Fixed an issue where a fatal error could be generated when trying to save a new Event Aggregator scheduled import [115339]
 
 = [4.6.23] 2018-09-12 =
 

--- a/src/Tribe/Aggregator/Record/Unsupported.php
+++ b/src/Tribe/Aggregator/Record/Unsupported.php
@@ -83,7 +83,8 @@ class Tribe__Events__Aggregator__Record__Unsupported extends Tribe__Events__Aggr
 	 *
 	 * @return string The record fixed hash.
 	 */
-	public function get_data_hash() {
+	public function
+	get_data_hash() {
 		return 'unsupported';
 	}
 

--- a/src/Tribe/Aggregator/Records.php
+++ b/src/Tribe/Aggregator/Records.php
@@ -2,8 +2,7 @@
 // Don't load directly
 defined( 'WPINC' ) or die;
 
-class
-Tribe__Events__Aggregator__Records {
+class Tribe__Events__Aggregator__Records {
 	/**
 	 * Slug of the Post Type used for Event Aggregator Records
 	 *
@@ -428,8 +427,17 @@ Tribe__Events__Aggregator__Records {
 
 	}
 
+	/**
+	 * Returns a WP_Query object built using some default arguments for records.
+	 *
+	 * @param array $args An array of arguments to override the default ones.
+	 *
+	 * @return WP_Query The built WP_Query object; since it's built with arguments
+	 *                  the query will run, actually hitting the database, before
+	 *                  returning.
+	 */
 	public function query( $args = array() ) {
-		$statuses = Tribe__Events__Aggregator__Records::$status;
+		$statuses = self::$status;
 		$defaults = array(
 			'post_status' => array( $statuses->success, $statuses->failed, $statuses->pending ),
 			'orderby'     => 'modified',
@@ -452,13 +460,11 @@ Tribe__Events__Aggregator__Records {
 
 		$args = (object) wp_parse_args( $args, $defaults );
 
-		// Enforce the Post Type
+		// Enforce the post type.
 		$args->post_type = self::$post_type;
 
-		// Do the actual Query
-		$query = new WP_Query( $args );
-
-		return $query;
+		// Run and return the query.
+		return new WP_Query( $args );
 	}
 
 	/**
@@ -705,5 +711,37 @@ Tribe__Events__Aggregator__Records {
 
 		// Filter eventbrite events to preserve some fields that aren't supported by Eventbrite
 		add_filter( 'tribe_aggregator_before_update_event', array( 'Tribe__Events__Aggregator__Record__Eventbrite', 'filter_event_to_preserve_fields' ), 10, 2 );
+	}
+
+	public function find_by_data_hash( $source, $data_hash ) {
+		/** @var WP_Query $matches */
+		$matches = $this->query( array(
+			'post_status' => $this->get_status( 'schedule' )->name,
+			'meta_query'  => array(
+				array(
+					'key'   => $this->prefix_meta( 'source' ),
+					'value' => $source,
+				),
+			),
+			'fields'      => 'ids',
+		) );
+
+		if ( empty( $matches->posts ) ) {
+			return false;
+		}
+
+		foreach ( $matches->posts as $post_id ) {
+			$this_record = $this->get_by_post_id( $post_id );
+
+			if ( ! $this_record instanceof Tribe__Events__Aggregator__Record__Abstract ) {
+				continue;
+			}
+
+			if ( $data_hash === $this_record->get_data_hash() ) {
+				return $this_record;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -125,26 +125,16 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 			// remove non-needed data from the Hash of the Record
 			unset( $hash['schedule_day'], $hash['schedule_time'] );
 			ksort( $hash );
-			$hash = maybe_serialize( $hash );
-			$hash = md5( $hash );
+			$hash = md5( maybe_serialize( $hash ) );
 
-			$matches = Tribe__Events__Aggregator__Records::instance()->query( array(
-				'post_status' => Tribe__Events__Aggregator__Records::instance()->get_status( 'schedule' )->name,
-				'meta_query' => array(
-					Tribe__Events__Aggregator__Records::instance()->prefix_meta( 'source' ) => $meta['source'],
-				),
-				'fields' => 'ids',
-			) );
+			/** @var Tribe__Events__Aggregator__Record__Abstract $match */
+			$match = tribe( 'events-aggregator.records' )->find_by_data_hash( $meta['source'], $hash );
 
-			foreach ( $matches->posts as $post_id ) {
-				$matching_hash = Tribe__Events__Aggregator__Records::instance()->get_by_post_id( $post_id )->get_data_hash();
-
-				if ( $matching_hash == $hash ) {
-					$url = get_edit_post_link( $post_id );
-					$anchor = '<a href="' . esc_url( $url ) . '">' . esc_attr__( 'click here to edit it', 'the-events-calendar' ) .  '</a>';
-					$message = sprintf( __( 'A record already exists with these settings, %1$s.', 'the-events-calendar' ), $anchor );
-					wp_send_json_error( array( 'message' => $message ) );
-				}
+			if ( $match instanceof Tribe__Events__Aggregator__Record__Abstract ) {
+				$url     = get_edit_post_link( $match->id );
+				$anchor  = '<a href="' . esc_url( $url ) . '">' . esc_attr__( 'click here to edit it', 'the-events-calendar' ) . '</a>';
+				$message = sprintf( __( 'A record already exists with these settings, %1$s.', 'the-events-calendar' ), $anchor );
+				wp_send_json_error( array( 'message' => $message ) );
 			}
 		}
 

--- a/tests/_support/Factories/Aggregator/V1/Import_Record.php
+++ b/tests/_support/Factories/Aggregator/V1/Import_Record.php
@@ -21,7 +21,7 @@ class Import_Record {
 	 *
 	 * @return array|object
 	 */
-	public function create_and_get_event_record( $origin = 'ical', array $overrides = [], bool $with_image = false ) {
+	public function create_and_get_event_data( $origin = 'ical', array $overrides = [], bool $with_image = false ) {
 		$uniqid = uniqid( 'record-', true );
 
 		$event_unique_id_key = $this->get_event_unique_id_field( $origin );
@@ -73,11 +73,11 @@ class Import_Record {
 		$record = array_merge( $record, $overrides );
 
 		if ( $with_image ) {
-			$record ['image'] = $this->create_and_get_image_record( $origin, $image_overrides );
+			$record ['image'] = $this->create_and_get_image_data( $origin, $image_overrides );
 		}
 
-		$record['organizer'] = $this->create_and_get_many_organizers_record( $origin, $organizer_count, $organizer_overrides );
-		$record['venue']     = (object) $this->create_and_get_venue_record( $origin, $venue_overrides );
+		$record['organizer'] = $this->create_and_get_many_organizers_data( $origin, $organizer_count, $organizer_overrides );
+		$record['venue']     = (object) $this->create_and_get_venue_data( $origin, $venue_overrides );
 
 		return (object) $record;
 	}
@@ -106,7 +106,7 @@ class Import_Record {
 	 *
 	 * @return string|array An image URL of an EA Image data array.
 	 */
-	public function create_and_get_image_record( $origin, array $image_overrides = [] ) {
+	public function create_and_get_image_data( $origin, array $image_overrides = [] ) {
 		$attachment_factory = new \WP_UnitTest_Factory_For_Attachment();
 		$image_id           = $attachment_factory->create_upload_object( codecept_data_dir( 'images/featured-image.jpg' ) );
 		$image              = get_post( $image_id );
@@ -123,9 +123,9 @@ class Import_Record {
 	 *
 	 * @return array
 	 */
-	public function create_and_get_many_organizers_record( $origin, $count, $overrides = [] ) {
+	public function create_and_get_many_organizers_data( $origin, $count, $overrides = [] ) {
 		return array_map( function () use ( $origin, $overrides ) {
-			return (object) $this->create_and_get_organizer_record( $origin, $overrides );
+			return (object) $this->create_and_get_organizer_data( $origin, $overrides );
 		}, range( 1, $count ) );
 	}
 
@@ -137,7 +137,7 @@ class Import_Record {
 	 *
 	 * @return array
 	 */
-	public function create_and_get_organizer_record( $origin, array $overrides = [] ) {
+	public function create_and_get_organizer_data( $origin, array $overrides = [] ) {
 		$uniqid = uniqid( 'organizer-', true );
 
 		return array_merge( [
@@ -172,7 +172,7 @@ class Import_Record {
 	 *
 	 * @return array
 	 */
-	public function create_and_get_venue_record( $origin, array $overrides ) {
+	public function create_and_get_venue_data( $origin, array $overrides ) {
 		$uniqid = uniqid( 'venue-', true );
 
 		return array_merge( [

--- a/tests/_support/Traits/Aggregator/BatchDataMaker.php
+++ b/tests/_support/Traits/Aggregator/BatchDataMaker.php
@@ -19,7 +19,7 @@ trait BatchDataMaker {
 		}
 
 		for ( $i = 0; $i < $events_count; $i ++ ) {
-			$events[] = $import_data->create_and_get_event_record( $origin );
+			$events[] = $import_data->create_and_get_event_data( $origin );
 		}
 
 		return array_merge( [

--- a/tests/_support/Traits/Aggregator/RecordMaker.php
+++ b/tests/_support/Traits/Aggregator/RecordMaker.php
@@ -2,11 +2,21 @@
 
 namespace Tribe\Events\Test\Traits\Aggregator;
 
-
 use Tribe__Events__Aggregator__Record__gCal as Record;
 
 trait RecordMaker {
-	protected function make_record( string $import_id, array $meta_overrides = [], string $status = 'pending' ): Record {
+	/**
+	 * Creates an Event Aggregator post for a manual record.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $import_id The record import ID, should be a unique string.
+	 * @param array  $meta_overrides An array of overrides of the default meta.
+	 * @param string $status The record status, e.g. pending, failed, success.
+	 *
+	 * @return Record The built record object.
+	 */
+	protected function make_manual_record( string $import_id, array $meta_overrides = [], string $status = 'pending' ): Record {
 		$meta = array_merge( [
 			'import_id' => $import_id,
 			'preview' => false,
@@ -18,6 +28,33 @@ trait RecordMaker {
 		$record = new Record();
 		$record->create( 'manual', [], $meta );
 		$record->set_status( $status );
+
+		return $record;
+	}
+
+	/**
+	 * Creates an Event Aggregator post for a schedule record.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $import_id The record import ID, should be a unique string.
+	 * @param array  $meta_overrides An array of overrides of the default meta.
+	 *
+	 * @return Record The built record object.
+	 */
+	protected function make_schedule_record( string $import_id, array $meta_overrides = [] ): Record {
+		$meta = array_merge( [
+			'import_id'   => $import_id,
+			'preview'     => false,
+			'origin'      => 'gcal',
+			'source_name' => 'Test Calendar',
+			'source'      => 'http://example.com/calendar',
+			'frequency'   => 'every30mins',
+		], $meta_overrides );
+
+		$record = new Record();
+		$record->create( 'schedule', [], $meta );
+		$record->set_status( 'schedule' );
 
 		return $record;
 	}

--- a/tests/aggregatorv1/Import/Batch/ForcedImportStatusCest.php
+++ b/tests/aggregatorv1/Import/Batch/ForcedImportStatusCest.php
@@ -30,7 +30,7 @@ class ForcedImportStatusCest {
 
 		$previous_hash = $data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$record        = $this->make_record( $import_id, $meta, 'pending' );
+		$record        = $this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/state", $data );
 
@@ -77,7 +77,7 @@ class ForcedImportStatusCest {
 
 		$previous_hash = $data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$this->make_record( $import_id, $meta, 'pending' );
+		$this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/state", $data );
 

--- a/tests/aggregatorv1/Import/Batch/IntervalCest.php
+++ b/tests/aggregatorv1/Import/Batch/IntervalCest.php
@@ -47,7 +47,7 @@ PHP;
 
 		$previous_hash = $batch_data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$this->make_record( $import_id, $meta, 'pending' );
+		$this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/batch", $batch_data );
 

--- a/tests/aggregatorv1/Import/Batch/ProcessingCest.php
+++ b/tests/aggregatorv1/Import/Batch/ProcessingCest.php
@@ -39,7 +39,7 @@ class ProcessingCest {
 
 		$previous_hash = $batch_data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$record        = $this->make_record( $import_id, $meta, 'pending' );
+		$record        = $this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/batch", $batch_data );
 
@@ -100,7 +100,7 @@ class ProcessingCest {
 
 		$previous_hash = $batch_data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$record        = $this->make_record( $import_id, $meta, 'pending' );
+		$record        = $this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/batch", $batch_data );
 
@@ -161,7 +161,7 @@ class ProcessingCest {
 
 		$previous_hash = $batch_data['batch_hash'];
 		$meta          = [ 'next_batch_hash' => $previous_hash ];
-		$record        = $this->make_record( $import_id, $meta, 'pending' );
+		$record        = $this->make_manual_record( $import_id, $meta, 'pending' );
 
 		$I->sendPOST( "import/{$import_id}/batch", $batch_data );
 

--- a/tests/aggregatorv1/Import/Batch/ValidationCest.php
+++ b/tests/aggregatorv1/Import/Batch/ValidationCest.php
@@ -39,7 +39,7 @@ class ValidationCest {
 		$batch_data         = $this->make_batch_data();
 
 		$overrides = [ 'next_batch_hash' => $batch_data['batch_hash'] ];
-		$this->make_record( $existing_import_id, $overrides, $status );
+		$this->make_manual_record( $existing_import_id, $overrides, $status );
 
 		$I->sendPOST( "import/{$existing_import_id}/batch", $batch_data );
 
@@ -60,7 +60,7 @@ class ValidationCest {
 		$batch_data         = $this->make_batch_data();
 
 		$overrides = [ 'next_batch_hash' => $batch_data['batch_hash'] ];
-		$this->make_record( $existing_import_id, $overrides, $status );
+		$this->make_manual_record( $existing_import_id, $overrides, $status );
 
 		unset( $batch_data['batch_hash'] );
 		$I->sendPOST( "import/{$existing_import_id}/batch", $batch_data );
@@ -82,7 +82,7 @@ class ValidationCest {
 		$batch_data         = $this->make_batch_data();
 
 		$overrides = [ 'next_batch_hash' => $batch_data['batch_hash'] ];
-		$this->make_record( $existing_import_id, $overrides, $status );
+		$this->make_manual_record( $existing_import_id, $overrides, $status );
 
 		$batch_data['batch_hash'] = 'unexpected';
 		$I->sendPOST( "import/{$existing_import_id}/batch", $batch_data );

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -285,7 +285,7 @@ class AbstractTest extends Events_TestCase {
 	 * @test
 	 */
 	public function should_allow_filtering_the_venue_id_when_global_id_does_not_provide_a_match() {
-		$item = $this->factory()->import_record->create_and_get_event_record(
+		$item = $this->factory()->import_record->create_and_get_event_data(
 			'url',
 			[
 				'venue' =>
@@ -315,7 +315,7 @@ class AbstractTest extends Events_TestCase {
 	 * @test
 	 */
 	public function should_allow_filtering_the_organizer_id_when_global_id_does_not_provide_a_match() {
-		$item = $this->factory()->import_record->create_and_get_event_record( 'url', [ 'organizer_count' => 3, ] );
+		$item = $this->factory()->import_record->create_and_get_event_data( 'url', [ 'organizer_count' => 3, ] );
 		$organizer_ids = $this->factory()->organizer->create_many(3);
 		$i =0;
 		add_filter( 'tribe_aggregator_find_matching_organizer', function ( $_ = null, $organizer_data ) use ( $organizer_ids, &$i ) {
@@ -398,7 +398,7 @@ class AbstractTest extends Events_TestCase {
 	 * @test
 	 */
 	public function should_correctly_create_and_link_new_organizers_to_events() {
-		$event_data = $this->factory()->import_record->create_and_get_event_record( 'ical' );
+		$event_data = $this->factory()->import_record->create_and_get_event_data( 'ical' );
 		$event_data->organizer = [
 			(object) [
 				'organizer' => 'Organizer-1',
@@ -428,7 +428,7 @@ class AbstractTest extends Events_TestCase {
 	public function should_not_track_modified_fields_when_creating_events_no_matter_the_authority() {
 		tribe_update_option( 'tribe_aggregator_default_gcal_update_authority', 'overwrite' );
 
-		$event_data = $this->factory()->import_record->create_and_get_event_record( 'gcal' );
+		$event_data = $this->factory()->import_record->create_and_get_event_data( 'gcal' );
 		$this->track_last_inserted_or_updated();
 
 		/** @var Base $record */

--- a/tests/wpunit/Tribe/Events/Aggregator/RecordsTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/RecordsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tribe\Events\Aggregator;
+
+use Tribe\Events\Test\Traits\Aggregator\RecordMaker;
+use Tribe__Events__Aggregator__Record__Abstract as Record;
+use Tribe__Events__Aggregator__Records as Records;
+
+class RecordsTest extends \Codeception\TestCase\WPTestCase {
+	use RecordMaker;
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( Records::class, $sut );
+	}
+
+	/**
+	 * @return Records
+	 */
+	private function make_instance() {
+		return new Records();
+	}
+
+	/**
+	 * It should allow getting a record by its data hash
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_a_record_by_its_data_hash() {
+		$record_one   = $this->make_schedule_record( 'record-one',['source'=>'http://source-one.cal'] );
+		$record_two   = $this->make_schedule_record( 'record-two',['source'=>'http://source-two.cal'] );
+		$record_three = $this->make_schedule_record( 'record-three',['source'=>'http://source-three.cal'] );
+
+		$records = $this->make_instance();
+
+		foreach ( [ $record_one, $record_two, $record_three] as $record) {
+			$match   = $records->find_by_data_hash( $record->meta['source'], $record->get_data_hash() );
+			$this->assertInstanceOf( Record::class, $match );
+			$this->assertEquals( $record->id, $match->id );
+		}
+	}
+
+	/**
+	 * It should return false if no record was found for a data hash
+	 *
+	 * @test
+	 */
+	public function should_return_false_if_no_record_was_found_for_a_data_hash() {
+		$record_one   = $this->make_schedule_record( 'record-one', [ 'source' => 'http://source-one.cal' ] );
+		$record_two   = $this->make_schedule_record( 'record-two', [ 'source' => 'http://source-two.cal' ] );
+		$record_three = $this->make_schedule_record( 'record-three', [ 'source' => 'http://source-three.cal' ] );
+
+		$records = $this->make_instance();
+
+		$this->assertFalse( $records->find_by_data_hash( $record_one->meta['source'], 'foo-bar' ) );
+		$this->assertFalse( $records->find_by_data_hash( $record_two->meta['source'], $record_one->get_data_hash() ) );
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/115339

This PR fixes the issue by moving the record matching by data hash in the Records class (with tests) and by ensuring more robust checks are made.
The issue is caused by lingering FB imports that have not been removed, but just unsupported, as part of the FB EA source removal: the import records would be used in the comparisons as their posts are still there (fixed in another PR) but the `Records::get_by_origin` method would return `null` or an error and on that `null` or error the method `get_data_hash` is called causing the fatal.