### PR TITLE
Revert "fix(Views V2) correctly suppress v1 query filters"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,10 +215,6 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
-= [TBD] TBD =
-
-* Tweak - added the `tribe_events_suppress_query_filters` filter to allow suppressing `Tribe__Events__Query` filters [134827]
-
 = [4.9.10] 2019-10-16 =
 
 * Tweak - added the `tribe_sanitize_deep` function to sanitize and validate input values [134427]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -24,18 +24,6 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * Initialize The Events Calendar query filters and post processing.
 		 */
 		public static function init() {
-			/**
-			 * A toggle filter to completely suppress all query filters for the whole request.
-			 *
-			 * @since TBD
-			 *
-			 * @param bool $suppress_filters Whether to completely suppress all query filters for the whole request.
-			 */
-			$suppress_filters = apply_filters( 'tribe_events_suppress_query_filters', false );
-
-			if ( $suppress_filters ) {
-				return;
-			}
 
 			// if tribe event query add filters
 			add_action( 'parse_query', array( __CLASS__, 'parse_query' ), 50 );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -66,7 +66,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	protected function add_filters() {
 		// Let's make sure to suppress query filters from the main query.
-		add_filter( 'tribe_events_suppress_query_filters', '__return_true' );
+		add_filter( 'tribe_suppress_query_filters', '__return_true' );
 		add_filter( 'template_include', [ $this, 'filter_template_include' ], 50 );
 		add_filter( 'posts_pre_query', [ $this, 'filter_posts_pre_query' ], 20, 2 );
 		add_filter( 'body_class', [ $this, 'filter_body_class' ] );


### PR DESCRIPTION
Reverts moderntribe/the-events-calendar#2782
---
We need to find a better method of turning this off since this one breaks a lot of other integrations with Single view.

https://central.tri.be/issues/136498