### PR TITLE
Spotfix/freemius activation

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -647,14 +647,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				'is_premium' => false,
 				'has_addons' => false,
 				'has_paid_plans' => false,
-				'menu' => array(
-					#'slug' => 'edit.php?post_type=tribe_events',
-					'slug' => 'edit.php?post_type=tribe_events&page=tribe-common&welcome-message-the-events-calendar=1',
-					'first-path' => 'edit.php?post_type=tribe_events&page=tribe-common&welcome-message-the-events-calendar=1',
-					'account' => false,
-					'contact' => false,
-					'support' => false,
-				),
 			) );
 			do_action( 'tec_fs_loaded' );
 		}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -648,7 +648,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				'has_addons' => false,
 				'has_paid_plans' => false,
 				'menu' => array(
-					'slug' => 'edit.php?post_type=tribe_events',
+					#'slug' => 'edit.php?post_type=tribe_events',
+					'slug' => 'edit.php?post_type=tribe_events&page=tribe-common&welcome-message-the-events-calendar=1',
 					'first-path' => 'edit.php?post_type=tribe_events&page=tribe-common&welcome-message-the-events-calendar=1',
 					'account' => false,
 					'contact' => false,


### PR DESCRIPTION
@zbtirrell — this removes the menu element from our call to fs_dynamic_init(). With this change, immediately after activation, the user is taken to:

![screenshot_2019-01-15 events lab wordpress](https://user-images.githubusercontent.com/3594411/51213012-cc370c00-18ce-11e9-895b-6ca6cba9663e.png)
