### PR TITLE
Handle non-YYYY-MM-DD date formats for the datepicker on EA submission

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [TBD] TBD =
 
+* Fix - Fixed issue where DD/MM/YYYY style dates were not supported during Event Aggregator imports [117691]
 * Tweak - added the `tribe_events_suppress_query_filters` filter to allow suppressing `Tribe__Events__Query` filters [134827]
 
 = [4.9.10] 2019-10-16 =

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -249,7 +249,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	 * @return int
 	 */
 	protected function to_timestamp( $time, $default = '' ) {
-		$time = Tribe__Date_Utils::is_timestamp( $time ) ? $time : strtotime( $time );
+		$time = Tribe__Date_Utils::is_timestamp( $time ) ? $time : strtotime( Tribe__Date_Utils::maybe_format_from_datepicker( $time ) );
 
 		return false !== $time ? $time : $default;
 	}


### PR DESCRIPTION
When converting dates, handle the possibility that dates may be in tough-to-strtotime formats like DD/MM/YYYY. The fix is to pass them through our format conversion method in `Tribe__Date_Utils`.

🎥 http://p.tri.be/hvgKba

🎫 https://central.tri.be/issues/117691