### PR TITLE
Fix/122368 prevent ex loading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,9 +215,10 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
-= [4.8.0.1] 2019-02-06 =
+= [4.8.0.1] 2019-02-07 =
 
 * Fix - Modify extension dependency checking with new system to determine if it can load [122368]
+* Tweak - Prevent most extensions from loading if Event Tickets is on an older version to prevent conflicts [122368]
 
 = [4.8] 2019-02-05 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -372,7 +372,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				add_action( 'admin_notices', array( $this, 'compatibility_notice' ) );
 				add_action( 'network_admin_notices', array( $this, 'compatibility_notice' ) );
 				add_filter( 'tribe_ecp_to_run_or_not_to_run', array( $this, 'disable_pro' ) );
-				add_action( 'tribe_plugins_loaded', array( $this, 'remove_fb_importer_ext' ), 0 );
+				add_action( 'tribe_plugins_loaded', array( $this, 'remove_exts' ), 0 );
 
 				//Disable Older Versions of Community Events to Prevent Fatal Error
 				remove_action( 'plugins_loaded', 'Tribe_CE_Load', 2 );
@@ -1487,18 +1487,23 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Prevents Facebook Importer Ext from Running if ET is on an Older Version
+		 * Prevents Certain Extensions from running if ET is on an Older Version
 		 *
 		 * @since 4.10.0.1
 		 *
 		 */
-		public function remove_fb_importer_ext() {
+		public function remove_exts() {
 
-			if ( ! class_exists( 'Tribe\Extensions\EA_FB\Facebook_Dev_Origin' ) ) {
-				return;
+			if ( class_exists( 'Tribe\Extensions\EA_FB\Facebook_Dev_Origin' ) ) {
+				remove_action( 'tribe_plugins_loaded', array( Tribe\Extensions\EA_FB\Facebook_Dev_Origin::instance(), 'register' ) );
 			}
 
-			remove_action( 'tribe_plugins_loaded', array( Tribe\Extensions\EA_FB\Facebook_Dev_Origin::instance(), 'register' ) );
+
+			if ( class_exists( 'Tribe__Extension__Instructor_Linked_Post_Type' ) ) {
+				remove_action( 'tribe_plugins_loaded', array( Tribe__Extension__Instructor_Linked_Post_Type::instance(), 'register' ) );
+			}
+
+
 		}
 
 		/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -372,6 +372,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				add_action( 'admin_notices', array( $this, 'compatibility_notice' ) );
 				add_action( 'network_admin_notices', array( $this, 'compatibility_notice' ) );
 				add_filter( 'tribe_ecp_to_run_or_not_to_run', array( $this, 'disable_pro' ) );
+				add_action( 'tribe_plugins_loaded', array( $this, 'remove_fb_importer_ext' ), 0 );
 
 				//Disable Older Versions of Community Events to Prevent Fatal Error
 				remove_action( 'plugins_loaded', 'Tribe_CE_Load', 2 );
@@ -1483,6 +1484,21 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function disable_pro() {
 			return false;
+		}
+
+		/**
+		 * Prevents Facebook Importer Ext from Running if ET is on an Older Version
+		 *
+		 * @since 4.10.0.1
+		 *
+		 */
+		public function remove_fb_importer_ext() {
+
+			if ( ! class_exists( 'Tribe\Extensions\EA_FB\Facebook_Dev_Origin' ) ) {
+				return;
+			}
+
+			remove_action( 'tribe_plugins_loaded', array( Tribe\Extensions\EA_FB\Facebook_Dev_Origin::instance(), 'register' ) );
 		}
 
 		/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1487,22 +1487,14 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Prevents Certain Extensions from running if ET is on an Older Version
+		 * Prevents Extensions from running if ET is on an Older Version
 		 *
 		 * @since 4.10.0.1
 		 *
 		 */
 		public function remove_exts() {
 
-			if ( class_exists( 'Tribe\Extensions\EA_FB\Facebook_Dev_Origin' ) ) {
-				remove_action( 'tribe_plugins_loaded', array( Tribe\Extensions\EA_FB\Facebook_Dev_Origin::instance(), 'register' ) );
-			}
-
-
-			if ( class_exists( 'Tribe__Extension__Instructor_Linked_Post_Type' ) ) {
-				remove_action( 'tribe_plugins_loaded', array( Tribe__Extension__Instructor_Linked_Post_Type::instance(), 'register' ) );
-			}
-
+			remove_all_actions( 'tribe_plugins_loaded', 10);
 
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1494,7 +1494,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function remove_exts() {
 
-			remove_all_actions( 'tribe_plugins_loaded', 10);
+			remove_all_actions( 'tribe_plugins_loaded', 10 );
 
 		}
 


### PR DESCRIPTION
_Ref:_ [C#122368](https://central.tri.be/issues/122368)

Prevents all extensions from loading on action tribe_plugins_loaded priority 10 if ET on an older version. 