### PR TITLE
Views V2: Single Event template loading behavior fixed

### DIFF
--- a/src/Tribe/Views/V2/Service_Provider.php
+++ b/src/Tribe/Views/V2/Service_Provider.php
@@ -88,7 +88,8 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 	protected function register_v1_compat() {
 		$v1_compat = new V1_Compat( $this->container );
 		$v1_compat->register();
+
 		$this->container->singleton( V1_Compat::class, $v1_compat );
-		$this->container->singleton( 'views-v2.v1-compat', $v1_compat );
+		$this->container->singleton( 'events.views.v1-compat', $v1_compat );
 	}
 }

--- a/src/Tribe/Views/V2/Template/Page.php
+++ b/src/Tribe/Views/V2/Template/Page.php
@@ -121,7 +121,7 @@ class Page {
 	 * @return void
 	 */
 	public function hijack_the_post() {
-		remove_filter( 'the_content', [ $this, 'hijack_the_post' ], 25 );
+		remove_filter( 'the_post', [ $this, 'hijack_the_post' ], 25 );
 
 		$GLOBALS['post'] = $this->get_mocked_page();
 	}
@@ -250,11 +250,6 @@ class Page {
 
 		// We dont want the main Query
 		if ( ! $query->is_main_query() ) {
-			$should_hijack = false;
-		}
-
-		// Bail when loading in Single Event Page
-		if ( $query->is_single() ) {
 			$should_hijack = false;
 		}
 

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -71,7 +71,7 @@ class Template_Bootstrap {
 	 *
 	 * @return string
 	 */
-	protected function get_legacy_single_event_html() {
+	protected function get_v1_single_event_html() {
 		ob_start();
 		tribe_get_view( 'single-event' );
 		$html = ob_get_clean();
@@ -98,7 +98,7 @@ class Template_Bootstrap {
 			&& ! tribe_is_showing_all()
 			&& ! \Tribe__Templates::is_embed()
 		) {
-			$html = $this->get_legacy_single_event_html();
+			$html = $this->get_v1_single_event_html();
 		} elseif ( isset( $query->query_vars['tribe_events_views_kitchen_sink'] ) ) {
 			$context = [
 				'query' => $query,

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -65,6 +65,21 @@ class Template_Bootstrap {
 	}
 
 	/**
+	 * Fetches the HTML for the Single Event page using the legacy view system
+	 *
+	 * @since  TBD
+	 *
+	 * @return string
+	 */
+	protected function get_legacy_single_event_html() {
+		ob_start();
+		tribe_get_view( 'single-event' );
+		$html = ob_get_clean();
+
+		return $html;
+	}
+
+	/**
 	 * Gets the View HTML
 	 *
 	 * @todo Stop handling kitchen sink template here.
@@ -74,9 +89,17 @@ class Template_Bootstrap {
 	 * @return string
 	 */
 	public function get_view_html() {
-		$query = tribe_get_global_query_object();
+		$query     = tribe_get_global_query_object();
+		$context   = tribe_context();
+		$view_slug = $context->get( 'view' );
 
-		if ( isset( $query->query_vars['tribe_events_views_kitchen_sink'] ) ) {
+		if (
+			'single-event' === $view_slug
+			&& ! tribe_is_showing_all()
+			&& ! \Tribe__Templates::is_embed()
+		) {
+			$html = $this->get_legacy_single_event_html();
+		} elseif ( isset( $query->query_vars['tribe_events_views_kitchen_sink'] ) ) {
 			$context = [
 				'query' => $query,
 			];
@@ -91,9 +114,7 @@ class Template_Bootstrap {
 
 			$html = tribe( Kitchen_Sink::class )->template( $template, $context, false );
 		} else {
-			$context   = tribe_context();
-			$view_slug = $context->get( 'view' );
-			$html      = View::make( $view_slug, $context )->get_html();
+			$html = View::make( $view_slug, $context )->get_html();
 		}
 
 		return $html;
@@ -114,11 +135,6 @@ class Template_Bootstrap {
 		}
 
 		if ( ! $query instanceof WP_Query ) {
-			return false;
-		}
-
-		// Dont load on Single event pages
-		if ( 'single-event' === $query->get( 'eventDisplay' ) ) {
 			return false;
 		}
 

--- a/src/Tribe/Views/V2/V1_Compat.php
+++ b/src/Tribe/Views/V2/V1_Compat.php
@@ -34,8 +34,7 @@ class V1_Compat extends \tad_DI52_ServiceProvider {
 	/**
 	 * Registers the provider and sets it up to update, move or remove Views v1 filters.
 	 */
-	public function register()
-	{
+	public function register() {
 		/*
 		 * Depending on the context of the request, this might fire before or after Common did bootstrap.
 		 * Let's handle both cases checking whether Common has already loaded or not.
@@ -82,7 +81,7 @@ class V1_Compat extends \tad_DI52_ServiceProvider {
 			'tribe_get_single_option' => [
 				[
 					'callback' => [ $backcompat, 'filter_multiday_cutoff' ],
-					'priority' => 10
+					'priority' => 10,
 				],
 				[ 'callback' => [ $backcompat, 'filter_enabled_views' ], 'priority' => 10 ],
 				[ 'callback' => [ $backcompat, 'filter_default_view' ], 'priority' => 10 ],


### PR DESCRIPTION
Our single event pages were broken due to View V2 deactivation of the V1 actions without correctly pulling the old single views to be included. 