### PR TITLE
Avoid HTTP calls on each Settings screen tab

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Tweak - Move Google Maps API loading to tribe_assets and only load once on single views when PRO is active, thanks to info2grow first reporting [112221]
 * Tweak - Accept 0 as an argument in tribe_get_events() so that `'post_parent' => 0` works, thanks Cy for the detailed report [111518]
 * Fix - handle left-over Facebook scheduled imports and notices [114831]
+* Tweak - Avoid unnecessary HTTP callls in the Settings screens [114013]
 
 = [4.6.23] 2018-09-12 =
 

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -341,12 +341,22 @@ class Tribe__Events__Aggregator__Service {
 
 		$args = $this->get_eventbrite_args();
 
+		$cached_response = get_transient( 'tribe_aggregator_has_eventbrite_authorized_response' );
+
+		if ( false !== $cached_response ) {
+			return $cached_response;
+		}
+
 		$response = $this->get( 'eventbrite/validate', $args );
 
+
 		// If we have an WP_Error we return only CSV
-		if ( is_wp_error( $response ) ) {
-			return tribe_error( 'core:aggregator:invalid-eventbrite-token', array(), array( 'response' => $response ) );
+		if ( $response instanceof WP_Error) {
+			$response= tribe_error( 'core:aggregator:invalid-eventbrite-token', array(), array( 'response' => $response ) );
 		}
+
+		// Check this each 15 minutes.
+		set_transient( 'tribe_aggregator_has_eventbrite_authorized_response', $response, 900 );
 
 		return $response;
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/114013

Cache the Eventbrite-related response for 15' in transients.
Transients will fall back to using the DB if no object caching system is in place thus providing
a graceful fall back for sites that have no object cache installed.