### PR TITLE
Fix datetime block padding

### DIFF
--- a/src/modules/blocks/event-datetime/style.pcss
+++ b/src/modules/blocks/event-datetime/style.pcss
@@ -16,7 +16,6 @@
 	line-height: normal;
 	margin-bottom: 0;
 	margin-top: 0;
-	color: red;
 
 	> * {
 		flex: 0 1 auto;
@@ -27,6 +26,10 @@
 		color: #060606;
 		font-size: 1.1em;
 		text-decoration: none;
+	}
+
+	.tribe-editor__date-time & {
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/118697

Seems that some core styles are taking over our editor styles and it looks like this: https://cloudup.com/c9LeOAMY5wd