### PR TITLE
Fix inconsistent display of events in Month view when filtering by category

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -892,9 +892,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			  */
 			 $args = apply_filters( 'tribe_events_month_daily_events_query_args', $args );
 
-			// we don't need this join since we already checked it
-			unset ( $args[ Tribe__Events__Main::TAXONOMY ] );
-
 			return tribe_get_events( $args, true );
 		}
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -226,10 +226,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 *		@see  get_posts()  for more params
 	 * }
-	 * @param bool  $full (optional) if the full query object is required or just an array of event posts
 	 *
-	 * @return array List of posts.
+	 * @param bool $full Whether to return an array of event posts (default) or the query object
+	 *                   to fetch them.
 	 *
+	 * @return array|WP_Query A list of event posts matching the query arguments or a WP_Query instance
+	 *                        if the `$full` argument is set to `true`.
 	 */
 	function tribe_get_events( $args = array(), $full = false ) {
 		if ( empty ( $args['eventDisplay'] ) ) {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/123472

This PR:
* fixes the issue that would cause inconsistent filtering of events in the Month view when filtering by category
* updates the `tribe_get_events` doc block to specify `WP_Query` as a possible return type.