### PR TITLE
Fix (Linked_Posts/Base.php) remove abstract static

### DIFF
--- a/src/Tribe/Linked_Posts/Base.php
+++ b/src/Tribe/Linked_Posts/Base.php
@@ -353,7 +353,10 @@ abstract class Tribe__Events__Linked_Posts__Base {
 	 *
 	 * @param int $event The event post ID or object.
 	 *
-	 * @return callable A closure that will fetch an Event linked posts..
+	 * @return callable A closure that will fetch an Event linked posts; the default implementation will return a
+	 *                  closure returning an empty array.
 	 */
-	abstract public static function get_fetch_callback( $event );
+	public static function get_fetch_callback( $event ){
+		return '__return_empty_array';
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/132567#note-7

Remove the use of `abstract static get_fetch_callback` from the code.
With older, strict, PHP versions it will raise a warning.