### PR TITLE
Newsletter signup changes

### DIFF
--- a/dev/docker/ci-compose.yml
+++ b/dev/docker/ci-compose.yml
@@ -49,7 +49,7 @@ services:
 
   chromedriver:
     container_name: ci_chromedriver
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.141.59-oxygen
     depends_on:
       - db
       - wordpress

--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 = [4.9.3.1] 2019-06-07 =
 
 * Fix - Remove caching of rewrite base slugs which make third-party, Photo and Week work as expected [129035]
+* Tweak - Adjust newsletter signup submission destination [129034]
 
 = [4.9.3] 2019-06-06 =
 

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -216,6 +216,10 @@ class Tribe__Events__Rewrite extends Tribe__Rewrite {
 	 * @return object         Return Base Slugs with l10n variations
 	 */
 	public function get_bases( $method = 'regex' ) {
+		if ( ! empty( $this->bases ) ) {
+			return (object) $this->bases;
+		}
+
 		$tec = Tribe__Events__Main::instance();
 
 		$default_bases = [

--- a/src/admin-views/admin-update-message.php
+++ b/src/admin-views/admin-update-message.php
@@ -36,11 +36,17 @@
 		<br/>
 		<h2><?php esc_html_e( 'PSST... Want a Discount?', 'the-events-calendar' ); ?></h2>
 		<p><?php esc_html_e( 'We send out discounts to our core users via our newsletter.', 'the-events-calendar' ); ?></p>
-		<form action="https://moderntribe.createsend.com/t/r/s/athqh/" method="post">
-			<p><input id="listthkduyk" name="cm-ol-thkduyk" type="checkbox" /> <label for="listthkduyk">Developer News</label></p>
-			<p><input id="listathqh" name="cm-ol-athqh" checked type="checkbox" /> <label for="listathqh">News and Announcements</label></p>
-			<p><input id="fieldEmail" class="regular-text" name="cm-athqh-athqh" type="email" placeholder="Email" required /></p>
-			<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'the-events-calendar' ); ?></button>
+		<form action="https://support-api.tri.be/mailing-list/subscribe" method="post">
+			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="Email" required /></p>
+			<div>
+				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />
+				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'the-events-calendar' ); ?></label>
+			</div>
+			<p>
+				<input type="hidden" name="list" value="tec-newsletter" />
+				<input type="hidden" name="source" value="plugin:tec" />
+				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'the-events-calendar' ); ?></button>
+			</p>
 		</form>
 		<br/>
 		<hr/>

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -45,7 +45,7 @@
 		<h4 data-tribe-icon="dashicons-megaphone"><?php esc_html_e( "Don't Miss Out", 'the-events-calendar' ); ?></h4>
 		<p><?php esc_html_e( 'Get the latest on The Events Calendar, occasional discounts, and hilarious gifs delivered straight to your inbox.', 'the-events-calendar' ); ?></p>
 
-		<form action="http://support-api.tri.be/mailing-list/subscribe" method="post">
+		<form action="https://support-api.tri.be/mailing-list/subscribe" method="post">
 			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'the-events-calendar' ); ?>" required /></p>
 			<div>
 				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -45,7 +45,7 @@
 		<h4 data-tribe-icon="dashicons-megaphone"><?php esc_html_e( "Don't Miss Out", 'the-events-calendar' ); ?></h4>
 		<p><?php esc_html_e( 'Get the latest on The Events Calendar, occasional discounts, and hilarious gifs delivered straight to your inbox.', 'the-events-calendar' ); ?></p>
 
-		<form action="http://support-integration.local/mailing-list/subscribe" method="post">
+		<form action="http://support-api.tri.be/mailing-list/subscribe" method="post">
 			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'the-events-calendar' ); ?>" required /></p>
 			<div>
 				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -45,14 +45,15 @@
 		<h4 data-tribe-icon="dashicons-megaphone"><?php esc_html_e( "Don't Miss Out", 'the-events-calendar' ); ?></h4>
 		<p><?php esc_html_e( 'Get the latest on The Events Calendar, occasional discounts, and hilarious gifs delivered straight to your inbox.', 'the-events-calendar' ); ?></p>
 
-		<form action="https://moderntribe.createsend.com/t/r/s/athqh/" method="post">
-			<p><input id="fieldEmail" class="regular-text" name="cm-athqh-athqh" type="email" placeholder="<?php esc_attr_e( 'Email', 'the-events-calendar' ); ?>" required /></p>
+		<form action="http://support-integration.local/mailing-list/subscribe" method="post">
+			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'the-events-calendar' ); ?>" required /></p>
 			<div>
-				<input id="cm-privacy-consent" name="cm-privacy-consent" required type="checkbox" role="checkbox" aria-checked="false" />
+				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />
 				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'the-events-calendar' ); ?></label>
-		   		<input id="cm-privacy-consent-hidden" name="cm-privacy-consent-hidden" type="hidden" value="true" />
 			</div>
 			<p>
+				<input type="hidden" name="list" value="tec-newsletter" />
+				<input type="hidden" name="source" value="plugin:tec" />
 				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'the-events-calendar' ); ?></button>
 			</p>
 		</form>

--- a/tests/views_integration/Tribe/Events/Views/V2/ThemeCompatibilityTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ThemeCompatibilityTest.php
@@ -87,10 +87,10 @@ class ThemeCompatibilityTest extends \Codeception\TestCase\WPTestCase {
 		update_option( 'stylesheet', 'invalid-value-for-theme' );
 
 		add_filter(
-			'tribe_events_views_v2_theme_compatibility_registred',
-			function( $themes ) use ( $theme ) {
+			'tribe_events_views_v2_theme_compatibility_registered',
+			static function( $themes ) use ( $theme ) {
 				$themes[] = $theme;
-				return $theme;
+				return $themes;
 			}
 		);
 
@@ -102,16 +102,16 @@ class ThemeCompatibilityTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 */
-	public function should_need_compatibility_for_supported_themes_in_stylesheet_but_not_in_template() {
+	public function should_need_compatibility_for_supported_themes_in_stylesheet_and_template() {
 		$theme = 'valid-theme';
-		update_option( 'template', 'invalid-value-for-theme' );
+		update_option( 'template', $theme );
 		update_option( 'stylesheet', $theme );
 
 		add_filter(
-			'tribe_events_views_v2_theme_compatibility_registred',
-			function( $themes ) use ( $theme ) {
+			'tribe_events_views_v2_theme_compatibility_registered',
+			static function( $themes ) use ( $theme ) {
 				$themes[] = $theme;
-				return $theme;
+				return $themes;
 			}
 		);
 


### PR DESCRIPTION
Updates the newsletter signup forms (which are embedded in the welcome and update screens) so that they submit to the Support API platform. Functionality is essentially as it used to be, but the data will no longer be sent directly to createsend.com.

![replacement-newsletter-signups](https://user-images.githubusercontent.com/3594411/59081406-c7d1b680-88a2-11e9-813d-3b85aad15f76.gif)

:warning: Important! This change depends on [Support API PR 28](https://github.com/moderntribe/support-api.tri.be/pull/28), which introduces the endpoint we need for this to work. That change must be approved and be deployed before this work ships.

:ticket: [♯129034](https://central.tri.be/issues/129034)