### PR TITLE
fix(Tribe__Events__Rewrite.php): readd request cache in `get_bases`.

### DIFF
--- a/dev/docker/ci-compose.yml
+++ b/dev/docker/ci-compose.yml
@@ -49,7 +49,7 @@ services:
 
   chromedriver:
     container_name: ci_chromedriver
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.141.59-oxygen
     depends_on:
       - db
       - wordpress

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -216,6 +216,10 @@ class Tribe__Events__Rewrite extends Tribe__Rewrite {
 	 * @return object         Return Base Slugs with l10n variations
 	 */
 	public function get_bases( $method = 'regex' ) {
+		if ( ! empty( $this->bases ) ) {
+			return (object) $this->bases;
+		}
+
 		$tec = Tribe__Events__Main::instance();
 
 		$default_bases = [

--- a/tests/views_integration/Tribe/Events/Views/V2/ThemeCompatibilityTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ThemeCompatibilityTest.php
@@ -87,10 +87,10 @@ class ThemeCompatibilityTest extends \Codeception\TestCase\WPTestCase {
 		update_option( 'stylesheet', 'invalid-value-for-theme' );
 
 		add_filter(
-			'tribe_events_views_v2_theme_compatibility_registred',
-			function( $themes ) use ( $theme ) {
+			'tribe_events_views_v2_theme_compatibility_registered',
+			static function( $themes ) use ( $theme ) {
 				$themes[] = $theme;
-				return $theme;
+				return $themes;
 			}
 		);
 
@@ -102,16 +102,16 @@ class ThemeCompatibilityTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 */
-	public function should_need_compatibility_for_supported_themes_in_stylesheet_but_not_in_template() {
+	public function should_need_compatibility_for_supported_themes_in_stylesheet_and_template() {
 		$theme = 'valid-theme';
-		update_option( 'template', 'invalid-value-for-theme' );
+		update_option( 'template', $theme );
 		update_option( 'stylesheet', $theme );
 
 		add_filter(
-			'tribe_events_views_v2_theme_compatibility_registred',
-			function( $themes ) use ( $theme ) {
+			'tribe_events_views_v2_theme_compatibility_registered',
+			static function( $themes ) use ( $theme ) {
 				$themes[] = $theme;
-				return $theme;
+				return $themes;
 			}
 		);
 


### PR DESCRIPTION
In release/B19.07.1 we've removed the caching, on a per-request base with a simple array, done in
the `get_bases` method. Getting the bases is a costly operation (there are 3 filters applying on it)
that should be done as little as possible. Furthermore the caching was removed as consequence of an
eager call to the `setup` method in the `Tribe__Rewrite::instance` method that is removed in the
linked PR (https://github.com/moderntribe/tribe-common/pull/1043), thus this caching can be
reinstated.