### PR TITLE
⌗116124 New Hook to Help with Listening for Retrieval of Cached Month View Events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,7 +217,8 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [TBD] TBD =
 
-* Add - Added additional caching to TEC REST API archives and the Post Repository event/venue/organizer responses [117159]
+* Feature - Added additional caching to TEC REST API archives and the Post Repository event/venue/organizer responses [117159]
+* Feature - Added new `tribe_events_set_month_view_events_from_cache` action to make it easier to listen for when Month View events are retrieved from the Month View cache [116124]
 
 = [4.6.26] 2018-11-13 =
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -569,6 +569,15 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			$cached_events = $cache->$cache_getter( $cache_key, 'save_post' );
 
 			if ( $cached_events !== false ) {
+				/**
+				 * A simple utility to listen for when events have been successfully pulled from cache.
+				 *
+				 * @since TBD
+				 *
+				 * @param array $cached_events The array of event data pulled from cache.
+				 */
+				do_action( 'tribe_events_set_month_view_events_from_cache', $cached_events );
+
 				$this->events_in_month = $cached_events;
 				return;
 			}


### PR DESCRIPTION
**Ticket:** [**⌗116124**](http://central.tri.be/issues/116124)

**Related PR:** https://github.com/moderntribe/tribe-common/pull/831

This is part of an initial pass at improving the cache invalidation on `tribe_last_save_post`.