### PR TITLE
Filter get_past_url() and get_upcoming_url() calls

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -684,16 +684,7 @@ class View implements View_Interface {
 			unset( $query_args['featured'] );
 		}
 
-		/**
-		 * Filters the query arguments that will be used to build a View URL.
-		 *
-		 * @since 4.9.10
-		 *
-		 * @param array          $query_args An array of query args that will be used to build the URL for the View.
-		 * @param View_Interface $this       This View instance.
-		 * @param bool           $canonical  Whether the URL should be the canonical one or not.
-		 */
-		$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+		$query_args = $this->filter_query_args( $query_args, $canonical );
 
 		if ( ! empty( $query_args['tribe-bar-date'] ) ) {
 			// If the Events Bar date is the same as today's date, then drop it.
@@ -808,6 +799,30 @@ class View implements View_Interface {
 
 		return $url;
 	}
+
+	/**
+	 * Filters URL query args with a predictable filter
+	 *
+	 * @since TBD
+	 *
+	 * @param array $query_args An array of query args that will be used to build the URL for the View.
+	 * @param bool  $canonical  Whether the URL should be the canonical one or not.
+	 */
+	public function filter_query_args( $query_args, $canonical ) {
+		/**
+		 * Filters the query arguments that will be used to build a View URL.
+		 *
+		 * @since 4.9.10
+		 *
+		 * @param array          $query_args An array of query args that will be used to build the URL for the View.
+		 * @param View_Interface $this       This View instance.
+		 * @param bool           $canonical  Whether the URL should be the canonical one or not.
+		 */
+		$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+
+		return $query_args;
+	}
+
 
 	/**
 	 * {@inheritDoc}

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -98,7 +98,6 @@ class List_View extends View {
 		$date           = $this->context->get( 'event_date', $default_date );
 		$event_date_var = $default_date === $date ? '' : $date;
 
-
 		$past = tribe_events()->by_args( $this->setup_repository_args( $this->context->alter( [
 			'event_display_mode' => 'past',
 			'paged'              => $page,

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -188,16 +188,7 @@ class List_View extends View {
 				'tribe-bar-search' => $this->context->get( 'keyword' ),
 			];
 
-			/**
-			 * Filters the query arguments that will be used to build a View URL.
-			 *
-			 * @since TBD
-			 *
-			 * @param array          $query_args An array of query args that will be used to build the URL for the View.
-			 * @param View_Interface $this       This View instance.
-			 * @param bool           $canonical  Whether the URL should be the canonical one or not.
-			 */
-			$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+			$query_args = $this->filter_query_args( $query_args, $canonical );
 
 			$upcoming_url_object = clone $this->url->add_query_args( array_filter( $query_args ) );
 

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -114,16 +114,7 @@ class List_View extends View {
 				'tribe-bar-search' => $this->context->get( 'keyword' ),
 			];
 
-			/**
-			 * Filters the query arguments that will be used to build a View URL.
-			 *
-			 * @since TBD
-			 *
-			 * @param array          $query_args An array of query args that will be used to build the URL for the View.
-			 * @param View_Interface $this       This View instance.
-			 * @param bool           $canonical  Whether the URL should be the canonical one or not.
-			 */
-			$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+			$query_args = $this->filter_query_args( $query_args, $canonical );
 
 			$past_url_object = clone $this->url->add_query_args( array_filter( $query_args ) );
 

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -98,19 +98,34 @@ class List_View extends View {
 		$date           = $this->context->get( 'event_date', $default_date );
 		$event_date_var = $default_date === $date ? '' : $date;
 
+
 		$past = tribe_events()->by_args( $this->setup_repository_args( $this->context->alter( [
 			'event_display_mode' => 'past',
 			'paged'              => $page,
 		] ) ) );
 
 		if ( $past->count() > 0 ) {
-			$past_url_object = clone $this->url->add_query_args( array_filter( [
+
+			$query_args = [
 				'post_type'        => TEC::POSTTYPE,
 				'eventDisplay'     => 'past',
 				'eventDate'        => $event_date_var,
 				$this->page_key    => $page,
 				'tribe-bar-search' => $this->context->get( 'keyword' ),
-			] ) );
+			];
+
+			/**
+			 * Filters the query arguments that will be used to build a View URL.
+			 *
+			 * @since TBD
+			 *
+			 * @param array          $query_args An array of query args that will be used to build the URL for the View.
+			 * @param View_Interface $this       This View instance.
+			 * @param bool           $canonical  Whether the URL should be the canonical one or not.
+			 */
+			$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+
+			$past_url_object = clone $this->url->add_query_args( array_filter( $query_args ) );
 
 			$past_url = (string) $past_url_object;
 
@@ -160,18 +175,31 @@ class List_View extends View {
 		$url = '';
 
 		$upcoming = tribe_events()->by_args( $this->setup_repository_args( $this->context->alter( [
-			'eventDisplay' => 'list',
+			'eventDisplay' => $this->slug,
 			'paged'        => $page,
 		] ) ) );
 
 		if ( $upcoming->count() > 0 ) {
-			$upcoming_url_object = clone $this->url->add_query_args( array_filter( [
+			$query_args = [
 				'post_type'        => TEC::POSTTYPE,
-				'eventDisplay'     => 'list',
+				'eventDisplay'     => $this->slug,
 				$this->page_key    => $page,
 				'eventDate'        => $event_date_var,
 				'tribe-bar-search' => $this->context->get( 'keyword' ),
-			] ) );
+			];
+
+			/**
+			 * Filters the query arguments that will be used to build a View URL.
+			 *
+			 * @since TBD
+			 *
+			 * @param array          $query_args An array of query args that will be used to build the URL for the View.
+			 * @param View_Interface $this       This View instance.
+			 * @param bool           $canonical  Whether the URL should be the canonical one or not.
+			 */
+			$query_args = apply_filters( 'tribe_events_views_v2_url_query_args', $query_args, $this, $canonical );
+
+			$upcoming_url_object = clone $this->url->add_query_args( array_filter( $query_args ) );
 
 			$upcoming_url = (string) $upcoming_url_object;
 


### PR DESCRIPTION
Filterbar hooks into `tribe_events_views_v2_url_query_args` filter to attach its query arguments to URLs. Our prev_url() and next_url() fire that filter, however, Map and Photo view's `get_past_url()` was not doing so. This changeset adds the filter so filterbar can work its magic on any of the URLs.

:movie_camera: http://p.tri.be/s6Gs7h

Related:
* https://github.com/moderntribe/events-pro/pull/1414
* https://github.com/moderntribe/events-filterbar/pull/217

see/138621
see/138632