### PR TITLE
VR > Events Bar > Twentyseventeen z-index

### DIFF
--- a/src/resources/postcss/components/skeleton/_events-bar.pcss
+++ b/src/resources/postcss/components/skeleton/_events-bar.pcss
@@ -36,6 +36,7 @@
 			flex: auto;
 			padding: 0;
 			position: static;
+			z-index: auto;
 		}
 	}
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/137407
🎥 https://www.loom.com/share/e947fc9baf4241af8674d396fce8a5fb

Reset `z-index` for the events bar so it doesn't conflict with the sticky menu of twentyseventeen.