### PR TITLE
the WP function get_post_statuses takes no parguments. This PR remove…

### DIFF
--- a/src/admin-views/aggregator/settings.php
+++ b/src/admin-views/aggregator/settings.php
@@ -5,7 +5,7 @@
  */
 $internal = array();
 $use_global_settings_phrase = esc_html__( 'Use global import settings', 'the-events-calendar' );
-$post_statuses = get_post_statuses( array() );
+$post_statuses = get_post_statuses();
 $category_dropdown = wp_dropdown_categories( [
 	'echo'       => false,
 	'hide_empty' => false,


### PR DESCRIPTION
…s an empty array arg from the EA settings admin view.

I've no idea what branch to open this PR against...it's a super tiny thing...ping me if I need to open against a different branch or whatevs...