### PR TITLE
fix(Main): fix autoloader related issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.9.2] TBD =
 
 * Fix - Fix event bar issue where it was required to pick the date in order to search events via keyword or location [126158]
+* Fix - Make back-compatibility handling more robust when dealing with classes non-existing in the older plugin versions [127173]
 
 = [4.9.1] 2019-05-02 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -373,12 +373,18 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				class_exists( 'Tribe__Tickets__Main' ) &&
 				! version_compare( Tribe__Tickets__Main::VERSION, $this->min_et_version, '>=' )
 			) {
-				add_action( 'admin_notices', array( $this, 'compatibility_notice' ) );
-				add_action( 'network_admin_notices', array( $this, 'compatibility_notice' ) );
-				add_filter( 'tribe_ecp_to_run_or_not_to_run', array( $this, 'disable_pro' ) );
-				add_action( 'tribe_plugins_loaded', array( $this, 'remove_exts' ), 0 );
+				add_action( 'admin_notices', [ $this, 'compatibility_notice' ] );
+				add_action( 'network_admin_notices', [ $this, 'compatibility_notice' ] );
+				add_filter( 'tribe_ecp_to_run_or_not_to_run', [ $this, 'disable_pro' ] );
+				add_action( 'tribe_plugins_loaded', [ $this, 'remove_exts' ], 0 );
+				/*
+				* After common was loaded by another source (e.g. Event Tickets) let's append this plugin source files
+				* to the ones the Autoloader will search. Since we're appending them the ones registered by the plugin
+				* "owning" common will be searched first.
+				*/
+				add_action( 'tribe_common_loaded', [ $this, 'register_plugin_autoload_paths' ] );
 
-				//Disable Older Versions of Community Events to Prevent Fatal Error
+				// Disable older versions of Community Events to prevent fatal Error.
 				remove_action( 'plugins_loaded', 'Tribe_CE_Load', 2 );
 
 				return;
@@ -428,22 +434,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * @return void
 		 */
 		protected function init_autoloading() {
-			$prefixes = array(
-				'Tribe__Events__' => $this->plugin_path . 'src/Tribe',
-				'ForceUTF8__' => $this->plugin_path . 'vendor/ForceUTF8',
-			);
+			$autoloader = $this->get_autoloader_instance();
+			$this->register_plugin_autoload_paths( $autoloader );
 
-			if ( ! class_exists( 'Tribe__Autoloader' ) ) {
-				require_once $GLOBALS['tribe-common-info']['dir'] . '/Autoloader.php';
-
-				$prefixes['Tribe__'] = $GLOBALS['tribe-common-info']['dir'];
-			}
-
-			$autoloader = Tribe__Autoloader::instance();
-			$autoloader->register_prefixes( $prefixes );
-
-			// deprecated classes are registered in a class to path fashion
-			foreach ( glob( $this->plugin_path . 'src/deprecated/*.php' ) as $file ) {
+			// Deprecated classes are registered in a class to path fashion.
+			foreach ( glob( $this->plugin_path . 'src/deprecated/*.php', GLOB_NOSORT ) as $file ) {
 				$class_name = str_replace( '.php', '', basename( $file ) );
 				$autoloader->register_class( $class_name, $file );
 			}
@@ -5673,5 +5668,38 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			return class_exists( 'Tribe__Events__Pro__Main' ) && defined( 'Tribe__Events__Pro__Main::VERSION' ) && version_compare( Tribe__Events__Pro__Main::VERSION, $version, '>=' );
 		}
 
+		/**
+		 * Returns the autoloader singleton instance to use in a context-aware manner.
+		 *
+		 * @since TBD
+		 *
+		 * @return \Tribe__Autoloader Teh singleton common Autoloader instance.
+		 */
+		public function get_autoloader_instance() {
+			if ( ! class_exists( 'Tribe__Autoloader' ) ) {
+				require_once $GLOBALS['tribe-common-info']['dir'] . '/Autoloader.php';
+
+				Tribe__Autoloader::instance()->register_prefixes( [
+					'Tribe__' => $GLOBALS['tribe-common-info']['dir'],
+				] );
+			}
+
+			return Tribe__Autoloader::instance();
+		}
+
+		/**
+		 * Registers the plugin autoload paths in the Common Autoloader instance.
+		 *
+		 * @since TBD
+		 */
+		public function register_plugin_autoload_paths( ) {
+			$prefixes = array(
+				'Tribe__Events__' => $this->plugin_path . 'src/Tribe',
+				'ForceUTF8__'     => $this->plugin_path . 'vendor/ForceUTF8',
+			);
+
+			$this->get_autoloader_instance()->register_prefixes( $prefixes );
+		}
 	}
+
 } // end if !class_exists Tribe__Events__Main


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/127173

This fix makes sure that, even when the plugin is not loaded due to a missing requirement or incompatibility, its source paths are registered, appending them, in the Autoloader.  
This makes it so that the paths registered by the plugin owning Common will be searced **first** using the "safe" version of the classes; if the classes are not found in the version of Common owned by the plugin loading it then the additional plugin paths will be searched avoiding fatals caused by some plugin functionalities relying on some classes that do not exist at all in the loaded (and probably older) version of Common.