### PR TITLE
Fix ORM and Views AJAX pagination issues.

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -958,12 +958,22 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return $html;
 			}
 
-			$tec = self::instance();
+			/*
+			 * The category might come from a query for a taxonomy archive or as
+			 * an additional query variable: let's check both.
+			 */
+			$event_taxonomy = self::instance()->get_event_taxonomy();
+			$category       = '';
+			if ( is_tax( $event_taxonomy ) ) {
+				$category = get_query_var( 'term' );
+			} elseif ( $tribe_cat = $wp_query->get( $event_taxonomy, false ) ) {
+				$category = $tribe_cat;
+			}
 
 			$data_attributes = array(
 				'live_ajax'         => tribe_get_option( 'liveFiltersUpdate', true ) ? 1 : 0,
 				'datepicker_format' => tribe_get_option( 'datepickerFormat' ),
-				'category'          => is_tax( $tec->get_event_taxonomy() ) ? get_query_var( 'term' ) : '',
+				'category'          => $category,
 				'featured'          => tribe( 'tec.featured_events' )->is_featured_query(),
 			);
 			// allow data attributes to be filtered before display

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -69,7 +69,6 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 
 			Tribe__Events__Query::init();
 
-
 			$tribe_paged = absint( tribe_get_request_var( 'tribe_paged', 1 ) );
 			$post_status = [ 'publish' ];
 			if ( is_user_logged_in() ) {
@@ -103,14 +102,14 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 				$args['start_date'] = tribe_beginning_of_day( $date );
 				$args['order']      = 'ASC';
 			} elseif ( 'past' === $display ) {
-				$args['starts_before'] = Tribe__Date_Utils::build_date_object( 'now' );
+				$args['starts_before'] = tribe_beginning_of_day( $date );
 				$args['order']         = 'DESC';
 			} elseif ( 'all' === $display ) {
 				$args['start_date'] = tribe_beginning_of_day( $date );
 				$args['order']      = 'ASC';
 			}
 
-			// check & set event category
+			// Check & set event category.
 			if ( isset( $_POST['tribe_event_category'] ) ) {
 				$args[ Tribe__Events__Main::TAXONOMY ] = $_POST['tribe_event_category'];
 			}
@@ -119,14 +118,20 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 
 			$query = tribe_get_events( $args, true );
 
-			// $hash is used to detect whether the primary arguments in the query have changed (i.e. due to a filter bar request)
-			// if they have, we want to go back to page 1
+			/*
+			 * The hash is used to detect whether the primary arguments in the query have changed (i.e. due to a filter bar request).
+			 * If they have, we want to go back to page 1.
+			 */
 			$hash = $query->query_vars;
 
-			$hash['paged']      = null;
-			$hash['start_date'] = null;
-			$hash['end_date']   = null;
-			$hash['search_orderby_title'] = null;
+			unset(
+				$hash['paged'],
+				$hash['start_date'],
+				$hash['end_date'],
+				$hash['starts_before'],
+				$hash['search_orderby_title']
+			);
+
 			$hash_str           = md5( maybe_serialize( $hash ) );
 
 			if ( ! empty( $_POST['hash'] ) && $hash_str !== $_POST['hash'] ) {
@@ -134,7 +139,6 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 				$args['paged'] = 1;
 				$query         = tribe_get_events( $args, true );
 			}
-
 
 			$response = array(
 				'html'        => '',

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -851,9 +851,6 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				return $daily_events;
 			}
 
-			$beginning_of_day           = $this->get_cutoff_details( $date, 'beginning' );
-			$end_of_day           = $this->get_cutoff_details( $date, 'end' );
-
 			$event_ids_on_date = $this->get_event_ids_by_day( $date );
 
 			// post__in doesn't work when it's empty, so just don't run the query if there are no IDs
@@ -861,21 +858,29 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				return new WP_Query();
 			}
 
-			// this  will skip updating term and meta caches - those were already
-			// updated in $this->set_events_in_month()
-			// expected order of events: sticky events, ongoing multi day events, all day events, then by start time
+			/**
+			 * Since we've already got the post IDs of the events fitting the search criteria
+			 * we can unset this to avoid furhter date-based filtering from happening.
+			 */
+			unset( $this->args['eventDate'] );
+
+			/*
+			 * This  will skip updating term and meta caches - those were already
+			 * updated in `$this->set_events_in_month()`.
+			 * We run another query to make sure the ordering applies correctly.
+			 * Expected order of events: sticky events, ongoing multi day events, all day events, then by start time.
+			 */
 			$args = wp_parse_args(
 				array(
 					'eventDisplay'           => 'month',
 					'posts_per_page'         => $this->events_per_day,
 					'post__in'               => $event_ids_on_date,
-					'date_overlaps'          => [ $beginning_of_day, $end_of_day ],
 					'update_post_term_cache' => false,
 					'update_post_meta_cache' => false,
 					'no_found_rows'          => false,
 					'do_not_inject_date'     => true,
 
-					// Don't replace `orderby` without taking in cosideration `menu_order`
+					// Don't replace `orderby` without taking in cosideration `menu_order`.
 					'orderby'                => 'post__in',
 				), $this->args
 			);


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/123950
* https://central.tri.be/issues/123945
* https://central.tri.be/issues/123472

This PR:
* fixes an issue in the List view where the past events AJAX pagination would not paginate beyond the first page.
* fixes an issue where the Month view would not display events (correctly or at all) depending on the timezone settings (Display, Site and Event)
* fixes an issue (not related in ORM but present in `master` too) where the event category would not be used and set in the Map view