### PR TITLE
Gutenberg > All blocks > adjust padding

### DIFF
--- a/src/modules/blocks/style.pcss
+++ b/src/modules/blocks/style.pcss
@@ -1,14 +1,6 @@
 .editor-block-list__block[data-type^="tribe/"] {
 	zoom: 1;
 
-	&:before,
-	&:after {
-		content: "";
-		display: table;
-		clear: both;
-		position: relative;
-	}
-
 	a.tribe-editor__action-link {
 		box-shadow: none;
 	}


### PR DESCRIPTION
🎫 https://central.tri.be/issues/118223

WP 5.0 is introducing some CSS that was not working fine with our styles for Gutenberg. It was creating a gap between our blocks.