### PR TITLE
Remove featured image if the value is empty

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -156,8 +156,12 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				$data['EventCost'] = reset( $data['EventCost'] );
 			}
 
-			if ( isset( $data['FeaturedImage'] ) && ! empty( $data['FeaturedImage'] ) ) {
-				update_metadata( 'post', $event_id, '_thumbnail_id', $data['FeaturedImage'] );
+			if ( isset( $data['FeaturedImage'] ) ) {
+				if ( empty( $data['FeaturedImage'] ) ) {
+					delete_post_meta( $event_id, '_thumbnail_id' );
+				} else {
+					update_metadata( 'post', $event_id, '_thumbnail_id', $data['FeaturedImage'] );
+				}
 				unset( $data['FeaturedImage'] );
 			}
 

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -323,8 +323,12 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 		 */
 		do_action( 'tribe_events_organizer_save', $organizerId, $data, $organizer );
 
-		if ( isset( $data['FeaturedImage'] ) && ! empty( $data['FeaturedImage'] ) ) {
-			update_post_meta( $organizerId, '_thumbnail_id', $data['FeaturedImage'] );
+		if ( isset( $data['FeaturedImage'] ) ) {
+			if ( empty( $data['FeaturedImage'] ) ) {
+				delete_post_meta( $organizerId, '_thumbnail_id' );
+			} else {
+				update_post_meta( $organizerId, '_thumbnail_id', $data['FeaturedImage'] );
+			}
 			unset( $data['FeaturedImage'] );
 		}
 

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -337,8 +337,12 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 		unset( $data['ShowMapLink'] );
 		unset( $data['ShowMap'] );
 
-		if ( isset( $data['FeaturedImage'] ) && ! empty( $data['FeaturedImage'] ) ) {
-			update_post_meta( $venue_id, '_thumbnail_id', $data['FeaturedImage'] );
+		if ( isset( $data['FeaturedImage'] ) ) {
+			if ( empty( $data['FeaturedImage'] ) ) {
+				delete_post_meta( $venue_id, '_thumbnail_id' );
+			} else {
+				update_post_meta( $venue_id, '_thumbnail_id', $data['FeaturedImage'] );
+			}
 			unset( $data['FeaturedImage'] );
 		}
 


### PR DESCRIPTION
If the value of `FeaturedImage` on the request is present but is set to
null or empty value it means we want to remove the image or update the
resource with an empty image, as right now the check was in place to
review if the request has a valid image to update the image value.

Updates: 

- Applies the same logic for the featured image of an Event.

Ticket: https://central.tri.be/issues/120913