### PR TITLE
Fixed PHP 7 compatibility issue: Use of func_get_args() in Tribe__Eve…

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -543,8 +543,8 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 		 **/
 		public static function getTemplateHierarchy( $template, $args = array() ) {
 			if ( ! is_array( $args ) ) {
+				$passed        = array( $template, $args );
 				$args          = array();
-				$passed        = func_get_args();
 				$backwards_map = array( 'namespace', 'plugin_path' );
 				$count = count( $passed );
 


### PR DESCRIPTION
Fixed PHP 7 compatibility issue: Use of func_get_args() in Tribe__Events__Templates::getTemplateHierarchy

Original Error:
> Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as
>                 passed to a parameter, but will instead provide the current value. The parameter "$args" was changed on line
>                 546. (PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed)