### PR TITLE
refactor(Views v2) move List_Behavior in Traits

### DIFF
--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -9,6 +9,7 @@
 namespace Tribe\Events\Views\V2\Views;
 
 use Tribe\Events\Views\V2\View;
+use Tribe\Events\Views\V2\Views\Traits\List_Behavior;
 use Tribe__Context;
 use Tribe__Events__Main as TEC;
 use Tribe__Events__Rewrite as Rewrite;

--- a/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
+++ b/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
@@ -7,7 +7,7 @@
  * @package Tribe\Events\Views\V2\Views
  */
 
-namespace Tribe\Events\Views\V2\Views;
+namespace Tribe\Events\Views\V2\Views\Traits;
 
 use Tribe__Context as Context;
 use Tribe__Date_Utils as Dates;

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/List_BehaviorTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/List_BehaviorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tribe\Events\Views\V2\Views;
+namespace Tribe\Events\Views\V2\Views\Traits;
 
 use Tribe\Events\Views\V2\View;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;


### PR DESCRIPTION
Ticket: n/a

Following check-in dev discussion, I'm moving the `List_Behavior` trait into a dedicated `Traits` directory in Views v2 code.