### PR TITLE
Use "Tags" without textdomain as its a WP taxonomy.

### DIFF
--- a/src/views/blocks/event-tags.php
+++ b/src/views/blocks/event-tags.php
@@ -16,5 +16,5 @@
 $event_id = $this->get( 'post_id' );
 ?>
 <div class="tribe-events-single-section tribe-events-section-tags tribe-clearfix">
-	<?php echo tribe_meta_event_tags( esc_html__( 'Tags', 'the-events-calendar' ), ', ', false ) ?>
+	<?php echo tribe_meta_event_tags( esc_html__( 'Tags' ), ', ', false ) ?>
 </div>


### PR DESCRIPTION
🎫 https://central.tri.be/issues/119393

Nico suggested to remove the textdomain as it's a WP taxonomy.