### PR TITLE
fix(Context) add WP parsed query vars to event_date

### DIFF
--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -93,6 +93,7 @@ class Context extends \tad_DI52_ServiceProvider {
 						],
 						Tribe__Context::REQUEST_VAR => [ 'eventDate', 'tribe-bar-date' ],
 						Tribe__Context::QUERY_VAR   => 'eventDate',
+						Tribe__Context::WP_PARSED   => 'eventDate',
 					],
 					'write' => [
 						Tribe__Context::REQUEST_VAR => [ 'eventDate', 'tribe-bar-date' ],


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138137 

This PR fixes an issue emerged in Day View that would, or reload of PHP initial state, set the Day View date to today's date, no matter the date set in the URL.

Since the Day View date, when permalinks are active, is set as part of the URL (e.g. `/events/2019-12-13/`) the Context attempt to read the requested date from a request var (from `GET` or `REQUEST`) would fail and fall back on the default value of today.

By the time the check is made by the context, though, WordPress has already parsed the URL into internally stored query args that, via the `Tribe__Context::WP_PARSED` location, can be accessed.

To avoid perturbation of previously working Views I've added the location last and re-ran the tests on PRO too: all passing.