### PR TITLE
Don't apply wpautop if it hasn't been applied already.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.7.4] TBD =
 
 * Fix - Display the tags block delimiter in the editor [119393]
+* Tweak - Ensure we don't re-apply wpautop to content that has had it removed [120562]
 
 = [4.7.3] 2018-12-18 =
 

--- a/src/Tribe/Editor/Template/Overwrite.php
+++ b/src/Tribe/Editor/Template/Overwrite.php
@@ -139,9 +139,15 @@ class Tribe__Events__Editor__Template__Overwrite {
 	 * @return string          Paragraph-converted text if non-block content.
 	 */
 	public function wpautop( $content ) {
+		// don't bother if wpautop isn't applied
+		if ( ! has_filter( 'the_content', 'wpautop' ) ) {
+			return $content;
+		}
+
 		if ( has_blocks( $content ) ) {
 			return $content;
 		}
+
 		return wpautop( $content );
 	}
 


### PR DESCRIPTION
This is re-applying `wpautop` in places we don't want it - rather than re-removing it, let's set up a check.

Discovered while debugging https://central.tri.be/issues/120562