### PR TITLE
fix(src) avoid query when fetching linked posts

### DIFF
--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -639,21 +639,14 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 			return $callback;
 		}
 
-		// This query is bound by `posts_per_page` and it's fine and reasonable; do not make it unbound.
 		return static function () use ( $event ) {
-			$organizer_ids = (array) get_post_meta( $event, '_EventOrganizerID' );
-			if ( empty( $organizer_ids ) ) {
-				return [];
-			}
-			$organizer_ids = (array) tribe_organizers()
-				->by( 'event', $event )
-				->order_by( 'post__in', $organizer_ids )
-				->get_ids();
+			$organizer_ids = array_map( 'absint', (array) get_post_meta( $event, '_EventOrganizerID' ) );
+
 			$organizers    = ! empty( $organizer_ids )
 				? array_map( 'tribe_get_organizer', $organizer_ids )
 				: [];
 
-			return $organizers;
+			return array_filter( $organizers );
 		};
 	}
 

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -697,16 +697,14 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 			return $callback;
 		}
 
-		// This query is bound by `posts_per_page` and it's fine and reasonable; do not make it unbound.
 		return static function () use ( $event ) {
-			$venue_ids = tribe_venues()->by( 'event', $event )->get_ids();
+			$venue_ids = array_map( 'absint', (array) get_post_meta( $event, '_EventVenueID' ) );
+
 			$venues    = ! empty( $venue_ids )
 				? array_map( 'tribe_get_venue_object', $venue_ids )
 				: [];
 
-			$venues = array_filter( $venues );
-
-			return $venues;
+			return array_filter( $venues );
 		};
 	}
 }


### PR DESCRIPTION
Ticket: n/a

This PR fixes an issue found out while running tests by:
1. removing queries we do not need when fetching Event linked posts (Organizers and Venues) to rely, instead, on the already set meta values
2. by fixing `1` this makes the snapshot tests, that rely on cache alteration, to work correctly again.