### PR TITLE
Add `tribe-common-style` as dependency of the new views styles

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -33,7 +33,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 			$plugin,
 			'tribe-events-calendar-views-v2',
 			'views/tribe-events-v2.css',
-			[],
+			[ 'tribe-common-style' ],
 			'wp_enqueue_scripts',
 			[ 'priority' => 10 ]
 		);


### PR DESCRIPTION
Now that we are only registering `tribe-common-style` we should add it as a dependency here.

Related: https://github.com/moderntribe/tribe-common/pull/1012