### PR TITLE
VR > Multiday duration fixes.

### DIFF
--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -130,9 +130,9 @@ class Event extends Base {
 						if ( $starts_this_week && $ends_this_week ) {
 							$this_week_duration = min( 7, max( 1, Dates::date_diff( $the_end_ymd, $the_start_ymd ) ) + $cross_day );
 						} elseif ( $ends_this_week ) {
-							$this_week_duration = $the_end_ymd - $week_start_ymd + $cross_day;
+							$this_week_duration = Dates::date_diff( $the_end_ymd, $week_start_ymd ) + $cross_day;
 						} elseif ( $starts_this_week ) {
-							$this_week_duration = $week_end_ymd - $the_start_ymd + $cross_day;
+							$this_week_duration = Dates::date_diff( $week_end_ymd, $the_start_ymd ) + $cross_day;
 						} else {
 							// If it happens this week and it doesn't start or end this week, then it spans the week.
 							$this_week_duration = 7;


### PR DESCRIPTION
🎫 https://central.tri.be/issues/137838
🎥 https://www.loom.com/share/d7ec4db91fa94fefab235df99b9c4f1b

Switching `ymd` calcs for `date_diff` as the first one is not precise for end of month subtractions.