### PR TITLE
Make the filterbar featured event filter work with ORM

### DIFF
--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -896,7 +896,10 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 			);
 
 			// If the request is false or not set we assume the request is for all events, not just featured ones.
-			if ( tribe_is_truthy( tribe_get_request_var( 'tribe_featuredevent', false ) ) ) {
+			if (
+				tribe_is_truthy( tribe_get_request_var( 'featured', false ) )
+				|| tribe_is_truthy( tribe_get_request_var( 'tribe_featuredevent', false ) )
+			) {
 				$args['featured'] = true;
 			}
 

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -895,6 +895,11 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 				), $this->args
 			);
 
+			// If the request is false or not set we assume the request is for all events, not just featured ones.
+			if ( tribe_is_truthy( tribe_get_request_var( 'tribe_featuredevent', false ) ) ) {
+				$args['featured'] = true;
+			}
+
 			/**
 			  * Filter Daily Events Query Arguments.
 			  *


### PR DESCRIPTION
🎫 https://central.tri.be/issues/125259

From what I talked with Luca, in ORM, if:

- the featured arg is true, then it brings only featured events.
- the featured arg is false, then it brings not featured events.
- not defined, brings all.

Adding the if statement to make this work with the filter bar. Maybe in the future we can revisit to see if we can hook to `tribe_events_month_daily_events_query_args` directly. I'm using both `featured` and `tribe_featuredevent` to get both cases working.