### PR TITLE
Be sure we have the `$event_id` for the new filter

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -91,6 +91,8 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 			return '';
 		}
 
+		$event_id = Tribe__Main::post_id_helper( $event );
+
 		$relevant_costs = array(
 			'min' => $this->get_cost_by_func( $costs, 'min' ),
 			'max' => $this->get_cost_by_func( $costs, 'max' ),
@@ -109,7 +111,6 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 			$cost = apply_filters( 'tribe_events_cost_unformatted', $cost, $event_id );
 
 			if ( $with_currency_symbol ) {
-				$event_id          = Tribe__Main::post_id_helper( $event );
 				$currency_symbol   = get_post_meta( $event_id, '_EventCurrencySymbol', true );
 				$currency_position = get_post_meta( $event_id, '_EventCurrencyPosition', true );
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/120193

Unrelated to the ticket, but discovered while doing QA.