### PR TITLE
Fix event cost values parsing.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - REST API Event responses now include the correct timezone even if the event has no timezone set or if using the site-wide timezone option [100159]
 * Fix - Resolved issue where deactivation feedback was not hooked properly [128341]
 * Fix - Added escaping to the event website URL target attribute [129565]
+* Fix - Resolved an issue where non-English decimal and thousands event cost separators could lead to wrong cost values in REST API responses [98061]
 
 = [4.9.3.1] 2019-06-07 =
 

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -511,13 +511,17 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 	 * @return array
 	 */
 	protected function get_cost_values( $event_id ) {
-		$cost_couples = tribe( 'tec.cost-utils' )->get_event_costs( $event_id );
+		/** @var Tribe__Cost_Utils $cost_utils */
+		$cost_utils   = tribe( 'tec.cost-utils' );
+		$cost_couples = $cost_utils->get_event_costs( $event_id );
 
-		global $wp_locale;
 		$cost_values = array();
 		foreach ( $cost_couples as $key => $value ) {
-			$value = str_replace( $wp_locale->number_format['decimal_point'], '.', '' . $value );
-			$value = str_replace( $wp_locale->number_format['thousands_sep'], '', $value );
+			list( $decimal_sep, $thousands_sep ) = $cost_utils->parse_separators( $value );
+
+			$value = str_replace( $thousands_sep, '', $value );
+			$value = str_replace( $decimal_sep, '.', '' . $value );
+
 			if ( is_numeric( $value ) ) {
 				$cost_values[] = $value;
 			} else {

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1044,10 +1044,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 					}
 
 					$date = new DateTime( $meta_value, $timezone );
+
+					$postarr['meta_input']["_Event{$check}Date"] = $date->format( $datetime_format );
+
 					$utc_date = $date->setTimezone( $utc );
 
 					// Set the localized and UTC date/time from local date/time and timezone; if provided override it.
-					$postarr[ 'meta_input' ][ "_Event{$check}Date" ] = $date->format( $datetime_format );
 					$postarr[ 'meta_input' ][ "_Event{$check}DateUTC" ] = $utc_date->format( $datetime_format );
 					$dates_changed[ $check ]                        = $utc_date;
 				}

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -5,6 +5,7 @@
  * @since 4.9
  */
 
+use Tribe__Date_Utils as Dates;
 use Tribe__Timezones as Timezones;
 
 /**
@@ -1045,7 +1046,8 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 					$date = new DateTime( $meta_value, $timezone );
 					$utc_date = $date->setTimezone( $utc );
 
-					// Set the UTC date/time from local date/time and timezone; if provided override it.
+					// Set the localized and UTC date/time from local date/time and timezone; if provided override it.
+					$postarr[ 'meta_input' ][ "_Event{$check}Date" ] = $date->format( $datetime_format );
 					$postarr[ 'meta_input' ][ "_Event{$check}DateUTC" ] = $utc_date->format( $datetime_format );
 					$dates_changed[ $check ]                        = $utc_date;
 				}
@@ -1075,6 +1077,15 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			// Sanity check, an event should end after its start.
 			$start = $this->get_from_postarr_or_meta( $postarr, '_EventStartDate', $post_id );
 			$end   = $this->get_from_postarr_or_meta( $postarr, '_EventEndDate', $post_id );
+			$duration   = $this->get_from_postarr_or_meta( $postarr, '_EventDuration', $post_id );
+
+			if ( isset( $start, $duration ) && empty( $end ) ) {
+				// Let's work out the End from Start and Duration if not set.
+				$duration_interval = new DateInterval( 'PT' . (int) $duration . 'S' );
+				$end      = Dates::build_date_object( $start, $timezone )
+				                 ->add( $duration_interval )
+				                 ->format( $datetime_format );
+			}
 
 			$dates_make_sense = true;
 

--- a/tests/_function-mocker-bootstrap.php
+++ b/tests/_function-mocker-bootstrap.php
@@ -54,7 +54,7 @@ $wp_php_files   = array_map( static function ( SplFileInfo $f ) {
 $wp_core_files  = array_merge( $wp_php_files, [ $wp_root . '/wp-admin', $wp_root . '/wp-includes' ] );
 
 tad\FunctionMocker\FunctionMocker::init( [
-	'redefinable-internals' => [ 'date' ],
+	'redefinable-internals' => [ 'date', 'time' ],
 	'cache-path'            => $cache_path,
 	// Include WP Core files and the plugin src files.
 	'include'               => array_merge( $wp_core_files, [ codecept_root_dir( 'src' ) ] ),

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month/Calendar_BodyTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month/Calendar_BodyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Events\Views\V2\Partials\Month;
 
+use tad\FunctionMocker\FunctionMocker as Test;
 use Tribe\Events\Views\V2\Partials\TestCase;
 
 class Calendar_BodyTest extends TestCase
@@ -13,6 +14,19 @@ class Calendar_BodyTest extends TestCase
 	 * Test static render
 	 */
 	public function test_static_render() {
+		// Mock the `time` function to return 2019-6-21 as the current day.
+		Test::replace( 'time', function () {
+			return ( new \DateTime( '2019-06-21 12:00:00', new \DateTimeZone( 'UTC' ) ) )
+				->getTimestamp();
+		} );
 		$this->assertMatchesSnapshot( $this->get_partial_html() );
+	}
+
+	public function setUp() {
+		parent::setUp();
+		// Start Function Mocker.
+		Test::setUp();
+		// Always return the same value when creating nonces.
+		Test::replace( 'wp_create_nonce', '2ab7cc6b39' );
 	}
 }


### PR DESCRIPTION
Ticket: 
* https://central.tri.be/issues/98061
* https://central.tri.be/issues/129780

An event cost string might be generated, or stored, in a different locale from the one set for the current request. This would lead to wrong parsing of cost values due to decimal and separator misalignments. This fix leverages the work done in https://github.com/moderntribe/tribe-common/pull/1068 to try and read the original decimal and current separators and use them to convert to the english decimal point format.

Furthermore this PR fixes an issue with event repository I've found while working on it.