### PR TITLE
Fix Month and List view ORM issues.

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1284,6 +1284,18 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 					}
 				}
 
+				/**
+				 * Some key arguments have been passed as arrays but will require unpacking.
+				 * Due to the dynamic nature of the ORM implementation this is a curated list
+				 * that should be updated here. Do not try to move this conditional unpacking logic
+				 * in the ORM: this is an issue the proxy function should handle ad-hoc.
+				 */
+				$requiring_unpack = [ 'date_overlaps' ];
+				foreach ( array_intersect( array_keys( $args ), $requiring_unpack ) as $key ) {
+					$event_orm->by( $key, ...$args[ $key ] );
+					unset( $args[ $key ] );
+				}
+
 				$event_orm->by_args( $args );
 
 				if ( $return_found_posts ) {

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -76,6 +76,8 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 				$post_status[] = 'private';
 			}
 
+			$display = tribe( 'context' )->get( 'event_display' );
+
 			$args = array(
 				'eventDisplay' => $display,
 				'post_type'    => Tribe__Events__Main::POSTTYPE,

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -852,10 +852,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			}
 
 			$beginning_of_day           = $this->get_cutoff_details( $date, 'beginning' );
-			$beginning_of_day_timestamp = $this->get_cutoff_details( $date, 'beginning_timestamp' );
-
 			$end_of_day           = $this->get_cutoff_details( $date, 'end' );
-			$end_of_day_timestamp = $this->get_cutoff_details( $date, 'end_timestamp' );
 
 			$event_ids_on_date = $this->get_event_ids_by_day( $date );
 
@@ -872,8 +869,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 					'eventDisplay'           => 'month',
 					'posts_per_page'         => $this->events_per_day,
 					'post__in'               => $event_ids_on_date,
-					'start_date'             => $beginning_of_day,
-					'end_date'               => $end_of_day,
+					'date_overlaps'          => [ $beginning_of_day, $end_of_day ],
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/123945
* https://central.tri.be/issues/123950

This PR fixes two issues caused by the ORM switch in `tribe_get_events`:
1. the Month view was fetching events in starting and ending on the same day, the correct way to fetch those events is to fetch those that **overlap** the day.
2. the List view was not looking around for the context anymore triggering a PHP notice and defaulting to fetch, pretty much, all events.
3. to support 1 the `tribe_get_events` function contains now an "unpack" conditional logic, to "unpack" some filters before calling them on the ORM; currently this will only unpack the `date_overlaps` argument but we can add more along the way