### PR TITLE
Include UTC dates meta for the events created on the block editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Moved the "Remove venue" button for a better user experience when removing venues from an event [120267]
 * Fix - Date/time block conflicts when clicking to open the block options [119413]
 * Fix - Layout bugs with the new Twenty Nineteen core theme [119689]
+* Fix - Include UTC dates meta on the event creation from the block editor [120399]
 * Tweak - Ensure we don't re-apply `wpautop()` to content that has had it removed [120562]
 * Tweak - Adjusted content in the admin welcome page that users are brought to upon newly activating The Events Calendar [117795]
 

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -18,11 +18,14 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		// Provide backwards compatibility for meta data
 		$post_type = Tribe__Events__Main::POSTTYPE;
 		add_filter( "rest_prepare_{$post_type}", array( $this, 'meta_backwards_compatibility' ), 10, 3 );
+		add_filter( "rest_pre_insert_{$post_type}", array( $this, 'add_utc_dates' ), 10, 2 );
 
 		register_meta( 'post', '_EventAllDay', $this->boolean() );
 		register_meta( 'post', '_EventTimezone', $this->text() );
 		register_meta( 'post', '_EventStartDate', $this->text() );
 		register_meta( 'post', '_EventEndDate', $this->text() );
+		register_meta( 'post', '_EventStartDateUTC', $this->text() );
+		register_meta( 'post', '_EventEndDateUTC', $this->text() );
 		register_meta( 'post', '_EventShowMap', $this->boolean() );
 		register_meta( 'post', '_EventShowMapLink', $this->boolean() );
 		register_meta( 'post', '_EventURL', $this->text() );
@@ -114,6 +117,58 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 			$data->data['meta']['_EventAllDay'] = tribe_is_truthy( $all_day );
 		}
 
+		$timezone_string = get_post_meta( $post->ID, '_EventTimezone', true );
+
+		if ( ! $timezone_string ) {
+			$timezone_string = Tribe__Events__Timezones::wp_timezone_string();
+		}
+
+		$data->data['meta']['_EventStartDateUTC'] = Tribe__Events__Timezones::to_utc( $data->data['meta']['_EventStartDate'], $timezone_string );
+		$data->data['meta']['_EventEndDateUTC']   = Tribe__Events__Timezones::to_utc( $data->data['meta']['_EventEndDate'], $timezone_string );
+
 		return $data;
+	}
+
+	/**
+	 * Adds, triggering their updates, the UTC start and end dates to the post insertion or
+	 * update REST payload.
+	 *
+	 * @since TBD
+	 *
+	 * @param             \stdClass     $post_data The post insertion/update payload.
+	 * @param \WP_REST_Request $request The current insertion or update request object.
+	 *
+	 * @return \stdClass The post insertion/update payload with an added `meta_input` entry if
+	 *                   the insertion/update of UTC dates is required.
+	 */
+	public function add_utc_dates( $post_data, WP_REST_Request $request ) {
+		$json_params = $request->get_json_params();
+		$meta = Tribe__Utils__Array::get( $json_params, 'meta', array() );
+
+		// No changes to start and end? No need to update UTC dates.
+		if ( ! ( isset( $meta['_EventStartDate'] ) && isset( $meta['_EventEndDate'] ) ) ) {
+			return $post_data;
+		}
+
+		if ( ! isset( $post_data->meta_input ) ) {
+			$post_data->meta_input = array();
+		}
+
+		$post_id          = $request->get_param( 'id' );
+		$event_start_date = isset( $meta['_EventStartDate'] ) ? $meta['_EventStartDate'] : get_post_meta( $post_id, '_EventStartDate', true );
+		$event_end_date   = isset( $meta['_EventEndDate'] ) ? $meta['_EventEndDate'] : get_post_meta( $post_id, '_EventEndDate', true );
+		$timezone_string  = Tribe__Events__Timezones::get_event_timezone_string( $post_id );
+		$timezone_string  = Tribe__Utils__Array::get( $meta, '_EventTimezone', $timezone_string );
+
+		// If a specific timezone was not specified, default to the sitewide timezone
+		if ( empty( $timezone_string ) ) {
+			$timezone_string = Tribe__Events__Timezones::wp_timezone_string();
+		}
+
+		$post_data->meta_input['_EventTimezone']     = $timezone_string;
+		$post_data->meta_input['_EventStartDateUTC'] = Tribe__Events__Timezones::to_utc( $event_start_date, $timezone_string );
+		$post_data->meta_input['_EventEndDateUTC']   = Tribe__Events__Timezones::to_utc( $event_end_date, $timezone_string );
+
+		return $post_data;
 	}
 }


### PR DESCRIPTION
🎫 https://central.tri.be/issues/120399

Include UTC dates meta for the events created on the block editor. This will prevent the API results from being broken and a lot of issues with the queries.

We had a first attempt on https://github.com/moderntribe/the-events-calendar/pull/2371, but it was using a lot of functionality from ORM. I adapted the concept to the available functions.
