### PR TITLE
Previewing and Importing CSV files with whitespace

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 * Feature - Added additional caching to TEC REST API archives and the Post Repository event/venue/organizer responses [117159]
 * Feature - Added new `tribe_events_set_month_view_events_from_cache` action to make it easier to listen for when Month View events are retrieved from the Month View cache [116124]
+* Fix - Importing CSV files with whitespace at the beginning of the rows won't remove headers and skip columns on Preview [117236]
 
 = [4.6.26.1] 2018-11-21 =
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -92,6 +92,17 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 
 		$rows    = $importer->do_import_preview();
 
+		/*
+		 * Strip whitespace from the beginning and end of row values
+		 */
+		$formatted_rows = array();
+
+		foreach ( $rows as $row ) {
+			$row              = array_map( 'trim', $row );
+			$formatted_rows[] = $row;
+		}
+
+		$rows    = $formatted_rows;
 		$headers = array_shift( $rows );
 
 		/*
@@ -99,12 +110,16 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		 * each column without an header a generated one.
 		 */
 		$empty_counter = 1;
-		foreach ( $headers as $key => &$header ) {
+		$formatted_headers = array();
+
+		foreach ( $headers as $header ) {
 			if ( empty( $header ) ) {
 				$header = __( 'Unknown Column ', 'the-events-calendar' ) . $empty_counter ++;
 			}
+			$formatted_headers[] = $header;
 		}
 
+		$headers = $formatted_headers;
 		$data    = array();
 
 		foreach ( $rows as $row ) {

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -98,8 +98,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$formatted_rows = array();
 
 		foreach ( $rows as $row ) {
-			$row              = array_map( 'trim', $row );
-			$formatted_rows[] = $row;
+			$formatted_rows[] = array_map( 'trim', $row );
 		}
 
 		$rows    = $formatted_rows;


### PR DESCRIPTION
Ref. https://central.tri.be/issues/117236

CSV files with whitespace at the beginning of the rows won't remove headers and skip columns on Preview