### PR TITLE
Modify the Event ORM to be Timezone Settings aware.

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -385,31 +385,33 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				}
 
 				/**
-				 * Filters whether or not to use the UTC Start Date hack to include meta table.
+				 * Filters whether or not to use the Start Date meta hack to include meta table.
 				 *
-				 * We stopped using `_EventStartDate` due to problems with inconsistency with timezones.
-				 * It was based on the Tribe__Events__Timezones::is_mode( 'site' ) definition.
 				 * We only add the `postmeta` hack if it's not the main admin events list
 				 * because this method filters out drafts without EventStartDate.
 				 * For this screen we're doing the JOIN manually in `Tribe__Events__Admin_List`.
 				 *
-				 * @param boolean $use_hack Whether to include the UTC start date or not.
+				 * @param boolean $use_hack Whether to include the start date meta or not.
 				 * @param \WP_Query|null $query The query that is currently being filtered or `null` if no query is
 				 *                              being filtered.
 				 *
 				 * @since TBD
 				 */
-				$include_utc_start_date = apply_filters( 'tribe_events_query_event_utc_start_date', true, $query );
+				$include_date_meta = apply_filters( 'tribe_events_query_include_start_date_meta', true, $query );
 				if (
-					$include_utc_start_date
+					$include_date_meta
 					&& ! tribe( 'context' )->is_editing_post( Tribe__Events__Main::POSTTYPE )
 				) {
+					$date_meta_key = Tribe__Events__Timezones::is_mode( 'site' )
+						? '_EventStartDateUTC'
+						: '_EventStartDate';
+
 					$meta_query[] = array(
-						'key'  => '_EventStartDateUTC',
+						'key'  => $date_meta_key,
 						'type' => 'DATETIME',
 					);
 
-					$query->set( 'tribe_use_utc', true );
+					$query->set( 'tribe_include_date_meta', true );
 				}
 			}
 
@@ -615,24 +617,22 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 			$postmeta_table = self::postmeta_table( $query );
 
 			/**
-			 * Which param will be queried in the Database for Events Date Start
+			 * Which param will be queried in the Database for Events Date Start.
 			 *
 			 * @since  1.0
-			 * @since  TBD  We moved into using ORM so we only use UTC dates now
 			 *
 			 * @var string
 			 */
-			$event_start_key = '_EventStartDateUTC';
+			$event_start_key = Tribe__Events__Timezones::is_mode( 'site' ) ? '_EventStartDateUTC' : '_EventStartDate';
 
 			/**
-			 * Which param will be queried in the Database for Events Date End
+			 * Which param will be queried in the Database for Events Date End.
 			 *
 			 * @since  1.0
-			 * @since  TBD  We moved into using ORM so we only use UTC dates now
 			 *
 			 * @var string
 			 */
-			$event_end_key   = '_EventEndDateUTC';
+			$event_end_key = Tribe__Events__Timezones::is_mode( 'site' ) ? '_EventEndDateUTC' : '_EventStartDate';
 
 			/**
 			 * When the "Use site timezone everywhere" option is checked in events settings,
@@ -696,15 +696,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$postmeta_table = self::postmeta_table( $query );
 
 				$start_date = $query->get( 'start_date' );
-				$end_date   = $query->get( 'end_date' );
-				/*
-				 * While in the `\Tribe__Events__Query::pre_get_posts()` we default to `true` here we want to default
-				 * to `false` not to interfere with all queries indiscriminately.
-				 *
-				 * @see \Tribe__Events__Query::pre_get_posts().
-				 */
-				$use_utc = $query->get( 'tribe_use_utc', false );
-				$use_utc = $use_utc || Tribe__Events__Timezones::is_mode( 'site' );
+				$end_date = $query->get( 'end_date' );
+				$use_utc = Tribe__Events__Timezones::is_mode( 'site' );
 				$site_tz = $use_utc ? Tribe__Events__Timezones::wp_timezone_string() : null;
 
 				// Sitewide timezone mode: convert the start date - if set - to UTC

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1286,7 +1286,8 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 					}
 				}
 
