### PR TITLE
Add filter so blocks can set the params during migration

### DIFF
--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -79,10 +79,11 @@ class Tribe__Events__Editor extends Tribe__Editor {
 			return false;
 		}
 
-		$on_classic_editor_page = tribe_get_request_var( 'classic-editor', false );
+		/** @var Tribe__Editor $editor */
+		$editor = tribe( 'editor' );
 
 		// Bail if in classic editor
-		if ( '' === $on_classic_editor_page || $on_classic_editor_page ) {
+		if ( $editor->is_classic_editor() ) {
 			return false;
 		}
 

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -139,7 +139,17 @@ class Tribe__Events__Editor extends Tribe__Editor {
 
 		foreach ( $blocks as $key => $block_param ) {
 			$slug = reset( $block_param );
-			$params = end( $block_param );
+			/**
+			 * Add an opportunity to set the default params of a block when migrating from classic into
+			 * blocks editor.
+			 *
+			 * @since TBD
+			 *
+			 * @param mixed $params Either array if set to values or slug string
+			 * @param string $slug Name of the block edited
+			 * @param WP_Post $post Post that is being affected
+			 */
+			$params = apply_filters( 'tribe_blocks_editor_update_classic_content_params', end( $block_param ), $slug, $post );
 			$json_param = false;
 
 			// Checks for Params to attach to the tag


### PR DESCRIPTION
add a new filter `tribe_blocks_editor_update_classic_content_params` so plugins can set the default params during the migration of blocks

Ticket: https://central.tri.be/issues/114554