### PR TITLE
Ensure common version is declared early to make decisions on loading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,6 +215,10 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
+= [4.9.3.2] TBD =
+
+* Fix - Prevent issue where older versions of the tribe-common libraries could be bootstrapped [129478]
+
 = [4.9.3.1] 2019-06-07 =
 
 * Fix - Remove caching of rewrite base slugs which make third-party, Photo and Week work as expected [129035]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -315,6 +315,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$this->pluginDir   = $this->plugin_dir = trailingslashit( basename( $this->plugin_path ) );
 			$this->pluginUrl   = $this->plugin_url = str_replace( basename( $this->plugin_file ), '', plugins_url( basename( $this->plugin_file ), $this->plugin_file ) );
 
+			// Set common lib information, needs to happen file load
+			$this->maybe_set_common_lib_info();
+
 			// let's initialize tec
 			add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 0 );
 
@@ -350,8 +353,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 * overwrite what should be loaded by the auto-loader
 			 */
 			if (
-				empty( $GLOBALS['tribe-common-info'] ) ||
-				version_compare( $GLOBALS['tribe-common-info']['version'], $common_version, '<' )
+				empty( $GLOBALS['tribe-common-info'] )
+				|| version_compare( $GLOBALS['tribe-common-info']['version'], $common_version, '<' )
 			) {
 				$GLOBALS['tribe-common-info'] = array(
 					'dir' => "{$this->plugin_path}common/src/Tribe",
@@ -395,9 +398,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				add_action( 'admin_notices', array( $this, 'notSupportedError' ) );
 				return;
 			}
-
-			// Set common lib information, needs to happen file load
-			$this->maybe_set_common_lib_info();
 
 			/**
 			 * Before any methods from this plugin are called, we initialize our Autoloading

--- a/tests/views_ui/_bootstrap.php
+++ b/tests/views_ui/_bootstrap.php
@@ -1,11 +1,1 @@
 <?php
-use Tribe\Events\Views\V2\Service_Provider;
-use Tribe\Events\Views\V2\View;
-
-// Let's  make sure Views v2 are activated if not.
-$options                          = get_option( \Tribe__Main::OPTIONNAME, [] );
-$options[ View::$option_enabled ] = true;
-
-update_option( \Tribe__Main::OPTIONNAME, $options );
-
-tribe_register_provider( Service_Provider::class );

--- a/tests/views_ui/_bootstrap.php
+++ b/tests/views_ui/_bootstrap.php
@@ -3,5 +3,9 @@ use Tribe\Events\Views\V2\Service_Provider;
 use Tribe\Events\Views\V2\View;
 
 // Let's  make sure Views v2 are activated if not.
-tribe_update_option( View::$option_enabled, true );
+$options                          = get_option( \Tribe__Main::OPTIONNAME, [] );
+$options[ View::$option_enabled ] = true;
+
+update_option( \Tribe__Main::OPTIONNAME, $options );
+
 tribe_register_provider( Service_Provider::class );


### PR DESCRIPTION
This moves the tribe-common registration back to `__construct()` so that it happens _before_ `plugins_loaded` priority `0` as per the Plugin Dependency spec.

See: https://central.tri.be/issues/129478
Related: https://github.com/moderntribe/event-tickets/pull/1285