### PR TITLE
Make sure we have the correct version of wp-browser

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -22,4 +22,6 @@ extensions:
         - 'Codeception\Command\GenerateWPAjax'
         - 'Codeception\Command\GenerateWPCanonical'
         - 'Codeception\Command\GenerateWPXMLRPC'
+        - 'Codeception\Command\DbSnapshot'
+        - 'tad\Codeception\Command\SearchReplace'
 

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -22,6 +22,4 @@ extensions:
         - 'Codeception\Command\GenerateWPAjax'
         - 'Codeception\Command\GenerateWPCanonical'
         - 'Codeception\Command\GenerateWPXMLRPC'
-        - 'Codeception\Command\DbSnapshot'
-        - 'tad\Codeception\Command\SearchReplace'
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "homepage": "http://tri.be/shop/wordpress-events-calendar/",
   "license": "GPL-2.0",
   "require-dev": {
-    "lucatume/wp-browser": "^2.0.5",
+    "lucatume/wp-browser": "2.1.6",
     "xamin/handlebars.php": "^0.10.3",
     "mikey179/vfsStream": "^1.6",
     "vlucas/phpdotenv": "^2.4",


### PR DESCRIPTION
Based on the documentation of `wp-browser` we need to remove the dependency for `Codeception\Command\DbSnapshot` if we go to version `wp-browser@2.2.0` 

---

If we stick to version `2.1.6` we could keep using `DbSnapshot` and that could be a faster solution.