### PR TITLE
VR - more refined suppression of v1 query filters.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -215,6 +215,10 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - added the `tribe_events_suppress_query_filters` filter to allow suppressing `Tribe__Events__Query` filters [134827]
+
 = [4.9.10] 2019-10-16 =
 
 * Tweak - added the `tribe_sanitize_deep` function to sanitize and validate input values [134427]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -24,6 +24,18 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 		 * Initialize The Events Calendar query filters and post processing.
 		 */
 		public static function init() {
+			/**
+			 * A toggle filter to completely suppress all query filters for the whole request.
+			 *
+			 * @since TBD
+			 *
+			 * @param bool $suppress_filters Whether to completely suppress all query filters for the whole request.
+			 */
+			$suppress_filters = apply_filters( 'tribe_events_suppress_query_filters', false );
+
+			if ( $suppress_filters ) {
+				return;
+			}
 
 			// if tribe event query add filters
 			add_action( 'parse_query', array( __CLASS__, 'parse_query' ), 50 );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -304,6 +304,5 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		}
 
 		return $html . '<p class="hide-if-no-js howto">' . __( 'We recommend a 16:9 aspect ratio for featured images.', 'the-events-calendar' ) . '</p>';
-
 	}
 }

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -20,8 +20,6 @@ namespace Tribe\Events\Views\V2;
 use Tribe\Events\Views\V2\Query\Abstract_Query_Controller;
 use Tribe\Events\Views\V2\Query\Event_Query_Controller;
 use Tribe\Events\Views\V2\Template\Title;
-use Tribe\Events\Views\V2\Template\Excerpt;
-use Tribe\Events\Views\V2\Assets;
 use Tribe__Events__Main as TEC;
 use Tribe__Rewrite as Rewrite;
 
@@ -65,7 +63,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @since 4.9.2
 	 */
 	protected function add_filters() {
-		// Let's make sure to suppress query filters from the main query.
+		add_action( 'tribe_events_parse_query', [ $this, 'parse_query' ] );
 		add_filter( 'template_include', [ $this, 'filter_template_include' ], 50 );
 		add_filter( 'posts_pre_query', [ $this, 'filter_posts_pre_query' ], 20, 2 );
 		add_filter( 'body_class', [ $this, 'filter_body_class' ] );
@@ -304,5 +302,21 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		}
 
 		return $html . '<p class="hide-if-no-js howto">' . __( 'We recommend a 16:9 aspect ratio for featured images.', 'the-events-calendar' ) . '</p>';
+	}
+
+	/**
+	 * Suppress v1 query filters on a per-query basis, if required.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Query $query The current WordPress query object.
+	 */
+	public function parse_query( $query ) {
+		if ( ! $query instanceof \WP_Query ) {
+			return;
+		}
+
+		$event_query = $this->container->make( Event_Query_Controller::class );
+		$event_query->parse_query( $query );
 	}
 }

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -66,7 +66,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	protected function add_filters() {
 		// Let's make sure to suppress query filters from the main query.
-		add_filter( 'tribe_suppress_query_filters', '__return_true' );
+		add_filter( 'tribe_events_suppress_query_filters', '__return_true' );
 		add_filter( 'template_include', [ $this, 'filter_template_include' ], 50 );
 		add_filter( 'posts_pre_query', [ $this, 'filter_posts_pre_query' ], 20, 2 );
 		add_filter( 'body_class', [ $this, 'filter_body_class' ] );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -66,7 +66,6 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	protected function add_filters() {
 		// Let's make sure to suppress query filters from the main query.
-		add_filter( 'tribe_events_suppress_query_filters', '__return_true' );
 		add_filter( 'template_include', [ $this, 'filter_template_include' ], 50 );
 		add_filter( 'posts_pre_query', [ $this, 'filter_posts_pre_query' ], 20, 2 );
 		add_filter( 'body_class', [ $this, 'filter_body_class' ] );

--- a/src/Tribe/Views/V2/Query/Event_Query_Controller.php
+++ b/src/Tribe/Views/V2/Query/Event_Query_Controller.php
@@ -41,4 +41,34 @@ class Event_Query_Controller extends Abstract_Query_Controller {
 		// @todo refine this to handle order depending on the View.
 		return tribe_events()->order_by('event_date', 'ASC');
 	}
+
+	/**
+	 * Parses the query to add/remove properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Query $query The current WordPress query object.
+	 */
+	public function parse_query( \WP_Query $query ) {
+
+		/*
+		 * If this method fires on the `tribe_events_parse_query` action, then the `Tribe__Events__Query::parse_query`
+		 * method should have set a number of `tribe_` flag properties on the query.
+		 * These allow us to know if we should suppress v1 query filters for this query or not.
+		 */
+		$suppress_filters = array_sum(
+			[
+				// It must be an event query.
+				! empty( $query->tribe_is_event_query ),
+				// It must be a query only for the events post type.
+				empty( $query->tribe_is_multi_posttype ),
+				// It must be a query for an archive of events.
+				! empty( $query->is_archive ),
+			]
+		);
+
+		if ( 3 === $suppress_filters ) {
+			$query->tribe_suppress_query_filters = true;
+		}
+	}
 }


### PR DESCRIPTION
Tickets:

* https://central.tri.be/issues/134827
* https://central.tri.be/issues/136498 

This PR:

* restores part of the code added in https://github.com/moderntribe/the-events-calendar/pull/2782 and reverted in https://github.com/moderntribe/the-events-calendar/pull/2787
* adds a more granular check on the query flags, the ones added by the `Tribe__Events__Query::parse_query` method, to selectively suppress v1 query filters

Screencap: https://drive.google.com/open?id=11pcKFgVedZ-VoJK_iwlstV3pQpVvLABc&authuser=luca@tri.be&usp=drive_fs