### PR TITLE
fix(Models/Post_Types/Event.php) cache slug

### DIFF
--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -169,7 +169,7 @@ class Event extends Base {
 	 * {@inheritDoc}
 	 */
 	protected function get_cache_slug() {
-		return 'events_';
+		return 'events';
 	}
 
 }


### PR DESCRIPTION
Ticket: n/a

Based on: https://github.com/moderntribe/tribe-common/pull/1149

This PR removes the trailing `_` from the Event model cache slug to follow the update in the `common` PR.