### PR TITLE
fix(Views V2) finer control over template bootstrap

### DIFF
--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -10,10 +10,9 @@
  */
 namespace Tribe\Events\Views\V2;
 
-use Tribe__Events__Main as TEC;
+use Tribe__Notices;
 use Tribe__Utils__Array as Arr;
 use WP_Query;
-use Tribe__Notices;
 
 class Template_Bootstrap {
 	/**
@@ -142,27 +141,25 @@ class Template_Bootstrap {
 	 *
 	 * @param  WP_Query $query Which WP_Query object we are going to load on
 	 *
-	 * @return boolean
+	 * @return boolean Whether any template managed by this class should load at all or not.
 	 */
 	public function should_load( $query = null ) {
-		if ( ! $query instanceof WP_Query ) {
+		if ( ! $query instanceof \WP_Query ) {
 			$query = tribe_get_global_query_object();
 		}
 
-		if ( ! $query instanceof WP_Query ) {
+		if ( ! $query instanceof \WP_Query ) {
 			return false;
 		}
 
 		/**
-		 * Bail if we are not dealing with our Post Type
+		 * Bail if we are not dealing with an Event, Venue or Organizer main query.
 		 *
-		 * @todo  needs support for Venues and Template
+		 * The `tribe_is_event_query` property is a logic `OR` of any post type and taxonomy we manage.
+		 *
+		 * @see \Tribe__Events__Query::parse_query() where this property is set.
 		 */
-		if ( ! in_array( TEC::POSTTYPE, (array) $query->get( 'post_type' ) ) ) {
-			return false;
-		}
-
-		return true;
+		return $query->is_main_query() && ! empty( $query->tribe_is_event_query );
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/TemplateBootstrapTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/TemplateBootstrapTest.php
@@ -126,7 +126,7 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 	public function it_should_load_only_on_correct_wp_query( $is_event_query, $is_main_query, $expected ) {
 		global $wp_query;
 		$query                       = $this->make(
-			\WP_Query::class, 
+			\WP_Query::class,
 			[
 				'is_main_query' => $is_main_query,
 			]
@@ -148,7 +148,7 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 		$query = $this->make(
 			\WP_Query::class,
 			[
-				'is_main_query' => false, ,
+				'is_main_query' => false,
 			]
 		);
 
@@ -190,8 +190,8 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 			[
 				'is_main_query' => static function () use ( &$called ) {
 					return $called = true;
-				}, ,
-			] 
+				},
+			]
 		);
 		$wp_query->tribe_is_event_query = true;
 

--- a/tests/views_integration/Tribe/Events/Views/V2/TemplateBootstrapTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/TemplateBootstrapTest.php
@@ -17,27 +17,27 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 
 	public function base_template_options() {
 		return [
-			'invalid' => [
+			'invalid'       => [
 				'foo',
 				'event',
 			],
-			'numeric' => [
+			'numeric'       => [
 				2,
 				'event',
 			],
-			'default' => [
+			'default'       => [
 				'default',
 				'page',
 			],
-			'empty_string' => [
+			'empty_string'  => [
 				'',
 				'event',
 			],
-			'numeric_zero' => [
+			'numeric_zero'  => [
 				0,
 				'event',
 			],
-			'null' => [
+			'null'          => [
 				null,
 				'event',
 			],
@@ -45,15 +45,15 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 				false,
 				'event',
 			],
-			'boolean_true' => [
+			'boolean_true'  => [
 				false,
 				'event',
 			],
-			'slug_event' => [
+			'slug_event'    => [
 				'event',
 				'event',
 			],
-			'slug_page' => [
+			'slug_page'     => [
 				'page',
 				'event',
 			],
@@ -96,20 +96,24 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 
 	public function query_args_to_load() {
 		return [
-			'invalid' => [
-				'foo',
+			'not_main_event_query'       => [
+				true,
+				false,
 				false,
 			],
-			'post_type_eq_tribe_events' => [
-				[ 'post_type' => 'tribe_events' ],
+			'main_event_query'           => [
+				true,
+				true,
 				true,
 			],
-			'post_type_contains_tribe_events' => [
-				[ 'post_type' => [ 'tribe_events', 'invalid_post_type' ] ],
+			'main_query_not_event_query' => [
+				false,
 				true,
+				false,
 			],
-			'post_type_not_tribe_events' => [
-				[ 'post_type' => 'post' ],
+			'not_main_not_event_query'   => [
+				false,
+				false,
 				false,
 			],
 		];
@@ -119,32 +123,56 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 * @dataProvider query_args_to_load
 	 */
-	public function it_should_load_only_on_correct_wp_query( $query_args, $expected ) {
-		$query = new \WP_Query( $query_args );
+	public function it_should_load_only_on_correct_wp_query( $is_event_query, $is_main_query, $expected ) {
+		global $wp_query;
+		$query                       = $this->make(
+			\WP_Query::class, 
+			[
+				'is_main_query' => $is_main_query,
+			]
+		);
+		$query->tribe_is_event_query = $is_event_query;
+		$wp_query                    = $query;
 
 		$should_load = $this->make_instance()->should_load( $query );
 
 		$this->assertEquals( $should_load, $expected );
 	}
 
+	/**
+	 * It should not load if query is not main query
+	 *
+	 * @test
+	 */
+	public function should_not_load_if_query_is_not_main_query() {
+		$query = $this->make(
+			\WP_Query::class,
+			[
+				'is_main_query' => false, ,
+			]
+		);
+
+		$this->assertFalse( $this->make_instance()->should_load( $query ) );
+	}
+
 	public function invalid_queries() {
 		return [
-			'string' => [
+			'string'        => [
 				'foo',
 			],
-			'numeric' => [
+			'numeric'       => [
 				2,
 			],
 			'boolean_false' => [
 				false,
 			],
-			'boolean_true' => [
+			'boolean_true'  => [
 				true,
 			],
-			'stdObject' => [
+			'stdObject'     => [
 				(object) [],
 			],
-			'array' => [
+			'array'         => [
 				[],
 			],
 		];
@@ -156,11 +184,20 @@ class TemplateBootstrapTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function it_should_use_global_query_on_invalid_query( $invalid_query ) {
 		global $wp_query;
-		$wp_query = new \WP_Query( [ 'post_type' => 'tribe_events' ] );
+		$called                         = false;
+		$wp_query                       = $this->make(
+			\WP_Query::class,
+			[
+				'is_main_query' => static function () use ( &$called ) {
+					return $called = true;
+				}, ,
+			] 
+		);
+		$wp_query->tribe_is_event_query = true;
 
 		$should_load = $this->make_instance()->should_load( $invalid_query );
 
 		$this->assertTrue( $should_load );
+		$this->assertTrue( $called );
 	}
-
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/136633 

[Screencap](https://drive.google.com/open?id=12kCKKNcsGzZy_NeSNh8R73l48_lsM8g3&authuser=luca@tri.be&usp=drive_fs)

This PR updates the Template_Bootstrap code to make sure Views are loaded only:

* if the query is the main one
* if the query is an event query (which included Venues, Organizers are Event Category too)