### PR TITLE
Adding a GitHub Action to perform automated code reviews with phpcs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Code Review
+on:
+  pull_request:
+    paths-ignore:
+      - 'lang/**'
+      - '**.txt'
+      - '**.md'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: moderntribe/action-tribe-phpcs@master
+        with:
+          github-bot-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
This will add our first GitHub action to TEC that allows for consistent code reviews that don't depend on Jenkins.

![Screen Shot 2019-10-07 at 2 02 56 PM](https://user-images.githubusercontent.com/430385/66397368-a9430f80-e9a9-11e9-8d0b-fb45cad58e8d.png)

_Note:_ This code lives inside of the `.github/workflows` directory which doesn't appear in the whitelist, so there isn't a worry about accidentally packaging it.