### PR TITLE
test(_support) update Event Factory to use Dates and Timezone utils

### DIFF
--- a/tests/_support/Factories/Event.php
+++ b/tests/_support/Factories/Event.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Events\Test\Factories;
 
+use Tribe__Date_Utils as Dates;
 use Tribe__Events__Main as Main;
 use Tribe__Timezones as Timezones;
 use Tribe__Utils__Array as Arr;
@@ -31,7 +32,7 @@ class Event extends \WP_UnitTest_Factory_For_Post {
 	 *                         Notable arguments:
 	 *                         `when` - by default events will happen in 24hrs; set this to a different hour offset
 	 *                         to have them happen at a different time.
-	 *                         `duration` - by defautl events will last for 2hrs; set this to a different duration
+	 *                         `duration` - by default events will last for 2hrs; set this to a different duration
 	 *                         in seconds if required.
 	 *                         `utc_offset` - by default events will happen on UTC time; set this to a different hour
 	 *                         offset if required.
@@ -51,13 +52,31 @@ class Event extends \WP_UnitTest_Factory_For_Post {
 		$utc_offset = Arr::get( $args, 'utc_offset', 0 );
 		$timezone   = Arr::get( $args, 'timezone', Timezones::build_timezone_object()->getName() );
 
-		$start_timestamp = is_numeric( $utc_start_time ) ? $utc_start_time : strtotime( $utc_start_time );
+		$utc = Timezones::build_timezone_object( 'UTC' );
+		$timezone_obj = Timezones::build_timezone_object($timezone);
+
+		$start_timestamp = is_numeric( $utc_start_time )
+			? $utc_start_time
+			: Dates::build_date_object( $utc_start_time, $utc )->getTimestamp();
 		$end_timestamp   = $start_timestamp + $duration;
 
-		$utc_start   = date( 'Y-m-d H:i:s', $start_timestamp );
-		$local_start = date( 'Y-m-d H:i:s', $start_timestamp + $utc_offset * 3600 );
-		$utc_end     = date( 'Y-m-d H:i:s', $end_timestamp );
-		$local_end   = date( 'Y-m-d H:i:s', $end_timestamp + $utc_offset * 3600 );
+		$utc_start   = Dates::build_date_object( $start_timestamp )
+		                    ->setTimezone( $utc )->format( Dates::DBDATETIMEFORMAT );
+		$utc_end     = Dates::build_date_object( $end_timestamp )
+		                    ->setTimezone( $utc )->format( Dates::DBDATETIMEFORMAT );
+
+		if ( isset( $args['utc_offset'] ) ) {
+			$local_start = Dates::build_date_object( $start_timestamp + $utc_offset * HOUR_IN_SECONDS )
+			                    ->setTimezone( $utc )->format( Dates::DBDATETIMEFORMAT );
+			$local_end   = Dates::build_date_object( $end_timestamp + $utc_offset * HOUR_IN_SECONDS )
+			                    ->setTimezone( $utc )->format( Dates::DBDATETIMEFORMAT );
+		} else {
+			// Use the timezone to create the "local" (to the site) times.
+			$local_start = Dates::build_date_object( $start_timestamp )
+			                    ->setTimezone( $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
+			$local_end   = Dates::build_date_object( $end_timestamp )
+			                    ->setTimezone( $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
+		}
 
 		$meta_input = [
 			'_EventStartDate'    => $local_start,
@@ -83,7 +102,7 @@ class Event extends \WP_UnitTest_Factory_For_Post {
 
 		unset( $args['when'], $args['duration'], $args['utc_offset'] );
 
-		$id = uniqid();
+		$id = uniqid( 'test_event', true );
 		$defaults = [
 			'post_type'  => $this->get_post_type(),
 			'post_title' => "Event {$id}",


### PR DESCRIPTION
Ticket: n/a

This PR updates the Event Factory to build the dates using the Dates and Timezone uitlities.
This should decouple the factory from the underlying system timezone setting and avoid some "wrong time of the day" failures.