### PR TITLE
Remove unused "WP_PLUGIN_URL" class constant

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -36,8 +36,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const MIN_ADDON_VERSION   = '4.4';
 		const MIN_COMMON_VERSION  = '4.7.20';
 
-		const WP_PLUGIN_URL       = 'https://wordpress.org/extend/plugins/the-events-calendar/';
-
 		/**
 		 * Maybe display data wrapper
 		 * @var array


### PR DESCRIPTION
`WP_PLUGIN_URL` has been added many years ago (long before the code has been moved to GitHub), along with other constants (like `FEED_URL` or `INFO_API_URL`) that have been removed again since then.

The constant is not used at all and might cause confusion for unexperienced developers because WordPress has a (global) constant of the same name (see https://github.com/WordPress/WordPress/blob/master/wp-includes/default-constants.php#L159-L166).

This PR removes it.

_If for whatever reason you decide to keep it, the URL should at least be changed to the current structure: `'https://wordpress.org/plugins/the-events-calendar/'`._