### PR TITLE
⌗119451 Use New Post Type Labels Introduced in WP 5.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Remove Price block dashboard gap [118683]
 * Fix - Making sure all Blocks Editor code for Meta saving is PHP 5.2 compatible
 * Fix - Prevent `undefined` from been displayed at the Date Time separators [119337]
+* Tweak - Tweak the registration of the Event, Venue, and Organizer post types so they use some new post type labels introduced in WordPress 5.0 like `item_updated`, `item_scheduled`, etc. [119451]
 
 = [4.7.1] 2018-12-05 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1976,11 +1976,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_event_label ),
 				'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
 				'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
-				'item_published'           => __( 'Post published.' ),
-				'item_published_privately' => __( 'Post published privately.' ),
-				'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
-				'item_scheduled'           => __( 'Post scheduled.' ),
-				'item_updated'             => __( 'Post updated.' )
+				'item_published'           => sprintf( esc_html__( '%s published.', 'the-events-calendar' ), $this->singular_event_label ),
+				'item_published_privately' => sprintf( esc_html__( '%s published privately.', 'the-events-calendar' ), $this->singular_event_label ),
+				'item_reverted_to_draft'   => sprintf( esc_html__( '%s reverted to draft.', 'the-events-calendar' ), $this->singular_event_label ),
+				'item_scheduled'           => sprintf( esc_html__( '%s scheduled.', 'the-events-calendar' ), $this->singular_event_label ),
+				'item_updated'             => sprintf( esc_html__( '%s updated.', 'the-events-calendar' ), $this->singular_event_label ),
 			) );
 
 			/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -90,12 +90,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 		public static $dotOrgSupportUrl = 'https://wordpress.org/support/plugin/the-events-calendar';
 
-		public $rewriteSlug = 'events';
+		public $rewriteSlug         = 'events';
 		public $rewriteSlugSingular = 'event';
-		public $category_slug = 'category';
-		public $tag_slug = 'tag';
-		public $monthSlug = 'month';
-		public $featured_slug = 'featured';
+		public $category_slug       = 'category';
+		public $tag_slug            = 'tag';
+		public $monthSlug           = 'month';
+		public $featured_slug       = 'featured';
 
 		/**
 		 * @deprecated 4.5.8 use `Tribe__Events__Pro__Main::instance()->all_slug` instead
@@ -121,11 +121,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 		// @todo remove in 4.0
 		public $upcomingSlug = 'upcoming';
-		public $pastSlug = 'past';
+		public $pastSlug     = 'past';
 
-		public $listSlug = 'list';
-		public $daySlug = 'day';
-		public $todaySlug = 'today';
+		public $listSlug               = 'list';
+		public $daySlug                = 'day';
+		public $todaySlug              = 'today';
 		protected $postExceptionThrown = false;
 
 		/**
@@ -296,9 +296,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		protected function __construct() {
 			$this->plugin_file = TRIBE_EVENTS_FILE;
-			$this->pluginPath = $this->plugin_path = trailingslashit( dirname( $this->plugin_file ) );
-			$this->pluginDir  = $this->plugin_dir = trailingslashit( basename( $this->plugin_path ) );
-			$this->pluginUrl  = $this->plugin_url = str_replace( basename( $this->plugin_file ), '', plugins_url( basename( $this->plugin_file ), $this->plugin_file ) );
+			$this->pluginPath  = $this->plugin_path = trailingslashit( dirname( $this->plugin_file ) );
+			$this->pluginDir   = $this->plugin_dir = trailingslashit( basename( $this->plugin_path ) );
+			$this->pluginUrl   = $this->plugin_url = str_replace( basename( $this->plugin_file ), '', plugins_url( basename( $this->plugin_file ), $this->plugin_file ) );
 
 			// Set common lib information, needs to happen file load
 			$this->maybe_set_common_lib_info();
@@ -1966,16 +1966,21 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 * @var array
 			 */
 			$this->postTypeArgs['labels'] = apply_filters( 'tribe_events_register_event_post_type_labels', array(
-				'name'               => $this->plural_event_label,
-				'singular_name'      => $this->singular_event_label,
-				'add_new'            => esc_html__( 'Add New', 'the-events-calendar' ),
-				'add_new_item'       => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_event_label ),
-				'edit_item'          => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_event_label ),
-				'new_item'           => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_event_label ),
-				'view_item'          => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_event_label ),
-				'search_items'       => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_event_label ),
-				'not_found'          => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
-				'not_found_in_trash' => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
+				'name'                     => $this->plural_event_label,
+				'singular_name'            => $this->singular_event_label,
+				'add_new'                  => esc_html__( 'Add New', 'the-events-calendar' ),
+				'add_new_item'             => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_event_label ),
+				'edit_item'                => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_event_label ),
+				'new_item'                 => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_event_label ),
+				'view_item'                => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_event_label ),
+				'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_event_label ),
+				'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
+				'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), $this->plural_event_label_lowercase ),
+				'item_published'           => __( 'Post published.' ),
+				'item_published_privately' => __( 'Post published privately.' ),
+				'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
+				'item_scheduled'           => __( 'Post scheduled.' ),
+				'item_updated'             => __( 'Post updated.' )
 			) );
 
 			/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Args for the event post type
 		 * @var array
 		 */
