### PR TITLE
fix(composer): Change case of package name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require-dev": {
     "lucatume/wp-browser": "^2.2.4",
     "xamin/handlebars.php": "^0.10.3",
-    "mikey179/vfsStream": "^1.6",
+    "mikey179/vfsstream": "^1.6",
     "spatie/phpunit-snapshot-assertions": "^1.2",
     "lucatume/wp-snaphot-assertions": "1.0.0",
     "moderntribe/tribe-common-styles": "dev-master",


### PR DESCRIPTION
Change the `mikey179/vfsStream` package to all lowercase to squash warnings about composer 2.0.
<img width="1293" alt="Screen Shot 2019-07-01 at 7 34 21 PM" src="https://user-images.githubusercontent.com/929375/60472543-410cc100-9c37-11e9-9637-7edddffdee07.png">

See also: https://github.com/moderntribe/events-pro/pull/1168