### PR TITLE
Updating our pw-protected event handling to blank out values

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -55,6 +55,10 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
 		add_action( 'tribe_common_loaded', [ $this, 'on_tribe_common_loaded' ], 1 );
 		add_action( 'wp_head', [ $this, 'on_wp_head' ], 1000 );
+
+		// Hide sensitive event info if post is password protected.
+		add_action( 'the_post', array( $this, 'action_manage_sensitive_info' ) );
+
 		add_action( 'tribe_events_pre_rewrite', [ $this, 'on_tribe_events_pre_rewrite' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'action_disable_assets_v1' ], 0 );
 		add_action( 'tribe_events_pro_shortcode_tribe_events_after_assets', [ $this, 'action_disable_shortcode_assets_v1' ] );
@@ -134,6 +138,19 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	public function action_disable_shortcode_assets_v1() {
 		$assets = $this->container->make( Assets::class );
 		$assets->disable_v1();
+	}
+
+	/**
+	 * Fires to manage sensitive information on password protected posts
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Post $post
+	 *
+	 * @return void
+	 */
+	public function action_manage_sensitive_info( $post ) {
+		$this->container->make( Template\Event::class )->manage_sensitive_info( $post );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Template/Event.php
+++ b/src/Tribe/Views/V2/Template/Event.php
@@ -38,8 +38,9 @@ class Event {
 	/**
 	 * Add/remove filters to hide/show sensitive event info on password protected posts
 	 *
-	 * @param WP_Post $post
+	 * @since TBD
 	 *
+	 * @param WP_Post $post
 	 **/
 	public function manage_sensitive_info( $post ) {
 		if ( post_password_required( $post ) ) {

--- a/src/Tribe/Views/V2/Template/Event.php
+++ b/src/Tribe/Views/V2/Template/Event.php
@@ -10,9 +10,15 @@
  */
 namespace Tribe\Events\Views\V2\Template;
 
+use Tribe__Events__Main;
 use Tribe\Events\Views\V2\View;
 
 class Event {
+	/**
+	 * @var boolean Whether or not we are currently filtering out content due to password protection
+	 */
+	protected $managing_sensitive_info = false;
+
 	/**
 	 * Determines the Path for the PHP file to be used as the main template
 	 * For Page base template setting it will select from theme or child theme
@@ -27,5 +33,45 @@ class Event {
 		$fake_view = View::make( 'reflector' );
 		$path = $fake_view->get_template()->get_template_file( 'index' );
 		return $path;
+	}
+
+	/**
+	 * Add/remove filters to hide/show sensitive event info on password protected posts
+	 *
+	 * @param WP_Post $post
+	 *
+	 **/
+	public function manage_sensitive_info( $post ) {
+		if ( post_password_required( $post ) ) {
+			add_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
+			add_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
+			add_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
+			add_filter( 'tribe_event_meta_venue_address', '__return_empty_string' );
+			add_filter( 'tribe_event_featured_image', '__return_empty_string' );
+			add_filter( 'tribe_get_venue', '__return_empty_string' );
+			add_filter( 'tribe_get_cost', '__return_empty_string' );
+
+			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
+				add_filter( 'the_title', '__return_empty_string' );
+				add_filter( 'tribe_get_template_part_templates', '__return_empty_array' );
+			}
+
+			$this->managing_sensitive_info = true;
+		} elseif ( $this->managing_sensitive_info ) {
+			remove_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
+			remove_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
+			remove_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
+			remove_filter( 'tribe_event_meta_venue_address', '__return_empty_string' );
+			remove_filter( 'tribe_event_featured_image', '__return_empty_string' );
+			remove_filter( 'tribe_get_venue', '__return_empty_string' );
+			remove_filter( 'tribe_get_cost', '__return_empty_string' );
+
+			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
+				remove_filter( 'the_title', '__return_empty_string' );
+				remove_filter( 'tribe_get_template_part_templates', '__return_empty_array' );
+			}
+
+			$this->managing_sensitive_info = false;
+		}
 	}
 }

--- a/src/Tribe/Views/V2/Template/Event.php
+++ b/src/Tribe/Views/V2/Template/Event.php
@@ -43,7 +43,9 @@ class Event {
 	 * @param WP_Post $post
 	 **/
 	public function manage_sensitive_info( $post ) {
-		if ( post_password_required( $post ) ) {
+		$password_required = post_password_required( $post );
+
+		if ( ! $this->managing_sensitive_info && $password_required ) {
 			add_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
 			add_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
 			add_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
@@ -58,7 +60,7 @@ class Event {
 			}
 
 			$this->managing_sensitive_info = true;
-		} elseif ( $this->managing_sensitive_info ) {
+		} elseif ( $this->managing_sensitive_info && ! $password_required ) {
 			remove_filter( 'tribe_events_event_schedule_details', '__return_empty_string' );
 			remove_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
 			remove_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1046,6 +1046,11 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$event = get_post( $event );
 		}
 
+		// if the post is password protected, don't return the schedule details
+		if ( post_password_required( $event ) ) {
+			return '';
+		}
+
 		$inner                    = $html ? '<span class="tribe-event-date-start">' : '';
 		$format                   = '';
 		$date_without_year_format = tribe_get_date_format();


### PR DESCRIPTION
Porting over the value blanking from v1. I've additionally done the following:

* Added a class property to avoid attempting to unhook filters that are not set.
* Added a password checker in the `tribe_events_event_schedule_details()` function as that function is called earlier than `the_post` in our V2 views.

:movie_camera: http://p.tri.be/aF58my

see/138862