-		protected $postTypeArgs = array(
+		protected $post_type_args = array(
 			'public'          => true,
 			'rewrite'         => array( 'slug' => 'event', 'with_front' => false ),
 			'menu_position'   => 6,
@@ -880,7 +880,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->singular_event_label_lowercase             = tribe_get_event_label_singular_lowercase();
 			$this->plural_event_label_lowercase               = tribe_get_event_label_plural_lowercase();
 
-			$this->postTypeArgs['rewrite']['slug']            = $rewrite->prepare_slug( $this->rewriteSlugSingular, self::POSTTYPE, false );
+			$this->post_type_args['rewrite']['slug']            = $rewrite->prepare_slug( $this->rewriteSlugSingular, self::POSTTYPE, false );
 			$this->currentDay                                 = '';
 			$this->errors                                     = '';
 
@@ -1837,7 +1837,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public function registerPostType() {
 			$this->generatePostTypeLabels();
 
-			$post_type_args = $this->postTypeArgs;
+			$post_type_args = $this->post_type_args;
 
 			/**
 			 * Filter the event post type arguments used in register_post_type.
@@ -1965,7 +1965,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 *
 			 * @var array
 			 */
-			$this->postTypeArgs['labels'] = apply_filters( 'tribe_events_register_event_post_type_labels', array(
+			$this->post_type_args['labels'] = apply_filters( 'tribe_events_register_event_post_type_labels', array(
 				'name'                     => $this->plural_event_label,
 				'singular_name'            => $this->singular_event_label,
 				'add_new'                  => esc_html__( 'Add New', 'the-events-calendar' ),
@@ -2414,8 +2414,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$tec = self::instance();
 
 			// reregister custom post type to make sure slugs are updated
-			$tec->postTypeArgs['rewrite']['slug'] = sanitize_title( $tec->getRewriteSlugSingular() );
-			register_post_type( self::POSTTYPE, apply_filters( 'tribe_events_register_event_type_args', $tec->postTypeArgs ) );
+			$tec->post_type_args['rewrite']['slug'] = sanitize_title( $tec->getRewriteSlugSingular() );
+			register_post_type( self::POSTTYPE, apply_filters( 'tribe_events_register_event_type_args', $tec->post_type_args ) );
 
 			add_action( 'shutdown', 'flush_rewrite_rules' );
 		}

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -96,11 +96,11 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 			'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_organizer_label ),
 			'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
 			'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
-			'item_published'           => __( 'Post published.' ),
-			'item_published_privately' => __( 'Post published privately.' ),
-			'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
-			'item_scheduled'           => __( 'Post scheduled.' ),
-			'item_updated'             => __( 'Post updated.' )
+			'item_published'           => sprintf( esc_html__( '%s published.', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'item_published_privately' => sprintf( esc_html__( '%s published privately.', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'item_reverted_to_draft'   => sprintf( esc_html__( '%s reverted to draft.', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'item_scheduled'           => sprintf( esc_html__( '%s scheduled.', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'item_updated'             => sprintf( esc_html__( '%s updated.', 'the-events-calendar' ), $this->singular_organizer_label ),
 		) );
 
 		$this->register_post_type();

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -84,18 +84,23 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 		 * @param array
 		 */
 		$this->post_type_args['labels'] = apply_filters( 'tribe_events_register_organizer_post_type_labels', array(
-			'name'                    => $this->plural_organizer_label,
-			'singular_name'           => $this->singular_organizer_label,
-			'singular_name_lowercase' => $this->singular_organizer_label_lowercase,
-			'plural_name_lowercase'   => $this->plural_organizer_label_lowercase,
-			'add_new'                 => esc_html__( 'Add New', 'the-events-calendar' ),
-			'add_new_item'            => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_organizer_label ),
-			'edit_item'               => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_organizer_label ),
-			'new_item'                => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_organizer_label ),
-			'view_item'               => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_organizer_label ),
-			'search_items'            => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_organizer_label ),
-			'not_found'               => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
-			'not_found_in_trash'      => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
+			'name'                     => $this->plural_organizer_label,
+			'singular_name'            => $this->singular_organizer_label,
+			'singular_name_lowercase'  => $this->singular_organizer_label_lowercase,
+			'plural_name_lowercase'    => $this->plural_organizer_label_lowercase,
+			'add_new'                  => esc_html__( 'Add New', 'the-events-calendar' ),
+			'add_new_item'             => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'edit_item'                => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'new_item'                 => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'view_item'                => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_organizer_label ),
+			'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_organizer_label ),
+			'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
+			'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_organizer_label ) ),
+			'item_published'           => __( 'Post published.' ),
+			'item_published_privately' => __( 'Post published privately.' ),
+			'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
+			'item_scheduled'           => __( 'Post scheduled.' ),
+			'item_updated'             => __( 'Post updated.' )
 		) );
 
 		$this->register_post_type();

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -115,11 +115,11 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 			'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_venue_label ),
 			'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
 			'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
-			'item_published'           => __( 'Post published.' ),
-			'item_published_privately' => __( 'Post published privately.' ),
-			'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
-			'item_scheduled'           => __( 'Post scheduled.' ),
-			'item_updated'             => __( 'Post updated.' )
+			'item_published'           => sprintf( esc_html__( '%s published.', 'the-events-calendar' ), $this->singular_venue_label ),
+			'item_published_privately' => sprintf( esc_html__( '%s published privately.', 'the-events-calendar' ), $this->singular_venue_label ),
+			'item_reverted_to_draft'   => sprintf( esc_html__( '%s reverted to draft.', 'the-events-calendar' ), $this->singular_venue_label ),
+			'item_scheduled'           => sprintf( esc_html__( '%s scheduled.', 'the-events-calendar' ), $this->singular_venue_label ),
+			'item_updated'             => sprintf( esc_html__( '%s updated.', 'the-events-calendar' ), $this->singular_venue_label ),
 		) );
 
 		$this->register_post_type();

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -103,18 +103,23 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 		 * @param array $args Array of arguments for register_post_type labels
 		 */
 		$this->post_type_args['labels'] = apply_filters( 'tribe_events_register_venue_post_type_labels', array(
-			'name'                    => $this->plural_venue_label,
-			'singular_name'           => $this->singular_venue_label,
-			'singular_name_lowercase' => $this->singular_venue_label_lowercase,
-			'plural_name_lowercase'   => $this->plural_venue_label_lowercase,
-			'add_new'                 => esc_html__( 'Add New', 'the-events-calendar' ),
-			'add_new_item'            => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_venue_label ),
-			'edit_item'               => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_venue_label ),
-			'new_item'                => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_venue_label ),
-			'view_item'               => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_venue_label ),
-			'search_items'            => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_venue_label ),
-			'not_found'               => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
-			'not_found_in_trash'      => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
+			'name'                     => $this->plural_venue_label,
+			'singular_name'            => $this->singular_venue_label,
+			'singular_name_lowercase'  => $this->singular_venue_label_lowercase,
+			'plural_name_lowercase'    => $this->plural_venue_label_lowercase,
+			'add_new'                  => esc_html__( 'Add New', 'the-events-calendar' ),
+			'add_new_item'             => sprintf( esc_html__( 'Add New %s', 'the-events-calendar' ), $this->singular_venue_label ),
+			'edit_item'                => sprintf( esc_html__( 'Edit %s', 'the-events-calendar' ), $this->singular_venue_label ),
+			'new_item'                 => sprintf( esc_html__( 'New %s', 'the-events-calendar' ), $this->singular_venue_label ),
+			'view_item'                => sprintf( esc_html__( 'View %s', 'the-events-calendar' ), $this->singular_venue_label ),
+			'search_items'             => sprintf( esc_html__( 'Search %s', 'the-events-calendar' ), $this->plural_venue_label ),
+			'not_found'                => sprintf( esc_html__( 'No %s found', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
+			'not_found_in_trash'       => sprintf( esc_html__( 'No %s found in Trash', 'the-events-calendar' ), strtolower( $this->plural_venue_label ) ),
+			'item_published'           => __( 'Post published.' ),
+			'item_published_privately' => __( 'Post published privately.' ),
+			'item_reverted_to_draft'   => __( 'Post reverted to draft.' ),
+			'item_scheduled'           => __( 'Post scheduled.' ),
+			'item_updated'             => __( 'Post updated.' )
 		) );
 
 		$this->register_post_type();


### PR DESCRIPTION
**Ticket:** [**⌗119451**](http://central.tri.be/issues/119451)

Read more about the new labels themselves here → https://make.wordpress.org/core/2018/12/05/new-post-type-labels-in-5-0/