### PR TITLE
#121275 - load more classes to prevent fatal on deactivation

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2763,7 +2763,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public static function deactivate( $network_deactivating ) {
 
+			/**
+			 * If Deactivation Class not found manually load all classes to deactivate
+			 */
 			if ( ! class_exists( 'Tribe__Events__Deactivation' ) ) {
+				require_once dirname( __FILE__ ) . '/Capabilities.php';
+				require_once dirname( __FILE__ ) . '/Aggregator/Records.php';
 				require_once dirname( __FILE__ ) . '/Deactivation.php';
 			}
 


### PR DESCRIPTION
_Ref:_ [C#121275](https://central.tri.be/issues/121275)

Load two more classes manually to prevent fatal error on deactivation