### PR TITLE
Fix List and Day view pagination issues.

### DIFF
--- a/src/Tribe/Template/Day.php
+++ b/src/Tribe/Template/Day.php
@@ -212,6 +212,7 @@ if ( ! class_exists( 'Tribe__Events__Template__Day' ) ) {
 				/** @var \Tribe__Events__Repositories__Event $events_orm */
 				$events_orm = tribe_events();
 
+				$events_orm->order_by( 'event_date' );
 				$events_orm->by( 'date_overlaps', tribe_beginning_of_day( $event_date ), tribe_end_of_day( $event_date ) );
 				$events_orm->by_args( $args );
 

--- a/src/Tribe/Template/List.php
+++ b/src/Tribe/Template/List.php
@@ -119,20 +119,17 @@ if ( ! class_exists( 'Tribe__Events__Template__List' ) ) {
 			$query = tribe_get_events( $args, true );
 
 			/*
-			 * The hash is used to detect whether the primary arguments in the query have changed (i.e. due to a filter bar request).
-			 * If they have, we want to go back to page 1.
+			 * The hash is used to detect whether the primary arguments in the query have changed (i.e. due to a filter
+			 * bar request); if they have, we want to go back to page 1.
 			 */
-			$hash = $query->query_vars;
-
-			unset(
-				$hash['paged'],
-				$hash['start_date'],
-				$hash['end_date'],
-				$hash['starts_before'],
-				$hash['search_orderby_title']
-			);
-
-			$hash_str           = md5( maybe_serialize( $hash ) );
+			$hash_str = $query->builder->hash( [
+				'exclude' => [
+					'paged',
+					'start_date',
+					'ends_before',
+					'ends_after',
+				],
+			], $query );
 
 			if ( ! empty( $_POST['hash'] ) && $hash_str !== $_POST['hash'] ) {
 				$tribe_paged   = 1;

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -197,7 +197,9 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 			$search_term = $wp_query->query_vars['s'];
 		} elseif ( ! empty( $_REQUEST['tribe-bar-search'] ) ) {
 			$search_term = $_REQUEST['tribe-bar-search'];
-		} elseif ( ! empty( $_REQUEST['tribe-bar-geoloc'] ) ) {
+		}
+
+		if ( ! empty( $_REQUEST['tribe-bar-geoloc'] ) ) {
 			$geographic_term = $_REQUEST['tribe-bar-geoloc'];
 		}
 

--- a/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
@@ -666,7 +666,11 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			'la_ten_event'  => [ '2019-04-10 14:30:00', 2 * HOUR_IN_SECONDS ],
 		], 'America/Los_Angeles' ) );
 
-		$nine_events = tribe_events()->use_utc( false )->where( 'on_date', '2019-04-09' )->collect();
+		$nine_events = tribe_events()
+			->use_utc( false )
+			->where( 'on_date', '2019-04-09' )
+			->order_by( 'event_date' )
+			->collect();
 		codecept_debug(
 			'4/9 events UTC dates: ' . implode( PHP_EOL, $nine_events->pluck_meta( '_EventStartDateUTC' ) )
 		);
@@ -682,7 +686,11 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			'America/Los_Angeles',
 		], $nine_events->pluck_meta( '_EventTimezone' ) );
 
-		$ten_events = tribe_events()->use_utc( false )->where( 'on_date', '2019-04-10' )->collect();
+		$ten_events = tribe_events()
+			->use_utc( false )
+			->where( 'on_date', '2019-04-10' )
+			->order_by( 'event_date' )
+			->collect();
 		codecept_debug(
 			'4/10 events UTC dates: ' . implode( PHP_EOL, $ten_events->pluck_meta( '_EventStartDateUTC' ) )
 		);
@@ -696,7 +704,11 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			'America/Los_Angeles',
 		], $ten_events->pluck_meta( '_EventTimezone' ) );
 
-		$ten_utc_events = tribe_events()->use_utc( true )->where( 'on_date', '2019-04-10' )->collect();
+		$ten_utc_events = tribe_events()
+			->use_utc( true )
+			->where( 'on_date', '2019-04-10' )
+			->order_by( 'event_date' )
+			->collect();
 		codecept_debug(
 			'4/10 events Europe/Paris dates: ' . implode( PHP_EOL, array_map( function ( $utc_date ) {
 				return ( new \DateTime( $utc_date, new \DateTimeZone( 'UTC' ) ) )
@@ -706,13 +718,13 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 		);
 
 		$this->assertEquals( [
-			'2019-04-10 11:00:00',
 			'2019-04-09 16:30:00',
+			'2019-04-10 11:00:00',
 			'2019-04-10 14:30:00',
 		], $ten_utc_events->pluck_meta( '_EventStartDate' ) );
 		$this->assertEquals( [
-			'Europe/Paris',
 			'America/Los_Angeles',
+			'Europe/Paris',
 			'America/Los_Angeles',
 		], $ten_utc_events->pluck_meta( '_EventTimezone' ) );
 	}


### PR DESCRIPTION
Tickets:

* https://central.tri.be/issues/123950
* https://central.tri.be/issues/125383

This PR fixes AJAX response pagination issues in the List view and Day view.
The first was caused by the List view relying on an hash generation, to detect whether query parameters were changed or not, that would generate the hash using incomplete information (see https://github.com/moderntribe/tribe-common/pull/980).
The second was caused by the Day view, in the `ajax_response` method, not defining the required order criteria.