### PR TITLE
Fixes venue/organizer archives with WPML

### DIFF
--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -99,7 +99,7 @@ class Tribe__Events__Integrations__WPML__Meta {
 	 * @param object $q
 	 */
 	public function include_all_languages( $q ) {
-		$keys       = array( '_eventvenueid_in', '_eventorganizerid_im' );
+		$keys       = array( '_eventvenueid_in', '_eventorganizerid_in' );
 		$meta_query = $q->get( 'meta_query' );
 
 		foreach ( $keys as $key ) {

--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -99,37 +99,43 @@ class Tribe__Events__Integrations__WPML__Meta {
 	 * @param object $q
 	 */
 	public function include_all_languages( $q ) {
-		$keys = array( 'venue', 'organizer' );
+		$keys       = array( '_eventvenueid_in', '_eventorganizerid_im' );
+		$meta_query = $q->get( 'meta_query' );
+
 		foreach ( $keys as $key ) {
-			if ( ! isset( $q->query_vars[ $key ] ) ) {
+			if ( ! isset( $meta_query[ $key ] ) ) {
 				continue;
 			}
 
-			if ( ! is_int( $q->query_vars[ $key ] ) ) {
-				continue;
+			$vars = $meta_query[ $key ]['value'];
+			$result = array();
+			foreach ( $vars as $var ) {
+				$type = get_post_type( $var );
+				/**
+				 * Get trid (the ID of the translation group) of a translated element, which is
+				 * required for the  wpml_get_element_translations filter and others which expect this argument.
+				 * https://wpml.org/wpml-hook/wpml_element_trid/
+				 *
+				 * @param mixed   $empty_value     This is usually the value the filter will be modifying.
+				 * @param int     $var             The ID of the item.
+				 * @param string  $element_type    The type of an element.
+				 */
+				$trid = apply_filters( 'wpml_element_trid', null, $var, $type );
+				/**
+				 * Get the element translations info using trid
+				 * https://wpml.org/wpml-hook/wpml_get_element_translations/
+				 *
+				 * @param mixed   $empty_value     This is usually the value the filter will be modifying.
+				 * @param int     $var             The ID of the translation group
+				 * @param string  $element_type    The type of an element.
+				 */
+				$translations = apply_filters( 'wpml_get_element_translations', null, $trid, $type );
+
+				$result = array_merge( $result, wp_list_pluck( $translations, 'element_id' ) );
 			}
 
-			$var = $q->query_vars[ $key ];
-			/**
-			 * Get trid (the ID of the translation group) of a translated element, which is
-			 * required for the  wpml_get_element_translations filter and others which expect this argument.
-			 * https://wpml.org/wpml-hook/wpml_element_trid/
-			 *
-			 * @param mixed   $empty_value     This is usually the value the filter will be modifying.
-			 * @param int     $var             The ID of the item.
-			 * @param string  $element_type    The type of an element.
-			 */
-			$trid = apply_filters( 'wpml_element_trid', null, $var, "post_tribe_{$key}" );
-			/**
-			 * Get the element translations info using trid
-			 * https://wpml.org/wpml-hook/wpml_get_element_translations/
-			 *
-			 * @param mixed   $empty_value     This is usually the value the filter will be modifying.
-			 * @param int     $var             The ID of the translation group
-			 * @param string  $element_type    The type of an element.
-			 */
-			$translations = apply_filters( 'wpml_get_element_translations', null, $trid, "post_tribe_{$key}" );
-			$q->query_vars[ $key ] = wp_list_pluck( $translations, 'element_id' );
+			$meta_query[ $key ]['value'] = $result;
+			$q->set( 'meta_query', $meta_query );
 		}
 	}
 


### PR DESCRIPTION
The query changed from arguments like `venue=xxx` to using the `meta_query` array.
This pull request caters for those changes.

https://wpml.org/forums/topic/events-not-showing-in-all-translated-venue-pages/