### PR TITLE
fix(Collections) add and use Lazy_Post_Collection

### DIFF
--- a/src/Tribe/Collections/Lazy_Post_Collection.php
+++ b/src/Tribe/Collections/Lazy_Post_Collection.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Models a lazy collection of posts that will store the post IDs in cache during serialization and rebuild the
+ * collection items from post IDs during unserialization.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Collections
+ */
+
+namespace Tribe\Events\Collections;
+
+use Tribe\Utils\Lazy_Collection;
+
+/**
+ * Class Lazy_Post_Collection
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Collections
+ */
+class Lazy_Post_Collection extends Lazy_Collection {
+	/**
+	 * The callback function that should be called to rebuild the collection items from an array of post IDs.
+	 *
+	 * @since TBD
+	 *
+	 * @var callable|string
+	 */
+	protected $unserialize_callback;
+
+	/**
+	 * Lazy_Post_Collection constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param callable $callback             The callback that should be used to fetch the collection items.
+	 * @param string   $unserialize_callback The callback that should be used to rebuild the collection items from the
+	 *                                       serialized post IDs.
+	 */
+	public function __construct( callable $callback, $unserialize_callback = 'get_post' ) {
+		parent::__construct( $callback );
+		$this->unserialize_callback = $unserialize_callback;
+	}
+
+	/**
+	 * Plucks the post IDs from the collection items before serialization.
+	 *
+	 * While serializing a post object w/ added properties will not generate any error during serialization, doing the
+	 * same during unserialization will yield a `false` result.
+	 * To avoid dealing with the lower level details of how the post object is built or decorated, here we extract
+	 * the post IDs to only store those.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<\WP_Post> $items The posts part of this collection.
+	 *
+	 * @return array The collection post IDs and callback.
+	 *
+	 * @see   Lazy_Post_Collection::custom_unserialize() for the other part of the post handling.
+	 */
+	protected function before_serialize( array $items ) {
+		return [
+			'callback' => $this->unserialize_callback,
+			'ids'      => wp_list_pluck( $items, 'ID' ),
+		];
+	}
+
+	/**
+	 * Custom handling of the lazy collection unserialization, this method will build complete post objects from
+	 * the serialized post IDs.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $serialized The serialized values, usually an array of post IDs.
+	 *
+	 * @return array<\WP_Post>|null Either the rebuilt collection, or `null` if the serialized string cannot be
+	 *                             unserialized.
+	 */
+	protected function custom_unserialize( $serialized ) {
+		$unserialized = unserialize( $serialized );
+
+		if ( false === $unserialized || ! is_array( $unserialized ) ) {
+			return null;
+		}
+
+		return array_map( $unserialized['callback'], $unserialized['ids'] );
+	}
+}

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -11,8 +11,8 @@ namespace Tribe\Events\Models\Post_Types;
 
 use DateInterval;
 use DatePeriod;
-use DateTimeImmutable;
 use DateTimeZone;
+use Tribe\Events\Collections\Lazy_Post_Collection;
 use Tribe\Models\Post_Types\Base;
 use Tribe\Utils\Lazy_Collection;
 use Tribe\Utils\Lazy_String;
@@ -184,7 +184,10 @@ class Event extends Base {
 					false
 				) )->on_resolve( $cache_this ),
 				'organizers'             => ( new Lazy_Collection( $organizer_fetch ) )->on_resolve( $cache_this ),
-				'venues'                 => ( new Lazy_Collection( $venue_fetch ) )->on_resolve( $cache_this ),
+				'venues'                 => ( new Lazy_Post_Collection(
+					$venue_fetch,
+					'tribe_get_venue_object' )
+				)->on_resolve( $cache_this ),
 				'thumbnail'              => ( new Post_Thumbnail( $post_id ) )->on_resolve( $cache_this ),
 				'permalink'              => get_permalink( $post_id ),
 				'schedule_details'       => ( new Lazy_String(


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138249

[Screencap](https://drive.google.com/open?id=1-oMtf5y_vLdzWruQWX2iXZLzC75qtmGC&authuser=luca@tri.be&usp=drive_fs)

Based on: https://github.com/moderntribe/tribe-common/pull/1241

This PR adds, and uses, the `Lazy_Post_Collection` class to
correctly handle serialization and unserialization of decorated post
objects.
Calls to `serialize` on `WP_Post` objects decorated by methods like
`tribe_get_event` or `tribe_get_venue_object` will not throw any error
and will produce a serialized version of the post object w/ all the
added properties added to it.

During unserialization, though, the additional, decorating, properties
will not be recognized by the `unserialize` function and the object
instance will fail to build, returning `false` as result of the
unserialization.

This commit adds extra care when dealing with post objects to store only
an aray of post IDs and a callback that should be used to hydrate them
during unserialization.