### PR TITLE
Proposal to show past events in WPML Translation Management dashboard.

### DIFF
--- a/src/Tribe/Integrations/WPML/Utils.php
+++ b/src/Tribe/Integrations/WPML/Utils.php
@@ -133,4 +133,16 @@ class Tribe__Events__Integrations__WPML__Utils {
 
 		return $locales;
 	}
+
+	/**
+	 * Remove filters added in Tribe__Events__Query
+	 * for WPML's Translation Management Dashboard to be able to show past events.
+	 */
+	public static function remove_tribe_events_query_filters( $args ) {
+		remove_action( 'pre_get_posts', array( 'Tribe__Events__Query', 'pre_get_posts' ), 50 );
+		remove_action( 'parse_query', array( 'Tribe__Events__Query', 'parse_query' ), 50 );
+
+		return $args;
+	}
+
 }

--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -51,6 +51,8 @@ class Tribe__Events__Integrations__WPML__WPML {
 	}
 
 	protected function hook_filters() {
+		add_filter( 'wpml_tm_dashboard_post_query_args', array( 'Tribe__Events__Integrations__WPML__Utils', 'remove_tribe_events_query_filters' ) );
+
 		$filters = Tribe__Events__Integrations__WPML__Filters::instance();
 		add_filter( 'tribe_events_rewrite_i18n_slugs_raw', array( $filters, 'filter_tribe_events_rewrite_i18n_slugs_raw' ), 10, 3 );
 


### PR DESCRIPTION
Hi, this is David from the WPML compatibility team.

We recently received a support request to display past events in the TM dashboard:
https://wpml.org/forums/topic/translation-management-the-events-calendar-past-events/
Would it be possible to add something along these lines in WPML integration code?