### PR TITLE
Scenario date marker

### DIFF
--- a/tests/features/views/list-view/view-layout.feature
+++ b/tests/features/views/list-view/view-layout.feature
@@ -47,3 +47,26 @@ Scenario: Manual event excerpt in List View
     And the event has the following event excerpt as added by the admin: "This event is gonna be super awesome! Come build your own life-size gingerbread house make a snow angel in a pile of donuts. Get your ticket today and join us for the best most sugary event in the WHOLE WORLD."
     When I view the List View for upcoming events
     Then I should see the next upcoming event displayed with the following excerpt: "This event is gonna be super awesome! Come build your own life-size gingerbread house make a snow angel in a pile of donuts. Get your ticket today and join us for the best most sugary event in the WHOLE WORLD."
+
+Scenario: Date marker number on current & upcoming multi-day events
+    Given there is an all-day multi-day event called "Coriander" that runs from the 1st of next month to the 5th of next month
+    When I view the List View for <date>
+    Then the date marker for "Coriander" should be the number <marker>
+
+    Examples:
+        | date                      | marker |
+        | today                     | 1      |
+        | the 1st day of next month | 1      |
+        | the 3rd day of next month | 3      |
+        | the 5th day of next month | 5      |
+
+Scenario: Date marker on past multi-day events
+    Given there is an all-day multi-day event called "Saffron" that ran from the 1st of last month to the 5th of last month
+    When I view the List View for <date>
+    Then the date marker for "Saffron" should be the number <marker>
+
+    Examples:
+        | date                      | marker |
+        | the 1st day of last month | 1      |
+        | the 3rd day of last month | 3      |
+        | the 5th day of last month | 5      |


### PR DESCRIPTION
I wrote scenarios for what number should show in the visual Date Marker on V2 List View for multi-day events (since we can only show 1 number in the Date Marker, this is trickier on multi-day events). These are for List View but we'll use the same pattern for Photo and Map Views.