### PR TITLE
Modifies the when to load the Query Abstractions

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -172,6 +172,9 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @return array An array of injected posts, or the original array of posts if no post injection is required.
 	 */
 	public function filter_posts_pre_query( $posts = null, \WP_Query $query = null ) {
+		if ( is_admin() ) {
+			return $posts;
+		}
 
 		/*
 		 * We should only inject posts if doing PHP initial state render and if this is the main query.
@@ -183,6 +186,11 @@ class Hooks extends \tad_DI52_ServiceProvider {
 			&& $query instanceof \WP_Query
 			&& $query->is_main_query()
 		) ) {
+			return $posts;
+		}
+
+		// Verifies and only applies it to the correct queries.
+		if ( tribe( Template_Bootstrap::class )->should_load( $query ) ) {
 			return $posts;
 		}
 


### PR DESCRIPTION
_Ref:_ [C#136590](http://central.tri.be/issues/136590) [C#136621](http://central.tri.be/issues/136621)
---
Two bugs were reported around the queries we around events when we have V2 active, this particular PR resolves these problems by limiting the scope of where those filters happen.


📹 http://i.bordoni.me/7731d40475c0