### PR TITLE
fix(tribe_get_events function): Set an `eventDisplay` query property if possible.

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1338,6 +1338,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				} else {
 					$result = $event_orm->get_query();
 
+					// Set the event display, if any, for back-compatibility purposes.
+					if ( ! empty( $event_display ) ) {
+						$result->set( 'eventDisplay', $event_display );
+					}
+
 					// Run the query.
 					$result->get_posts();
 				}


### PR DESCRIPTION
Some integrations rely on an `eventDisplay` query property to be set to work. Moving the
implementation of `tribe_get_events` to an ORM-based functionality we've removed that property
setting: this fix makes sure such property is set, if possible.

re https://central.tri.be/issues/125511