### PR TITLE
Fixed database storage of pipe separated additional fields

### DIFF
--- a/src/Tribe/Importer/File_Importer_Events.php
+++ b/src/Tribe/Importer/File_Importer_Events.php
@@ -270,7 +270,12 @@ class Tribe__Events__Importer__File_Importer_Events extends Tribe__Events__Impor
 
 		if ( ! empty ( $additional_fields ) ) {
 			foreach ( $additional_fields as $key => $csv_column ) {
-				$event[ $key ] = $this->get_value_by_key( $record, $key );
+				$value = $this->get_value_by_key( $record, $key );
+				if ( strpos( $value, '|' ) > -1 ) {
+					$event[ $key ] = explode( '|', $value );
+				} else {
+					$event[ $key ] = $value;
+				}
 			}
 		}
 


### PR DESCRIPTION
When importing pipe separated additional fields via CSV, they were being stored as a single row pipe separated string in the meta data table instead of multiple searchable rows.