### PR TITLE
Dont disable V1 on single event views

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -299,6 +299,11 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return void
 	 */
 	public function disable_v1() {
+		// Dont disable V1 on Single Event page
+		if ( tribe( Template_Bootstrap::class )->is_single_event() ) {
+			return;
+		}
+
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-script', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_tribe-events-bar', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_the-events-calendar', '__return_false' );

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -93,6 +93,17 @@ class Template_Bootstrap {
 			: tribe( Template\Event::class );
 	}
 
+	public function is_single_event() {
+		$conditions = [
+			is_singular( TEC::POSTTYPE ),
+			'single-event' === tribe_context()->get( 'view' ),
+		];
+
+		$is_single_event = in_array( true, $conditions );
+
+		return $is_single_event;
+	}
+
 	/**
 	 * Fetches the HTML for the Single Event page using the legacy view system
 	 *

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -99,7 +99,7 @@ class Template_Bootstrap {
 	 *
 	 * @since  TBD
 	 *
-	 * @return bool
+	 * @return bool Whether the current request is for the single event template or not.
 	 */
 	public function is_single_event() {
 		$conditions = [

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -93,6 +93,14 @@ class Template_Bootstrap {
 			: tribe( Template\Event::class );
 	}
 
+	/**
+	 * Detemines wether we are in a Single event page or not,
+	 * base only on global context.
+	 *
+	 * @since  TBD
+	 *
+	 * @return bool
+	 */
 	public function is_single_event() {
 		$conditions = [
 			is_singular( TEC::POSTTYPE ),


### PR DESCRIPTION
 _Ref:_ [C#136503](http://central.tri.be/issues/136503)
---
Super simple change that was causing regressions, due to how agressive the V1 disabling was happening.

📹 http://i.bordoni.me/2cc7af256998