### PR TITLE
VR - Allow filtering a View URL arguments

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -522,6 +522,20 @@ class View implements View_Interface {
 			'tribe-bar-search' => $this->context->get( 'keyword', '' ),
 		];
 
+
+		//@todo lucatume check geoloc!
+
+		/**
+		 * Filters the query arguments that will be used to build a View URL.
+		 *
+		 * @since TBD
+		 *
+		 * @param array          $query_args An array of query args that will be used to build the URL for the View.
+		 * @param View_Interface $this       This View instance.
+		 * @param bool           $canonical  Whether the URL should be the canonical one or not.
+		 */
+		$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+
 		if ( ! empty( $query_args['tribe-bar-date'] ) ) {
 			// If the Events Bar date is the same as today's date, then drop it.
 			$today          = $this->context->get( 'today', 'today' );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/134293 

To support Filterbar we need not only to read the URL arguments, but to add them too.
The filter opens the door to that.