### PR TITLE
Respect the correct post Status for List Widget

### DIFF
--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -130,18 +130,25 @@ class Tribe__Events__List_Widget extends WP_Widget {
 			return;
 		}
 
-		self::$posts = tribe_get_events(
-			apply_filters(
-				'tribe_events_list_widget_query_args', array(
-					'eventDisplay'   => 'list',
-					'posts_per_page' => self::$limit,
-					'is_tribe_widget' => true,
-					'tribe_render_context' => 'widget',
-					'featured' => empty( $instance['featured_events_only'] ) ? null : (bool) $instance['featured_events_only'],
-					'start_date' => Dates::build_date_object( 'now' ),
-				)
-			)
+		$post_status = [ 'publish' ];
+		if ( is_user_logged_in() ) {
+			$post_status[] = 'private';
+		}
+
+		$query_args = apply_filters(
+			'tribe_events_list_widget_query_args',
+			[
+				'eventDisplay' => 'list',
+				'posts_per_page' => self::$limit,
+				'is_tribe_widget' => true,
+				'post_status' => $post_status,
+				'tribe_render_context' => 'widget',
+				'featured' => empty( $instance['featured_events_only'] ) ? null : (bool) $instance['featured_events_only'],
+				'start_date' => Dates::build_date_object( 'now' ),
+			]
 		);
+
+		self::$posts = tribe_get_events( $query_args );
 
 		// If no posts, and the don't show if no posts checked, let's bail
 		if ( empty( self::$posts ) && $no_upcoming_events ) {
@@ -151,7 +158,7 @@ class Tribe__Events__List_Widget extends WP_Widget {
 		echo $before_widget;
 		do_action( 'tribe_events_before_list_widget' );
 
-		if ( $title ){
+		if ( $title ) {
 			do_action( 'tribe_events_list_widget_before_the_title' );
 			echo $before_title . $title . $after_title;
 			do_action( 'tribe_events_list_widget_after_the_title' );


### PR DESCRIPTION
_Ref:_ [C#125787](http://central.tri.be/issues/125787)
---
On this particular change here we are basically adding the `post_status` default, should we have this on the `tribe_get_events` level? for backwards compatible, it current is using `any` which causes problems.