### PR TITLE
#121275 - fix fatal on deactivation and activation when older version…

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2738,9 +2738,14 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @param bool $network_deactivating
 		 */
 		public static function activate() {
+
 			self::instance()->plugins_loaded();
 
 			self::flushRewriteRules();
+
+			if ( ! class_exists( 'Tribe__Events__Editor__Compatibility' ) ) {
+				require_once dirname( __FILE__ ) . '/Editor/Compatibility.php';
+			}
 
 			$editor_compatibility = new Tribe__Events__Editor__Compatibility();
 			$editor_compatibility->deactivate_gutenberg_extension_plugin();
@@ -2757,6 +2762,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @param bool $network_deactivating
 		 */
 		public static function deactivate( $network_deactivating ) {
+
+			if ( ! class_exists( 'Tribe__Events__Deactivation' ) ) {
+				require_once dirname( __FILE__ ) . '/Deactivation.php';
+			}
+
 			$deactivation = new Tribe__Events__Deactivation( $network_deactivating );
 			add_action( 'shutdown', array( $deactivation, 'deactivate' ) );
 		}


### PR DESCRIPTION
… of ET

_Ref:_ [C#121275](https://central.tri.be/issues/121275)

If the class does not exist load the file to prevent fatal errors on activate and deactivate. 

This happens with and older version of ET is active and the latest for TEC tries to activate and deactivate. 