### PR TITLE
Fix iCal feed generation to use ORM args correctly

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -268,7 +268,14 @@ class Tribe__Events__iCal {
 				return;
 			}
 
-			$events_posts = $this->get_events_list( $wp_query->query, $wp_query );
+			$args = $wp_query->query_vars;
+
+			if ( 'list' === $args['eventDisplay'] ) {
+				// Whe producing a List view iCal feed the `eventDate` is misleading.
+				unset( $args['eventDate'] );
+			}
+
+			$events_posts = $this->get_events_list( $args, $wp_query );
 		}
 
 		$event_ids = wp_list_pluck( $events_posts, 'ID' );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/125433

Switching to the ORM the main query arguments, the contents of the `query` property, and the main
query variables, the contents of the `query_vars` property, are not always in sync. While building
the ORM query a number of variables are set on the query in the `query_vars` property that are not
set on the `query` argument. Since the iCal feed function was reading the `query` property and not
the `query_vars` one, some arguments that produced the correct event list in the view template would
not make it into the `query` property resulting in a different set of events. The fix simply changes
the iCal feed generation to use the `query_vars` property. Furthermore a small "fix" to the
arguments is needed when producing the iCal feed for the List view to remove the `eventDate`
argument, used in the Day view.