### PR TITLE
#121486 - if et is older version disable older ce to prevent fatal

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -373,6 +373,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				add_action( 'network_admin_notices', array( $this, 'compatibility_notice' ) );
 				add_filter( 'tribe_ecp_to_run_or_not_to_run', array( $this, 'disable_pro' ) );
 
+				//Disable Older Versions of Community Events to Prevent Fatal Error
+				remove_action( 'plugins_loaded', 'Tribe_CE_Load', 2 );
+
 				return;
 			}
 


### PR DESCRIPTION
_Ref:_ [C#121486](https://central.tri.be/issues/121486)

This disables Pre PDC Version of CE if TEC shuts down due to an older version of ET.

