### PR TITLE
VR > Month > Multi-day starting last month ending this month in same week.

### DIFF
--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -128,7 +128,7 @@ class Event extends Base {
 					$this_week_duration = 1;
 					if ( $is_multiday ) {
 						if ( $starts_this_week && $ends_this_week ) {
-							$this_week_duration = min( 7, max( 1, $the_end_ymd - $the_start_ymd ) + $cross_day );
+							$this_week_duration = min( 7, max( 1, Dates::date_diff( $the_end_ymd, $the_start_ymd ) ) + $cross_day );
 						} elseif ( $ends_this_week ) {
 							$this_week_duration = $the_end_ymd - $week_start_ymd + $cross_day;
 						} elseif ( $starts_this_week ) {


### PR DESCRIPTION
🎫 https://central.tri.be/issues/136606
🎥 https://www.loom.com/share/0a569261f28e44cfa84a19855cfe477d

Use date diff instead of operating with `ymd`. When using ymd, the substraction between months gives a high number, so it defaults to 7 (using `min`).