-				if ( ! empty( $args['tribe_is_past'] ) ) {
+				$is_past = ! empty( $args['tribe_is_past'] ) || 'past' === $event_display;
+				if ( $is_past ) {
 					$args['order'] = 'DESC';
 					$pivot_date = tribe_get_request_var( 'tribe-bar-date', 'now' );
 					$date       = Tribe__Date_Utils::build_date_object( $pivot_date );

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1457,6 +1457,8 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 * @param bool $use_utc Whether ot use the UTC dates and times to read events or not. If `true` then the
 	 *                      `_EventStartDateUTC` and `_EventEndDateUTC` meta keys will be used, if `false` then the
 	 *                      `_EventStartDate` and `_EventEndDate` meta keys will be used.
+	 *
+	 * @return static This repository instance.
 	 */
 	public function use_utc( $use_utc ) {
 		$this->normal_timezone = $use_utc ?
@@ -1464,5 +1466,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			: Timezones::build_timezone_object();
 		$this->start_meta_key = $use_utc ? '_EventStartDateUTC' : '_EventStartDate';
 		$this->end_meta_key = $use_utc ? '_EventEndDateUTC' : '_EventEndDate';
+
+		return $this;
 	}
 }

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -30,6 +30,39 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	protected $menu_order = 0;
 
 	/**
+	 * The meta key that should be used for the start date.
+	 *
+	 * Defaults to `_EventStartDateUTC`.
+	 *
+	 * @see \Tribe__Events__Repositories__Event::use_utc()
+	 *
+	 * @var string
+	 */
+	protected $start_meta_key = '_EventStarDateUTC';
+
+	/**
+	 * The meta key that should be used for the end date.
+	 *
+	 * Defaults to `_EventEndDateUTC`.
+	 *
+	 * @see \Tribe__Events__Repositories__Event::use_utc()
+	 *
+	 * @var string
+	 */
+	protected $end_meta_key = '_EvenEndDateUTC';
+
+	/**
+	 * The timezone object that should be used to normalize dates.
+	 *
+	 * Defaults to the UTC timezone.
+	 *
+	 * @see \Tribe__Events__Repositories__Event::use_utc()
+	 *
+	 * @var \DateTimeZone
+	 */
+	protected $normal_timezone;
+
+	/**
 	 * Tribe__Events__Repositories__Event constructor.
 	 *
 	 * Sets up the repository default parameters and schema.
@@ -38,6 +71,23 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		/**
+		 * Depending on the setting used to present event on the site the timezone used to normalize
+		 * events and the keys used to sort them will be different.
+		 * This initial setting can be reverted on a per-instance base using the `use_utc` method.
+		 *
+		 * @see Tribe__Events__Repositories__Event::use_utc()
+		 */
+		if ( Timezones::is_mode( 'site' ) ) {
+			$this->normal_timezone = new DateTimeZone( 'UTC' );
+			$this->start_meta_key = '_EventStartDateUTC';
+			$this->end_meta_key = '_EventEndDateUTC';
+		} else {
+			$this->normal_timezone = Timezones::build_timezone_object();
+			$this->start_meta_key = '_EventStartDate';
+			$this->end_meta_key = '_EventEndDate';
+		}
 
 		$this->create_args['post_type'] = Tribe__Events__Main::POSTTYPE;
 		$this->taxonomies               = array(
@@ -172,12 +222,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_starts_before( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'starts-before' => array(
-					'key'     => '_EventStartDateUTC',
+					'key'     => $this->start_meta_key,
 					'compare' => '<',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -201,12 +251,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_ends_on_or_before( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'ends-before' => array(
-					'key'     => '_EventEndDateUTC',
+					'key'     => $this->end_meta_key,
 					'compare' => '<=',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -230,12 +280,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_ends_before( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'ends-before' => array(
-					'key'     => '_EventEndDateUTC',
+					'key'     => $this->end_meta_key,
 					'compare' => '<',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -259,12 +309,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_starts_after( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'starts-after' => array(
-					'key'     => '_EventStartDateUTC',
+					'key'     => $this->start_meta_key,
 					'compare' => '>',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -288,12 +338,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_starts_on_or_after( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'starts-after' => array(
-					'key'     => '_EventStartDateUTC',
+					'key'     => $this->start_meta_key,
 					'compare' => '>=',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -317,12 +367,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_ends_after( $datetime, $timezone = null ) {
 		$date = Tribe__Date_Utils::build_date_object( $datetime, $timezone )
-		                         ->setTimezone( new DateTimeZone( 'UTC' ) );
+		                         ->setTimezone( $this->normal_timezone );
 
 		return array(
 			'meta_query' => array(
 				'ends-after' => array(
-					'key'     => '_EventEndDateUTC',
+					'key'     => $this->end_meta_key,
 					'compare' => '>',
 					'value'   => $date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 					'type'    => 'DATETIME',
@@ -348,14 +398,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_date_overlaps( $start_datetime, $end_datetime, $timezone = null ) {
 		global $wpdb;
-		$utc = new DateTimeZone( 'UTC' );
+		$utc = $this->normal_timezone;
 
 		$lower = Tribe__Date_Utils::build_date_object( $start_datetime, $timezone )->setTimezone( $utc );
 		$upper = Tribe__Date_Utils::build_date_object( $end_datetime, $timezone )->setTimezone( $utc );
 		$lower_string = $lower->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 		$upper_string = $upper->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
-		$start_key = '_EventStartDateUTC';
-		$end_key = '_EventEndDateUTC';
+		$start_key = $this->start_meta_key;
+		$end_key = $this->end_meta_key;
 
 		$join_start_key = 'tribe_start_date_utc';
 		$join_end_key = 'tribe_end_date_utc';
@@ -403,12 +453,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 *                                            if the `$datetime` parameter is a DatTime object.
 	 */
 	public function filter_by_starts_between( $start_datetime, $end_datetime, $timezone = null ) {
-		$utc = new DateTimeZone( 'UTC' );
+		$utc = $this->normal_timezone;
 
 		$lower = Tribe__Date_Utils::build_date_object( $start_datetime, $timezone )->setTimezone( $utc );
 		$upper = Tribe__Date_Utils::build_date_object( $end_datetime, $timezone )->setTimezone( $utc );
 
-		$this->by( 'meta_between', '_EventStartDateUTC', array(
+		$this->by( 'meta_between', $this->start_meta_key, array(
 			$lower->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 			$upper->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 		), 'DATETIME' );
@@ -428,12 +478,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 *                                            if the `$datetime` parameter is a DatTime object.
 	 */
 	public function filter_by_ends_between( $start_datetime, $end_datetime, $timezone = null ) {
-		$utc = new DateTimeZone( 'UTC' );
+		$utc = $this->normal_timezone;
 
 		$lower = Tribe__Date_Utils::build_date_object( $start_datetime, $timezone )->setTimezone( $utc );
 		$upper = Tribe__Date_Utils::build_date_object( $end_datetime, $timezone )->setTimezone( $utc );
 
-		$this->by( 'meta_between', '_EventEndDateUTC', array(
+		$this->by( 'meta_between', $this->end_meta_key, array(
 			$lower->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 			$upper->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
 		), 'DATETIME' );
@@ -533,10 +583,10 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_runs_between( $start_datetime, $end_datetime, $timezone = null ) {
 		$start_date = Tribe__Date_Utils::build_date_object( $start_datetime, $timezone )
-		                               ->setTimezone( new DateTimeZone( 'UTC' ) )
+		                               ->setTimezone( $this->normal_timezone )
 		                               ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 		$end_date   = Tribe__Date_Utils::build_date_object( $end_datetime, $timezone )
-		                               ->setTimezone( new DateTimeZone( 'UTC' ) )
+		                               ->setTimezone( $this->normal_timezone )
 		                               ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 
 		return array(
@@ -544,14 +594,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 				'runs-between' => array(
 					'starts'   => array(
 						'after-the-start' => array(
-							'key'     => '_EventStartDateUTC',
+							'key'     => $this->start_meta_key,
 							'value'   => $start_date,
 							'compare' => '>=',
 							'type'    => 'DATETIME',
 						),
 						'relation'        => 'AND',
 						'before-the-end'  => array(
-							'key'     => '_EventStartDateUTC',
+							'key'     => $this->start_meta_key,
 							'value'   => $end_date,
 							'compare' => '<=',
 							'type'    => 'DATETIME',
@@ -560,14 +610,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 					'relation' => 'OR',
 					'ends'     => array(
 						'after-the-start' => array(
-							'key'     => '_EventEndDateUTC',
+							'key'     => $this->end_meta_key,
 							'value'   => $start_date,
 							'compare' => '>=',
 							'type'    => 'DATETIME',
 						),
 						'relation'        => 'AND',
 						'before-the-end'  => array(
-							'key'     => '_EventEndDateUTC',
+							'key'     => $this->end_meta_key,
 							'value'   => $end_date,
 							'compare' => '<=',
 							'type'    => 'DATETIME',
@@ -637,10 +687,10 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 */
 	public function filter_by_starts_and_ends_between( $start_datetime, $end_datetime, $timezone = null ) {
 		$start_date = Tribe__Date_Utils::build_date_object( $start_datetime, $timezone )
-		                               ->setTimezone( new DateTimeZone( 'UTC' ) )
+		                               ->setTimezone( $this->normal_timezone )
 		                               ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 		$end_date   = Tribe__Date_Utils::build_date_object( $end_datetime, $timezone )
-		                               ->setTimezone( new DateTimeZone( 'UTC' ) )
+		                               ->setTimezone( $this->normal_timezone )
 		                               ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 
 		$interval = array( $start_date, $end_date );
@@ -649,14 +699,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			'meta_query' => array(
 				'starts-ends-between' => array(
 					'starts-between' => array(
-						'key'     => '_EventStartDateUTC',
+						'key'     => $this->start_meta_key,
 						'value'   => $interval,
 						'compare' => 'BETWEEN',
 						'type'    => 'DATETIME',
 					),
 					'relation'       => 'AND',
 					'ends-between'   => array(
-						'key'     => '_EventEndDateUTC',
+						'key'     => $this->end_meta_key,
 						'value'   => $interval,
 						'compare' => 'BETWEEN',
 						'type'    => 'DATETIME',
@@ -973,7 +1023,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			);
 			$timezone                      = Tribe__Timezones::build_timezone_object( $input_timezone );
 			$timezone_changed              = $input_timezone !== $current_event_timezone_string;
-			$utc                           = new DateTimeZone( 'UTC' );
+			$utc                           = $this->normal_timezone;
 			$dates_changed                 = array();
 
 			/**
@@ -1393,5 +1443,26 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 
 		// Add on second to the previous day to get the start of this day.
 		$this->filter_by_starts_between( $begin, $end );
+	}
+
+	/**
+	 * Instructs the repository to use UTC dates and times for reading operations or not.
+	 *
+	 * By default the repository will use the events `_EventStartDateUTC` and `_EventEndDateUTC` meta keys
+	 * depending on the site Time Zone Settings.
+	 * This method allows overriding this behavior on a per-instance basis.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $use_utc Whether ot use the UTC dates and times to read events or not. If `true` then the
+	 *                      `_EventStartDateUTC` and `_EventEndDateUTC` meta keys will be used, if `false` then the
+	 *                      `_EventStartDate` and `_EventEndDate` meta keys will be used.
+	 */
+	public function use_utc( $use_utc ) {
+		$this->normal_timezone = $use_utc ?
+			new DateTimeZone( 'UTC' )
+			: Timezones::build_timezone_object();
+		$this->start_meta_key = $use_utc ? '_EventStartDateUTC' : '_EventStartDate';
+		$this->end_meta_key = $use_utc ? '_EventEndDateUTC' : '_EventEndDate';
 	}
 }

--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -175,6 +175,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 				$args = [
 					'post_status'  => $post_status,
 					'eventDisplay' => 'day',
+					'order' => 'ASC',
 				];
 
 				$search = tribe_get_request_var( 'tribe-bar-search' );

--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -206,6 +206,9 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 
 				$args['posts_per_page'] = -1; // show ALL day posts
 
+				// By default do not show hidden events.
+				$args['hidden'] = false;
+
 				/** @var \Tribe__Events__Repositories__Event $events_orm */
 				$events_orm = tribe_events();
 

--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -205,7 +205,9 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 
 				$args['posts_per_page'] = -1; // show ALL day posts
 
+				/** @var \Tribe__Events__Repositories__Event $events_orm */
 				$events_orm = tribe_events();
+
 				$events_orm->by( 'date_overlaps', tribe_beginning_of_day( $event_date ), tribe_end_of_day( $event_date ) );
 				$events_orm->by_args( $args );
 

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -99,14 +99,14 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 			$args['eventDisplay'] = $display;
 
 			if ( 'list' === $display ) {
-				$args['start_date'] = tribe_beginning_of_day( $date );
-				$args['order']      = 'ASC';
+				$args['ends_after'] = $date;
+				$args['order'] = 'ASC';
 			} elseif ( 'past' === $display ) {
-				$args['starts_before'] = tribe_beginning_of_day( $date );
-				$args['order']         = 'DESC';
+				$args['ends_before'] = $date;
+				$args['order'] = 'DESC';
 			} elseif ( 'all' === $display ) {
-				$args['start_date'] = tribe_beginning_of_day( $date );
-				$args['order']      = 'ASC';
+				$args['start_date'] = $date;
+				$args['order'] = 'ASC';
 			}
 
 			// Check & set event category.

--- a/src/Tribe/Template/Month.php
+++ b/src/Tribe/Template/Month.php
@@ -605,14 +605,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Month' ) ) {
 
 
 			if ( null === $events_in_month ) {
-				/**
-				 * Documented in the `\Tribe__Events__Query::pre_get_posts` method.
-				 *
-				 * @see   \Tribe__Events__Query::pre_get_posts()
-				 *
-				 * @since TBD
-				 */
-				$use_utc = apply_filters( 'tribe_events_query_event_utc_start_date', true );
+				$use_utc = Tribe__Timezones::is_mode( 'site' );
 				$start_date_key = $use_utc ? '_EventStartDateUTC' : '_EventStartDate';
 
 				$start_date_sql = esc_sql( $start_date );

--- a/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
@@ -12,6 +12,8 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 
 		// your set up methods here
 		$this->factory()->event = new Event();
+		// Explicitly set the timezone mode to use the site-wide setting.
+		tribe_update_option('tribe_events_timezone_mode', 'site');
 	}
 
 	/**
@@ -642,5 +644,76 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			'2018-01-10 14:00:00',
 			'2018-01-10 10:00:00',
 		], $ny_matches->pluck_meta( '_EventStartDate' ) );
+	}
+
+	/**
+	 * It should allow overriding the timezone settings
+	 *
+	 * @test
+	 */
+	public function should_allow_overriding_the_timezone_settings() {
+		$site_timezone = 'Europe/Paris';
+		update_option( 'timezone_string', $site_timezone );
+
+		extract( $this->create_events_from_dates( [
+			'paris_nine_event' => [ '2019-04-09 10:00:00', 2 * HOUR_IN_SECONDS ],
+			'paris_ten_event'  => [ '2019-04-10 11:00:00', 2 * HOUR_IN_SECONDS ],
+		], 'Europe/Paris' ) );
+		extract( $this->create_events_from_dates( [
+			// 4/10 1:30am in Europe/Paris.
+			'la_nine_event' => [ '2019-04-09 16:30:00', 2 * HOUR_IN_SECONDS ],
+			// 4/10 11:30pm in Europe/Paris.
+			'la_ten_event'  => [ '2019-04-10 14:30:00', 2 * HOUR_IN_SECONDS ],
+		], 'America/Los_Angeles' ) );
+
+		$nine_events = tribe_events()->use_utc( false )->where( 'on_date', '2019-04-09' )->collect();
+		codecept_debug(
+			'4/9 events UTC dates: ' . implode( PHP_EOL, $nine_events->pluck_meta( '_EventStartDateUTC' ) )
+		);
+
+		$this->assertEquals(
+			[
+				'2019-04-09 10:00:00',
+				'2019-04-09 16:30:00',
+			],
+			$nine_events->pluck_meta( '_EventStartDate' ) );
+		$this->assertEquals( [
+			'Europe/Paris',
+			'America/Los_Angeles',
+		], $nine_events->pluck_meta( '_EventTimezone' ) );
+
+		$ten_events = tribe_events()->use_utc( false )->where( 'on_date', '2019-04-10' )->collect();
+		codecept_debug(
+			'4/10 events UTC dates: ' . implode( PHP_EOL, $ten_events->pluck_meta( '_EventStartDateUTC' ) )
+		);
+
+		$this->assertEquals( [
+			'2019-04-10 11:00:00',
+			'2019-04-10 14:30:00',
+		], $ten_events->pluck_meta( '_EventStartDate' ) );
+		$this->assertEquals( [
+			'Europe/Paris',
+			'America/Los_Angeles',
+		], $ten_events->pluck_meta( '_EventTimezone' ) );
+
+		$ten_utc_events = tribe_events()->use_utc( true )->where( 'on_date', '2019-04-10' )->collect();
+		codecept_debug(
+			'4/10 events Europe/Paris dates: ' . implode( PHP_EOL, array_map( function ( $utc_date ) {
+				return ( new \DateTime( $utc_date, new \DateTimeZone( 'UTC' ) ) )
+					->setTimezone( new \DateTimeZone( 'Europe/Paris' ) )
+					->format( 'Y-m-d H:i:s' );
+			}, $ten_events->pluck_meta( '_EventStartDateUTC' ) ) )
+		);
+
+		$this->assertEquals( [
+			'2019-04-10 11:00:00',
+			'2019-04-09 16:30:00',
+			'2019-04-10 14:30:00',
+		], $ten_utc_events->pluck_meta( '_EventStartDate' ) );
+		$this->assertEquals( [
+			'Europe/Paris',
+			'America/Los_Angeles',
+			'America/Los_Angeles',
+		], $ten_utc_events->pluck_meta( '_EventTimezone' ) );
 	}
 }


### PR DESCRIPTION
Tickets: 
* https://central.tri.be/issues/125196
* https://central.tri.be/issues/123950
* https://central.tri.be/issues/125383

This PR updates the Event ORM to make it so that, upon construction, the Timezone settings will be taken into account.
The settings are the ones the user can set in `Events > Settings > Time Zone Settings` section.
This changes the ORM behavior to improve back-compatibility with existing views and honor the setting.
By default the ORM would use the UTC date/times to sort events, this would align with the "Use site-wide timezone setting everywhere" but it would ignore the "Use manual time zones for each event" setting before this fix.
What the settings mean is not immediate; here's an example:
* given the site timezone is Europe/Paris
* given a Asia/Tokyo timezone event on 4/9, 4pm to 6pm (it would be 4/10 9am to 11am in Europe/Paris time)
* given a Europe/Paris timezone event on 4/9, 4pm to 6pm

With "Use manual time zones for each event": both would show up on 4/9.
With "Use site-wide timezone setting everywhere": the 4/9 Paris event would show up on 4/9, the 4/9 Tokyo event would show up on 4/10 (see date/time conversion above).

The PR  also adds a `Tribe__Events__Repositories__Event::use_utc( bool $use_utc )` method to allow overriding this initial setup on a per-instance basis.

Other fixes:
* fix the List view to make sure it uses the same filtering criteria as the main query.
* fix an issue with Day view ordering and hidden events showing.