### PR TITLE
Rolling back timezone fix from 100159

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,7 +229,6 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 * Fix - Save of event meta data when Classic editor plugin and gutenberg blocks for events are enabled [121267]
 * Fix - Moved The Events Calendar specific code from common Context class into The Events Calendar [129241]
 * Fix - Fixed issue where multiday events were not returning correct end date in block editor [128033]
-* Fix - REST API Event responses now include the correct timezone even if the event has no timezone set or if using the site-wide timezone option [100159]
 * Fix - Resolved issue where deactivation feedback was not hooked properly [128341]
 * Fix - Added escaping to the event website URL target attribute [129565]
 * Fix - Fix Timezone definitions for `*.ics` file on events [89999]

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -94,16 +94,6 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 		$venue     = $this->get_venue_data( $event_id, $context );
 		$organizer = $this->get_organizer_data( $event_id, $context );
 
-		if ( Tribe__Timezones::is_mode( Tribe__Timezones::SITE_TIMEZONE ) ) {
-			// Use site timezone
-			$timezone      = Tribe__Timezones::wp_timezone_string();
-			$timezone_abbr = Tribe__Timezones::abbr( date_i18n( 'Y-m-d H:i:s' ), $timezone );
-		} else {
-			// Use event timezone
-			$timezone      = Tribe__Events__Timezones::get_event_timezone_string( $event_id );
-			$timezone_abbr = Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
-		}
-
 		$data = array(
 			'id'                     => $event_id,
 			'global_id'              => false,
@@ -131,8 +121,8 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 			'utc_start_date_details' => $this->get_date_details( $meta['_EventStartDateUTC'] ),
 			'utc_end_date'           => $meta['_EventEndDateUTC'],
 			'utc_end_date_details'   => $this->get_date_details( $meta['_EventEndDateUTC'] ),
-			'timezone'               => $timezone,
-			'timezone_abbr'          => $timezone_abbr,
+			'timezone'               => isset( $meta['_EventTimezone'] ) ? $meta['_EventTimezone'] : '',
+			'timezone_abbr'          => isset( $meta['_EventTimezoneAbbr'] ) ? $meta['_EventTimezoneAbbr'] : '',
 			'cost'                   => tribe_get_cost( $event_id, true ),
 			'cost_details'           => array(
 				'currency_symbol'   => isset( $meta['_EventCurrencySymbol'] ) ? $meta['_EventCurrencySymbol'] : '',


### PR DESCRIPTION
The behavior in the REST endpoint resulted in undesirable data.

This reverts #1837

See: https://central.tri.be/issues/100159