### PR TITLE
tests(_bootstrap.php) regen snapshots on Codeception --debug flag

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -4,3 +4,14 @@ Codeception\Util\Autoload::addNamespace( 'Tribe\Tests', dirname(__DIR__) . '/com
 Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test', __DIR__ . '/_support' );
 Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test', __DIR__ . '/_support/classes' );
 Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test\Acceptance\Steps', __DIR__ . '/acceptance/_steps' );
+
+/**
+ * Codeception will regenerate snapshots on `--debug`, while the `spatie/snapshot-assertions`
+ * library will do the same on `--update-snapshots`.
+ * Since Codeception has strict check on the CLI arguments appending `--update-snapshots` to the
+ * `vendor/bin/codecept run` command will throw an error.
+ * We handle that intention here.
+ */
+if ( in_array( '--debug', $_SERVER['argv'], true ) ) {
+	$_SERVER['argv'][] = '--update-snapshots';
+}


### PR DESCRIPTION
The `spatie/phpunit-snapshot-assertions` will automatically regenerate snapshots on `--update-snaspshots` flag.
Since Codeception has strict check on che CLI arguments that flag will be dropped.
This fix bridges the gap.