### PR TITLE
Properly disable the assets from V1 at P0

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -310,6 +310,8 @@ class Assets extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_asset_enqueue_tribe-events-full-calendar-style', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-style', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-override-style', '__return_false' );
+
+		add_filter( 'tribe_events_assets_should_enqueue_frontend', '__return_false' );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -53,7 +53,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'tribe_common_loaded', [ $this, 'on_tribe_common_loaded' ], 1 );
 		add_action( 'wp_head', [ $this, 'on_wp_head' ], 1000 );
 		add_action( 'tribe_events_pre_rewrite', [ $this, 'on_tribe_events_pre_rewrite' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'action_disable_assets_v1' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'action_disable_assets_v1' ], 0 );
 		add_action( 'tribe_events_pro_shortcode_tribe_events_assets', [ $this, 'action_disable_shortcode_assets_v1' ] );
 		add_filter( 'tribe_events_views_v2_after_make_view', [ $this, 'action_include_filters_excerpt' ] );
 

--- a/src/Tribe/Views/V2/V1_Compat.php
+++ b/src/Tribe/Views/V2/V1_Compat.php
@@ -59,6 +59,7 @@ class V1_Compat extends \tad_DI52_ServiceProvider {
 	 */
 	public function remove_v1_filters() {
 		$backcompat        = V1_Backcompat::instance();
+		$tec_bar           = tribe( 'tec.bar' );
 
 		$filters_to_remove = [
 			'query_vars'              => [
@@ -85,6 +86,18 @@ class V1_Compat extends \tad_DI52_ServiceProvider {
 				],
 				[ 'callback' => [ $backcompat, 'filter_enabled_views' ], 'priority' => 10 ],
 				[ 'callback' => [ $backcompat, 'filter_default_view' ], 'priority' => 10 ],
+			],
+			'wp_enqueue_scripts' => [
+				[ 'callback' => [ $tec_bar, 'load_script' ], 'priority' => 9 ]
+			],
+			'body_class' => [
+				[ 'callback' => [ $tec_bar, 'body_class' ], 'priority' => 10 ]
+			],
+			'tribe_events_bar_before_template' => [
+				[ 'callback' => [ $tec_bar, 'disabled_bar_before' ], 'priority' => 10 ]
+			],
+			'tribe_events_bar_after_template' => [
+				[ 'callback' => [ $tec_bar, 'disabled_bar_after' ], 'priority' => 10 ]
 			],
 		];
 


### PR DESCRIPTION
_Ref:_ [C#135494](http://central.tri.be/issues/135494) [C#136666](http://central.tri.be/issues/136666)
---
While looking at some of the issues, I found that most of the assets were not fully disabled.
This should clear the field for @paulmskim to make the datepickers work properly.

📹 http://i.bordoni.me/d3d3ce6918fa