### PR TITLE
Fix event REST endpoint which prevented events from appearing

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -622,7 +622,9 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		// Event presentation data
 		$postarr['EventShowMap']          = tribe_is_truthy( $request['show_map'] );
 		$postarr['EventShowMapLink']      = tribe_is_truthy( $request['show_map_link'] );
-		$postarr['EventHideFromUpcoming'] = tribe_is_truthy( $request['hide_from_listings'] ) ? 'yes' : false;
+		if ( tribe_is_truthy( $request['hide_from_listings'] ) ) {
+			$postarr['EventHideFromUpcoming'] = 'yes';
+		}
 		$postarr['EventShowInCalendar']   = tribe_is_truthy( $request['sticky'] );
 		$postarr['feature_event']         = tribe_is_truthy( $request['featured'] );
 


### PR DESCRIPTION
As I described [here](https://wordpress.org/support/topic/events-created-via-rest-api-do-not-show-up-in-list-of-upcoming-events/#post-12045755), there is a difference in handling events 'EventHideFromUpcoming' field between the REST API and the front end. While the latter only checks for its existence, the former works with 'yes' and an empty string. This results in events being created with 'EventHideFromUpcoming' set to an empty string by the REST API which is the reason why it doesn't appear on the web page.

Now, it only sets 'EventHideFromUpcoming' if the value is meant to represent 'yes'.