### PR TITLE
Fix issues with TEC views.

### DIFF
--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -18,11 +18,14 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		// Provide backwards compatibility for meta data
 		$post_type = Tribe__Events__Main::POSTTYPE;
 		add_filter( "rest_prepare_{$post_type}", array( $this, 'meta_backwards_compatibility' ), 10, 3 );
+		add_filter( "rest_pre_insert_{$post_type}", array( $this, 'add_utc_dates' ), 10, 2 );
 
 		register_meta( 'post', '_EventAllDay', $this->boolean() );
 		register_meta( 'post', '_EventTimezone', $this->text() );
 		register_meta( 'post', '_EventStartDate', $this->text() );
 		register_meta( 'post', '_EventEndDate', $this->text() );
+		register_meta( 'post', '_EventStartDateUTC', $this->text() );
+		register_meta( 'post', '_EventEndDateUTC', $this->text() );
 		register_meta( 'post', '_EventShowMap', $this->boolean() );
 		register_meta( 'post', '_EventShowMapLink', $this->boolean() );
 		register_meta( 'post', '_EventURL', $this->text() );
@@ -114,6 +117,61 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 			$data->data['meta']['_EventAllDay'] = tribe_is_truthy( $all_day );
 		}
 
+		$timezone = Tribe__Timezones::build_timezone_object( $data->data['meta']['_EventTimezone'] );
+		$utc = new DateTimeZone( 'UTC' );
+		$utc_start_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventStartDate'], $timezone );
+		$utc_end_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventEndDate'], $timezone );
+		$data->data['meta']['_EventStartDateUTC'] = $utc_start_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
+		$data->data['meta']['_EventEndDateUTC'] = $utc_end_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
+
 		return $data;
+	}
+
+	/**
+	 * Adds, triggering their updates, the UTC start and end dates to the post insertion or
+	 * update REST payload.
+	 *
+	 * @since TBD
+	 *
+	 * @param             \stdClass     $post_data The post insertion/update payload.
+	 * @param \WP_REST_Request $request The current insertion or update request object.
+	 *
+	 * @return \stdClass The post insertion/update payload with an added `meta_input` entry if
+	 *                   the insertion/update of UTC dates is required.
+	 */
+	public function add_utc_dates($post_data, WP_REST_Request $request) {
+		$json_params = $request->get_json_params();
+		$meta = Tribe__Utils__Array::get( $json_params, 'meta', array() );
+
+		// No changes to start or end? No need to update UTC dates.
+		if ( ! ( isset( $meta['_EventStartDate'] ) || isset( $meta['_EventEndDate'] ) ) ) {
+			return $post_data;
+		}
+
+		if ( ! isset( $post_data->meta_input ) ) {
+			$post_data->meta_input = array();
+		}
+
+		$post_id         = $request->get_param( 'id' );
+
+		$timezone_string = Tribe__Events__Timezones::get_event_timezone_string( $post_id );
+		$timezone_string = Tribe__Utils__Array::get( $meta, '_EventTimezone', $timezone_string );
+		$timezone        = Tribe__Timezones::build_timezone_object( $timezone_string );
+		$utc             = new DateTimeZone( 'UTC' );
+
+		$start_date      = get_post_meta( $post_id, '_EventStartDate', true );
+		$start_date      = Tribe__Utils__Array::get( $meta, '_EventStartDate', $start_date );
+		$end_date        = get_post_meta( $post_id, '_EventEndDate', true );
+		$end_date        = Tribe__Utils__Array::get( $meta, '_EventEndDate', $end_date );
+		$utc_start_date  = Tribe__Date_Utils::build_date_object( $start_date, $timezone )
+											->setTimezone( $utc )
+											->format( 'Y-m-d H:i:s' );
+		$utc_end_date    = Tribe__Date_Utils::build_date_object( $end_date, $timezone )
+											->setTimezone( $utc )
+											->format( 'Y-m-d H:i:s' );
+		$post_data->meta_input['_EventStartDateUTC'] = $utc_start_date;
+		$post_data->meta_input['_EventEndDateUTC'] = $utc_end_date;
+
+		return $post_data;
 	}
 }

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1208,6 +1208,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 					unset( $args['end_date'] );
 				}
 
+				if ( isset( $args['eventDate'] ) ) {
+					$args['on_date'] = $args['eventDate'];
+					unset( $args['eventDate'] );
+				}
+
 				if ( ! empty( $args['orderby'] ) ) {
 					$event_orm->order_by( $args['orderby'] );
 

--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -184,7 +184,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 				if ( isset( $_POST['tribe_event_category'] ) ) {
 					$args[ Tribe__Events__Main::TAXONOMY ] = $_POST['tribe_event_category'];
 				}
-
+global $wpdb;
 				$query = tribe_get_events( $args, true );
 
 				global $post;

--- a/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
@@ -402,4 +402,32 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			$starts_before_ends_on_end,
 		], tribe_events()->where( 'starts_and_ends_between', $start, $end, $ny_timezone_string )->get_ids() );
 	}
+
+	/**
+	 * It should allow fetching events by on date
+	 *
+	 * @test
+	 */
+	public function should_allow_fetching_events_by_on_date() {
+		$ny_timezone_string    = 'America/New_York';
+		extract( $this->create_events_from_dates( [
+			'one'   => [ '2018-01-01 10:00:00', 2 * HOUR_IN_SECONDS ],
+			'two'   => [ '2018-01-10 10:00:00', 2 * HOUR_IN_SECONDS ],
+			'three' => [ '2018-01-10 14:00:00', 2 * HOUR_IN_SECONDS ],
+			'four'  => [ '2018-01-15 15:00:00', 2 * HOUR_IN_SECONDS ],
+			'five'  => [ '2018-01-17 14:00:00', 2 * HOUR_IN_SECONDS ],
+			'six'   => [ '2018-01-19 14:00:00', 2 * HOUR_IN_SECONDS ],
+			'seven' => [ '2018-01-11 02:00:00', 2 * HOUR_IN_SECONDS ],
+		], $ny_timezone_string ) );
+
+		$this->assertEquals( [
+			'2018-01-10 10:00:00',
+			'2018-01-10 14:00:00',
+		], tribe_events()->where( 'on_date', '2018-01-10' )->pluck( 'start_date' ) );
+
+		$this->assertEquals( [
+			'2018-01-10 10:00:00',
+			'2018-01-10 14:00:00',
+		], tribe_events()->where( 'on_date', '2018-01-10', 'Asia/Taipei' )->pluck( 'start_date' ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/119512

This PR fixes the issues found by Scott when testing the ORM-based implementation of `tribe_get_events`.

* makes sure the UTC start and end dates are saved, and read, to/from the database when processin the REST API requests coming from the blocks editor
* adds support, in the Events ORM, for the `on_date` filter
* updates the `Query::getEvents` methdo to forward requests for the Day view (`eventDate`) to the ORM