### PR TITLE
Include UTC dates meta for the events created on the block editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Moved the "Remove venue" button for a better user experience when removing venues from an event [120267]
 * Fix - Date/time block conflicts when clicking to open the block options [119413]
 * Fix - Fixed a number of small layout bugs with the new Twenty Nineteen core theme [119689]
+* Fix - Include UTC dates meta on the event creation from the block editor [120399]
 * Tweak - Ensure we don't re-apply `wpautop()` to content that has had it removed [120562]
 
 = [4.7.3] 2018-12-18 =

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -165,10 +165,10 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		$end_date        = Tribe__Utils__Array::get( $meta, '_EventEndDate', $end_date );
 		$utc_start_date  = Tribe__Date_Utils::build_date_object( $start_date, $timezone )
 											->setTimezone( $utc )
-											->format( 'Y-m-d H:i:s' );
+											->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 		$utc_end_date    = Tribe__Date_Utils::build_date_object( $end_date, $timezone )
 											->setTimezone( $utc )
-											->format( 'Y-m-d H:i:s' );
+											->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 		$post_data->meta_input['_EventStartDateUTC'] = $utc_start_date;
 		$post_data->meta_input['_EventEndDateUTC'] = $utc_end_date;
 

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -18,11 +18,14 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		// Provide backwards compatibility for meta data
 		$post_type = Tribe__Events__Main::POSTTYPE;
 		add_filter( "rest_prepare_{$post_type}", array( $this, 'meta_backwards_compatibility' ), 10, 3 );
+		add_filter( "rest_pre_insert_{$post_type}", array( $this, 'add_utc_dates' ), 10, 2 );
 
 		register_meta( 'post', '_EventAllDay', $this->boolean() );
 		register_meta( 'post', '_EventTimezone', $this->text() );
 		register_meta( 'post', '_EventStartDate', $this->text() );
 		register_meta( 'post', '_EventEndDate', $this->text() );
+		register_meta( 'post', '_EventStartDateUTC', $this->text() );
+		register_meta( 'post', '_EventEndDateUTC', $this->text() );
 		register_meta( 'post', '_EventShowMap', $this->boolean() );
 		register_meta( 'post', '_EventShowMapLink', $this->boolean() );
 		register_meta( 'post', '_EventURL', $this->text() );
@@ -114,6 +117,61 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 			$data->data['meta']['_EventAllDay'] = tribe_is_truthy( $all_day );
 		}
 
+		$timezone = Tribe__Timezones::build_timezone_object( $data->data['meta']['_EventTimezone'] );
+		$utc = new DateTimeZone( 'UTC' );
+		$utc_start_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventStartDate'], $timezone );
+		$utc_end_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventEndDate'], $timezone );
+		$data->data['meta']['_EventStartDateUTC'] = $utc_start_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
+		$data->data['meta']['_EventEndDateUTC'] = $utc_end_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
+
 		return $data;
+	}
+
+	/**
+	 * Adds, triggering their updates, the UTC start and end dates to the post insertion or
+	 * update REST payload.
+	 *
+	 * @since TBD
+	 *
+	 * @param             \stdClass     $post_data The post insertion/update payload.
+	 * @param \WP_REST_Request $request The current insertion or update request object.
+	 *
+	 * @return \stdClass The post insertion/update payload with an added `meta_input` entry if
+	 *                   the insertion/update of UTC dates is required.
+	 */
+	public function add_utc_dates( $post_data, WP_REST_Request $request ) {
+		$json_params = $request->get_json_params();
+		$meta = Tribe__Utils__Array::get( $json_params, 'meta', array() );
+
+		// No changes to start or end? No need to update UTC dates.
+		if ( ! ( isset( $meta['_EventStartDate'] ) || isset( $meta['_EventEndDate'] ) ) ) {
+			return $post_data;
+		}
+
+		if ( ! isset( $post_data->meta_input ) ) {
+			$post_data->meta_input = array();
+		}
+
+		$post_id         = $request->get_param( 'id' );
+
+		$timezone_string = Tribe__Events__Timezones::get_event_timezone_string( $post_id );
+		$timezone_string = Tribe__Utils__Array::get( $meta, '_EventTimezone', $timezone_string );
+		$timezone        = Tribe__Timezones::build_timezone_object( $timezone_string );
+		$utc             = new DateTimeZone( 'UTC' );
+
+		$start_date      = get_post_meta( $post_id, '_EventStartDate', true );
+		$start_date      = Tribe__Utils__Array::get( $meta, '_EventStartDate', $start_date );
+		$end_date        = get_post_meta( $post_id, '_EventEndDate', true );
+		$end_date        = Tribe__Utils__Array::get( $meta, '_EventEndDate', $end_date );
+		$utc_start_date  = Tribe__Date_Utils::build_date_object( $start_date, $timezone )
+											->setTimezone( $utc )
+											->format( 'Y-m-d H:i:s' );
+		$utc_end_date    = Tribe__Date_Utils::build_date_object( $end_date, $timezone )
+											->setTimezone( $utc )
+											->format( 'Y-m-d H:i:s' );
+		$post_data->meta_input['_EventStartDateUTC'] = $utc_start_date;
+		$post_data->meta_input['_EventEndDateUTC'] = $utc_end_date;
+
+		return $post_data;
 	}
 }

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -121,8 +121,8 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		$utc = new DateTimeZone( 'UTC' );
 		$utc_start_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventStartDate'], $timezone );
 		$utc_end_date = Tribe__Date_Utils::build_date_object( $data->data['meta']['_EventEndDate'], $timezone );
-		$data->data['meta']['_EventStartDateUTC'] = $utc_start_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
-		$data->data['meta']['_EventEndDateUTC'] = $utc_end_date->setTimezone( $utc )->format( 'Y-m-d H:I:s' );
+		$data->data['meta']['_EventStartDateUTC'] = $utc_start_date->setTimezone( $utc )->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+		$data->data['meta']['_EventEndDateUTC'] = $utc_end_date->setTimezone( $utc )->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 
 		return $data;
 	}


### PR DESCRIPTION
🎫 https://central.tri.be/issues/120399

Include UTC dates meta for the events created on the block editor. This will prevent the api results from being broken and a lot of issues with the queries.

Props to @lucatume - his work 🥇 