### PR TITLE
fix(Views V2) avoid inf. loop on object cache

### DIFF
--- a/src/Tribe/Views/V2/Template/Excerpt.php
+++ b/src/Tribe/Views/V2/Template/Excerpt.php
@@ -8,9 +8,9 @@
  */
 namespace Tribe\Events\Views\V2\Template;
 
-use Tribe__Template as Base_Template;
-use Tribe__Events__Main as Plugin;
 use Tribe\Events\Views\V2\Hooks;
+use Tribe__Events__Main as Plugin;
+use Tribe__Template as Base_Template;
 
 /**
  * Class Excerpt
@@ -67,7 +67,10 @@ class Excerpt extends Base_Template {
 			return $link;
 		}
 
-		$event = tribe_get_event( get_the_ID() );
+		// Read the method doc-block to understand why we do this here.
+		$event = $this->avoiding_filter_loop( static function () {
+			return tribe_get_event( get_the_ID() );
+		} );
 
 		$template = strtolower( get_template() );
 
@@ -75,17 +78,17 @@ class Excerpt extends Base_Template {
 		$should_replace_read_more = $template && 'twentyseventeen' === $template;
 
 		/**
-		 * Detemines the require
+		 * Determines if we need to replace the excerpt read more link in a given scenario or not.
 		 *
 		 * @since 4.9.11
 		 *
-		 * @param bool    $should_replace_read_more Determines if we need to replace the excerpt read more link
-		 *                                          in a given scenario.
-		 * @param WP_Post $event                    Event that we are dealing with.
+		 * @param bool     $should_replace_read_more Whether we need to replace the excerpt read more link or not.
+		 * @param \WP_Post $event                    Event that we are dealing with.
+		 *
+		 * @see tribe_get_event() for the format and the properties of the decorated post.
 		 */
 		$should_replace_read_more = apply_filters( 'tribe_events_views_v2_should_replace_excerpt_more_link', $should_replace_read_more, $event );
 
-		// If shouldn't replace we bail.
 		if ( ! $should_replace_read_more ) {
 			return $link;
 		}
@@ -93,4 +96,39 @@ class Excerpt extends Base_Template {
 		return $this->template( 'components/read-more', [ 'event' => $event ], false );
 	}
 
+	/**
+	 * Handles the infinite loop that could happen when the excerpt filtering fires as a consequence of a
+	 * `Lazy_String` resolution in the `tribe_get_event` function.
+	 *
+	 * To correctly apply the `read-more` template, and account for possible third-parties overrides, we need the
+	 * result of a call to the `tribe_get_event` function.
+	 * If object caching is active that function will be fired on `shutdown` and will resolve all of its `Lazy_String`
+	 * instances.
+	 * One of those is the one holding the value of the filtered post excerpt.
+	 * This will cause an infinite loop if not handled.
+	 *
+	 * @since TBD
+	 *
+	 * @param callable $function The function that should be resolved avoiding a filter infinite loop.
+	 *
+	 * @return mixed The result value of the function call.
+	 */
+	protected function avoiding_filter_loop( callable $function ) {
+		$hooks = tribe( Hooks::class );
+		// As registered in `Tribe\Events\Views\V2\Hooks::action_include_filters_excerpt`.
+		$priority   = 50;
+		$has_filter = has_filter( 'excerpt_more', [ $hooks, 'filter_excerpt_more' ] );
+
+		if ( $has_filter ) {
+			remove_filter( 'excerpt_more', [ $hooks, 'filter_excerpt_more' ], $priority );
+		}
+
+		$result = $function();
+
+		if ( $has_filter ) {
+			add_filter( 'excerpt_more', [ $hooks, 'filter_excerpt_more' ], $priority );
+		}
+
+		return $result;
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138249  

This PR is a slight variation on the fix @bordoni had originally implemented to avoid infinite loops on excerpt.
This PR re-introduces the fix and takes into account the additional scenario of object-cache presence.

[Screencap](https://drive.google.com/open?id=1-R3zdQKmdE_Z2Sz7vv5VZwl6t_a-Cc4l&authuser=luca@tri.be&usp=drive_fs)

To test the fix I'v put together a really incomplete, yet fitting for this specific issue testing, pluging [in this gist](https://gist.github.com/e44c5fe6b81d60651f8fbec3d49fecc0).