### PR TITLE
Fix the use of `get_the_content` with a post ID

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2690,7 +2690,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Fetch the
 			$location = trim( $this->fullAddressString( $post->ID ) );
 
-			$event_details = apply_filters( 'the_content', get_the_content( $post->ID ) );
+			$event_details = apply_filters( 'the_content', get_the_content( null, false, $post->ID ) );
 
 			// Hack: Add space after paragraph
 			// Normally Google Cal understands the newline character %0a


### PR DESCRIPTION
Referencing the [get_the_content](https://developer.wordpress.org/reference/functions/get_the_content/) docs, the post ID needs to be the third parameter. I've added in the default values for the first two parameters for this function.