### PR TITLE
Add sorting to the list widget

### DIFF
--- a/src/Tribe/List_Widget.php
+++ b/src/Tribe/List_Widget.php
@@ -145,6 +145,7 @@ class Tribe__Events__List_Widget extends WP_Widget {
 				'tribe_render_context' => 'widget',
 				'featured' => empty( $instance['featured_events_only'] ) ? null : (bool) $instance['featured_events_only'],
 				'start_date' => Dates::build_date_object( 'now' ),
+				'order' => 'ASC',
 			]
 		);
 


### PR DESCRIPTION
https://central.tri.be/issues/126131

As per https://support.theeventscalendar.com/agent/index.php#Conversation;id=75d0ce47, this should ensure that the results of the widget are sorted.