### PR TITLE
Add methods to know if date filters are being applied to the ORM query.

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1172,6 +1172,14 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 
 				$hidden = false;
 
+				if ( isset( $args['tribe_render_context'] ) ) {
+					$event_orm->set_render_context( $args['tribe_render_context'] );
+				}
+
+				if ( isset( $args['eventDisplay'] ) ) {
+					$event_orm->set_display_context( $args['eventDisplay'] );
+				}
+
 				// Backcompat defaults.
 				if ( isset( $args['hide_upcoming'] ) ) {
 					// Negate the hide_upcoming for $hidden

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -857,7 +857,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			 */
 			$datetime_format = 'Y-m-d H:i:s';
 			foreach ( array( 'Start', 'End' ) as $check ) {
-				if ( isset( $meta["_Event{$check}Date"] ) ) {
+				if ( isset( $meta[ "_Event{$check}Date" ] ) ) {
 					$meta_value = $meta[ "_Event{$check}Date" ];
 
 					if ( $meta_value instanceof DateTime || $meta_value instanceof DateTimeImmutable ) {
@@ -865,7 +865,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 						$postarr[ 'meta_input' ][ "_Event{$check}Date" ] = $meta_value;
 					}
 
-					$date = new DateTimeImmutable( $meta_value , $timezone );
+					$date = new DateTimeImmutable( $meta_value, $timezone );
 
 					$utc_date = $date->setTimezone( $utc );
 					// Set the UTC date/time from local date/time and timezone; if provided override it.
@@ -1185,7 +1185,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 *
 	 * @return array The filtered list of filters that are leveraging the event start and/or end dates
 	 */
-	public function get_date_filters(): array {
+	public function get_date_filters() {
 		$date_filters = array(
 			'starts_before',
 			'starts_after',

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -857,8 +857,16 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			 */
 			$datetime_format = 'Y-m-d H:i:s';
 			foreach ( array( 'Start', 'End' ) as $check ) {
-				if ( isset( $meta[ "_Event{$check}Date" ] ) ) {
-					$date     = new DateTimeImmutable( $meta[ "_Event{$check}Date" ], $timezone );
+				if ( isset( $meta["_Event{$check}Date"] ) ) {
+					$meta_value = $meta[ "_Event{$check}Date" ];
+
+					if ( $meta_value instanceof DateTime || $meta_value instanceof DateTimeImmutable ) {
+						$meta_value                 = $meta_value->format( 'Y-m-d H:i:s' );
+						$postarr[ 'meta_input' ][ "_Event{$check}Date" ] = $meta_value;
+					}
+
+					$date = new DateTimeImmutable( $meta_value , $timezone );
+
 					$utc_date = $date->setTimezone( $utc );
 					// Set the UTC date/time from local date/time and timezone; if provided override it.
 					$postarr[ 'meta_input' ][ "_Event{$check}DateUTC" ] = $utc_date->format( $datetime_format );
@@ -1167,5 +1175,56 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 		}
 
 		return parent::order_by( $order_by );
+	}
+
+	/**
+	 * Returns a filtered list of filters that are leveraging the event start and/or
+	 * end dates.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The filtered list of filters that are leveraging the event start and/or end dates
+	 */
+	public function get_date_filters(): array {
+		$date_filters = array(
+			'starts_before',
+			'starts_after',
+			'starts_between',
+			'ends_before',
+			'ends_after',
+			'ends_between',
+			'starts_and_ends_between',
+			'runs_between',
+		);
+
+		/**
+		 * Filters the list of filters that should be considered related to an event start and/or end
+		 * dates.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $date_filters The list of filters that should be considered related to an event start and/or end
+		 *                            dates.
+		 * @param Tribe__Events__Repositories__Event This repository instance.
+		 */
+		return apply_filters( "tribe_repository_{$this->filter_name}_date_filters", $date_filters, $this );
+	}
+
+	/**
+	 * Whether the repository read operations have any kind of date-related filter
+	 * applied or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the repository read operations have any kind of date-related filter applied or not.
+	 */
+	public function has_date_filters() {
+		foreach ( $this->get_date_filters() as $filter ) {
+			if ( $this->has_filter( $filter ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/114076

Based on: https://github.com/moderntribe/tribe-common/pull/813 

This PR adds the `get_date_filters` and `has_date_filters` method to the Event repository to know if any kind of date-related filtering, e.g. `starts_after` or `runs_between` is being applied or not to the query.

The PR also make sure the render and display context are passed to the ORM in the `tribe_get_events` function.