### PR TITLE
fix(AJAX Pagination): Fix a number of issues with AJAX pagination in local timezone.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.8.3] TBD =
 
 * Fix - Include second param for the `the_title` for Events, Venue and Organizer Rest API endpoints, prevent warnings (Props to Alex) [123317]
+* Tweak - Add the `tribe_events_has_next_args` and `tribe_events_has_previous_args` filters to allow filtering the arguments that will be used to check if next/previous archive pages or events are available [123950]
 
 = [4.8.2] 2019-03-04 =
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1296,7 +1296,12 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$is_past = ! empty( $args['tribe_is_past'] ) || 'past' === $event_display;
 				if ( $is_past ) {
 					$args['order'] = 'DESC';
-					$pivot_date = tribe_get_request_var( 'tribe-bar-date', 'now' );
+					/*
+					 * If in the context of a "past" view let's try to use, as limit, the same
+					 * end date limit passed, if any.
+					 */
+					$now = isset( $args['ends_before'] ) ? $args['ends_before'] : 'now';
+					$pivot_date = tribe_get_request_var( 'tribe-bar-date', $now );
 					$date       = Tribe__Date_Utils::build_date_object( $pivot_date );
 					// Remove any existing date meta queries.
 					if ( isset( $args['meta_query'] ) ) {

--- a/src/Tribe/Service_Providers/ORM.php
+++ b/src/Tribe/Service_Providers/ORM.php
@@ -23,5 +23,42 @@ class Tribe__Events__Service_Providers__ORM extends tad_DI52_ServiceProvider {
 		$this->container->bind( 'events.event-repository', 'Tribe__Events__Repositories__Event' );
 		$this->container->bind( 'events.organizer-repository', 'Tribe__Events__Repositories__Organizer' );
 		$this->container->bind( 'events.venue-repository', 'Tribe__Events__Repositories__Venue' );
+
+		add_filter( 'tribe_events_has_next_args', [ $this, 'maybe_remove_date_meta_queries' ], 1, 2 );
+		add_filter( 'tribe_events_has_previous_args', [ $this, 'maybe_remove_date_meta_queries' ], 1, 2 );
+	}
+
+	/**
+	 * Handles next and previous links arguments when generated on a repository-managed query.
+	 *
+	 * The next and previous links are built by using the global query arguments and slightly altering them.
+	 * This approach, when done on the arguments provided by a repository generated query, might yield duplicated
+	 * meta queries that will, in turn, return wrong results.
+	 * The arguments will be already set in the arguments of the query.
+	 *
+	 * @since TBD
+	 *
+	 * @param array          $args An array of query arguments that will be used to check if there are next or previous
+	 *                             events.
+	 * @param \WP_Query|null $query The query the arguments were taken from.
+	 *
+	 * @return array A filtered array of arguments where the date-related contents of the meta query are removed to
+	 *               avoid duplicates.
+	 */
+	public function maybe_remove_date_meta_queries( array $args = [], WP_Query $query = null ) {
+		if ( empty( $args['meta_query'] ) || ! $query instanceof WP_Query ) {
+			return $args;
+		}
+
+		if ( empty( $query->builder ) || ! $query->builder instanceof Tribe__Repository__Interface ) {
+			return $args;
+		}
+
+		$args['meta_query'] = tribe_filter_meta_query(
+			$args['meta_query'],
+			array( 'key' => '/_Event(Start|End)Date(UTC)*/' )
+		);
+
+		return $args;
 	}
 }

--- a/src/Tribe/Service_Providers/ORM.php
+++ b/src/Tribe/Service_Providers/ORM.php
@@ -56,7 +56,7 @@ class Tribe__Events__Service_Providers__ORM extends tad_DI52_ServiceProvider {
 
 		$args['meta_query'] = tribe_filter_meta_query(
 			$args['meta_query'],
-			array( 'key' => '/_Event(Start|End)Date(UTC)*/' )
+			[ 'key' => '/_Event(Start|End)Date(UTC)*/' ]
 		);
 
 		return $args;

--- a/src/functions/template-tags/loop.php
+++ b/src/functions/template-tags/loop.php
@@ -289,6 +289,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$args['no_found_rows']  = true;
 			$args['posts_per_page'] = 1;
 
+			/**
+			 * Filters the arguments that will be used to check if there is a previous page/event.
+			 *
+			 * @since TBD
+			 *
+			 * @param array $args An array of arguments that will be used to check if a previous page/event
+			 *                    is present.
+			 * @param WP_Query $wp_query The query object, if any, the query arguments have been taken from.
+			 */
+			$args = apply_filters( 'tribe_events_has_previous_args', $args, $wp_query );
+
 			$past_event   = tribe_get_events( $args );
 			$has_previous = ( count( $past_event ) >= 1 );
 		}
@@ -333,6 +344,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$args['no_paging'] = true;
 			$args['no_found_rows'] = true;
 			$args['posts_per_page'] = 1;
+
+			/**
+			 * Filters the arguments that will be used to check if there is a next page/event.
+			 *
+			 * @since TBD
+			 *
+			 * @param array $args An array of arguments that will be used to check if a next page/event
+			 *                    is present.
+			 * @param WP_Query $wp_query The query object the query arguments have been taken from.
+			 */
+			$args = apply_filters( 'tribe_events_has_next_args', $args, $wp_query );
 
 			$next_event = tribe_get_events( $args );
 			$has_next   = ( count( $next_event ) >= 1 );


### PR DESCRIPTION
These fixes makes sure AJAX pagination keeps working correctly when using the "Use manual timezones
for each event" Timezone Setting. In the List view the issues were caused on a the "now" date not
being "recycled" when generating the hash, in the other views the issue was caused by duplicate
event date meta queries caused by the way the next and previous links queries work by "recycling"
the global query arguments.

re https://central.tri.be/issues/123950

screencast: https://github.com/moderntribe/the-events-calendar/pull/2461