### PR TITLE
Register blocks using `common` action

### DIFF
--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -69,16 +69,16 @@ class Tribe__Events__Editor__Provider extends tad_DI52_ServiceProvider {
 		tribe( 'events.editor' )->hook();
 
 		// Register blocks to own own action
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.classic-event-details', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-datetime', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-venue', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-organizer', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-links', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-price', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-category', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-tags', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-website', 'register' ) );
-		add_action( 'tribe_events_editor_register_blocks', tribe_callback( 'events.editor.blocks.featured-image', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.classic-event-details', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-datetime', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-venue', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-organizer', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-links', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-price', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-category', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-tags', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.event-website', 'register' ) );
+		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.featured-image', 'register' ) );
 	}
 
 	/**


### PR DESCRIPTION
Use the new action `tribe_editor_register_blocks` instead of
`tribe_events_editor_register_blocks` to register the blocks

Ticket: https://central.tri.be/issues/119362