### PR TITLE
TEC-2989 TEC-3033 - VR - Fix pwd protected post fields

### DIFF
--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -413,6 +413,10 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 			add_filter( 'tribe_get_venue', '__return_empty_string' );
 			add_filter( 'tribe_get_cost', '__return_empty_string' );
 
+			if ( wp_doing_ajax() ) {
+				add_filter( 'the_title', [ $this, 'filter_get_the_title' ], 10, 2 );
+			}
+
 			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
 				add_filter( 'the_title', '__return_empty_string' );
 				add_filter( 'tribe_get_template_part_templates', '__return_empty_array' );
@@ -425,6 +429,10 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 			remove_filter( 'tribe_event_featured_image', '__return_empty_string' );
 			remove_filter( 'tribe_get_venue', '__return_empty_string' );
 			remove_filter( 'tribe_get_cost', '__return_empty_string' );
+
+			if ( wp_doing_ajax() ) {
+				remove_filter( 'the_title', [ $this, 'filter_get_the_title' ], 10 );
+			}
 
 			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
 				remove_filter( 'the_title', '__return_empty_string' );
@@ -567,5 +575,37 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 				'meta_before'  => '',
 				'meta_after'   => '',
 			) );
+	}
+
+	/**
+	 * Filters the post title as WordPress does in `get_the_title` to apply the password-protected prefix in
+	 * the context of AJAX requests.
+	 *
+	 * @since TBD
+	 *
+	 * @param string      $title   The post title.
+	 * @param int|WP_Post $post_id The post ID, or object, to apply the filter for.
+	 *
+	 * @return string The filtered post title.
+	 */
+	public function filter_get_the_title( $title, $post_id = 0 ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return $title;
+		}
+
+		if ( ! empty( $post->post_password ) ) {
+			/* translators: %s: Protected post title. */
+			$prepend = __( 'Protected: %s' );
+
+			/**
+			 * @see get_the_title() for the original filter documentation.
+			 */
+			$protected_title_format = apply_filters( 'protected_title_format', $prepend, $post );
+			$title                  = sprintf( $protected_title_format, $title );
+		}
+
+		return $title;
 	}
 }

--- a/src/Tribe/Template_Factory.php
+++ b/src/Tribe/Template_Factory.php
@@ -408,6 +408,7 @@ class Tribe__Events__Template_Factory extends Tribe__Template_Factory {
 			add_filter( 'tribe_events_recurrence_tooltip', '__return_false' );
 			add_filter( 'tribe_event_meta_venue_name', '__return_empty_string' );
 			add_filter( 'tribe_event_meta_venue_address', '__return_empty_string' );
+			add_filter( 'tribe_get_full_address', '__return_empty_string' );
 			add_filter( 'tribe_event_featured_image', '__return_empty_string' );
 			add_filter( 'tribe_get_venue', '__return_empty_string' );
 			add_filter( 'tribe_get_cost', '__return_empty_string' );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -19,7 +19,6 @@ namespace Tribe\Events\Views\V2;
 
 use Tribe\Events\Views\V2\Query\Abstract_Query_Controller;
 use Tribe\Events\Views\V2\Query\Event_Query_Controller;
-use Tribe\Events\Views\V2\Repository\Caching_Set_Decorator;
 use Tribe\Events\Views\V2\Repository\Event_Period;
 use Tribe\Events\Views\V2\Template\Title;
 use Tribe__Events__Main as TEC;

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -558,7 +558,9 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @param \WP_Post|int $post The event post ID or object currently being decorated.
 	 */
 	public function manage_sensitive_info( $post ) {
-		$this->container->make( Template\Event::class )->manage_sensitive_info( $post );
+		if ( $this->container->make( Template_Bootstrap::class )->is_single_event() ) {
+			$this->container->make( Template\Event::class )->manage_sensitive_info( $post );
+		}
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Template/Event.php
+++ b/src/Tribe/Views/V2/Template/Event.php
@@ -10,14 +10,37 @@
  */
 namespace Tribe\Events\Views\V2\Template;
 
-use Tribe__Events__Main;
+use Tribe\Events\Collections\Lazy_Post_Collection;
+use Tribe\Events\Views\V2\Template_Bootstrap;
 use Tribe\Events\Views\V2\View;
+use Tribe\Utils\Lazy_String;
+use Tribe\Utils\Post_Thumbnail;
 
 class Event {
 	/**
 	 * @var boolean Whether or not we are currently filtering out content due to password protection
 	 */
 	protected $managing_sensitive_info = false;
+
+	/**
+	 * The current template bootstrap instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Template_Bootstrap
+	 */
+	protected $template_bootstrap;
+
+	/**
+	 * Event constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Template_Bootstrap $template_bootstrap The current template bootstrap instance.
+	 */
+	public function __construct( Template_Bootstrap $template_bootstrap ) {
+		$this->template_bootstrap = $template_bootstrap;
+	}
 
 	/**
 	 * Determines the Path for the PHP file to be used as the main template
@@ -40,7 +63,7 @@ class Event {
 	 *
 	 * @since TBD
 	 *
-	 * @param WP_Post $post
+	 * @param int|\WP_Post $post The post ID or object to filter.
 	 **/
 	public function manage_sensitive_info( $post ) {
 		$password_required = post_password_required( $post );
@@ -54,7 +77,11 @@ class Event {
 			add_filter( 'tribe_get_venue', '__return_empty_string' );
 			add_filter( 'tribe_get_cost', '__return_empty_string' );
 
-			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
+			if ( tribe_context()->doing_ajax() ) {
+				add_filter( 'the_title', [ $this, 'filter_get_the_title' ], 10, 2 );
+			}
+
+			if ( $this->template_bootstrap->is_single_event() ) {
 				add_filter( 'the_title', '__return_empty_string' );
 				add_filter( 'tribe_get_template_part_templates', '__return_empty_array' );
 			}
@@ -69,12 +96,89 @@ class Event {
 			remove_filter( 'tribe_get_venue', '__return_empty_string' );
 			remove_filter( 'tribe_get_cost', '__return_empty_string' );
 
-			if ( is_singular( Tribe__Events__Main::POSTTYPE ) ) {
+			if ( tribe_context()->doing_ajax() ) {
+				remove_filter( 'the_title', [ $this, 'filter_get_the_title' ], 10 );
+			}
+
+			if ( $this->template_bootstrap->is_single_event() ) {
 				remove_filter( 'the_title', '__return_empty_string' );
 				remove_filter( 'tribe_get_template_part_templates', '__return_empty_array' );
 			}
 
 			$this->managing_sensitive_info = false;
 		}
+	}
+
+	/**
+	 * Filters the post title as WordPress does in `get_the_title` to apply the password-protected prefix in
+	 * the context of AJAX requests.
+	 *
+	 * @since TBD
+	 *
+	 * @param string      $title   The post title.
+	 * @param int|\WP_Post $post_id The post ID, or object, to apply the filter for.
+	 *
+	 * @return string The filtered post title.
+	 */
+	public function filter_get_the_title( $title, $post_id = 0 ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof \WP_Post ) {
+			return $title;
+		}
+
+		if ( ! empty( $post->post_password ) ) {
+			/* translators: %s: Protected post title. */
+			$prepend = __( 'Protected: %s' );
+
+			/**
+			 * @see get_the_title() for the original filter documentation.
+			 */
+			$protected_title_format = apply_filters( 'protected_title_format', $prepend, $post );
+			$title                  = sprintf( $protected_title_format, $title );
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Filters and modifies the event WP_Post object returned from the `tribe_get_event` function to hide some
+	 * sensitive information if required.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Post $event The event post object, decorated w/ properties added by the `tribe_get_event` function.
+	 *
+	 * @return \WP_Post The event post object, decorated w/ properties added by the `tribe_get_event` function, some of
+	 *                  them updated to hide sensitive information, if required.
+	 */
+	public function filter_event_properties( \WP_Post $event ) {
+		if ( post_password_required( $event ) ) {
+			$props = [
+				'start_date',
+				'start_date_utc',
+				'end_date',
+				'end_date_utc',
+				'cost',
+				'recurring',
+				'permalink_all',
+			];
+
+			foreach ( $props as $prop ) {
+				$event->{$prop} = '';
+			}
+
+			foreach ( [ 'venues', 'organizers' ] as $lazy_collection ) {
+				$event->{$lazy_collection} = new Lazy_Post_Collection( '__return_empty_array' );
+			}
+
+			foreach ( [ 'plain_schedule_details', 'schedule_details', 'excerpt' ] as $lazy_string ) {
+				$event->{$lazy_string} = new Lazy_String( '__return_empty_string' );
+			}
+
+			$event->thumbnail = new Post_Thumbnail( - 1 );
+		}
+
+		return $event;
 	}
 }

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -11,11 +11,11 @@
 namespace Tribe\Events\Views\V2;
 
 use Tribe__Events__Main as TEC;
+use Tribe__Events__Templates as V1_Event_Templates;
 use Tribe__Notices;
+use Tribe__Templates as V1_Templates;
 use Tribe__Utils__Array as Arr;
 use WP_Query;
-use Tribe__Templates as V1_Templates;
-use Tribe__Events__Templates as V1_Event_Templates;
 
 
 /**
@@ -97,8 +97,7 @@ class Template_Bootstrap {
 	}
 
 	/**
-	 * Detemines wether we are in a Single event page or not,
-	 * base only on global context.
+	 * Determines whether we are in a Single event page or not, base only on global context.
 	 *
 	 * @since  4.9.11
 	 *
@@ -110,9 +109,7 @@ class Template_Bootstrap {
 			'single-event' === tribe_context()->get( 'view' ),
 		];
 
-		$is_single_event = in_array( true, $conditions );
-
-		return $is_single_event;
+		return in_array( true, $conditions, true );
 	}
 
 	/**
@@ -127,6 +124,10 @@ class Template_Bootstrap {
 			Tribe__Notices::set_notice( 'event-past', sprintf( esc_html__( 'This %s has passed.', 'the-events-calendar' ), tribe_get_event_label_singular_lowercase() ) );
 		}
 		$setting = $this->get_template_setting();
+
+		// A number of TEC, and third-party, functions, depend on this. Let's fire it.
+		global $post;
+		do_action( 'the_post', $post );
 
 		ob_start();
 		if ( 'page' === $setting ) {


### PR DESCRIPTION
Tickets: [TEC-2989], [TEC-3033]

This PR:

* fixes some password-protected fields issues I found on V1
* ports over V1 behavior, where possible, on V2

Screencaps:

1. [How it works on v1](https://drive.google.com/open?id=10ViBRIYfMnWzkAQ8YdX6rb9dumcaNwKY&authuser=luca@tri.be&usp=drive_fs); to provide a frame of reference about how it currently works
2. [How it works on v2](https://drive.google.com/open?id=10XwurNb5WbiUinoXLTUx1h4fwoF37o36&authuser=luca@tri.be&usp=drive_fs); the same in v2; there's an exception where the event day still shows (in pretty much all views) due to how v1 and v2 are different in terms of layout and UI building.
3. [How it works on V2 w/ object-caching enabled](https://drive.google.com/open?id=10ZAXQpMJQxQ5jsvBZqV-qzY33I6uXsGE&authuser=luca@tri.be&usp=drive_fs); same as the previous video, but w/ object-caching
4. [Differences between  Month on v1 and v2](https://drive.google.com/open?id=10jAL0rNOE5FUnvSCQx7PYrFdWva0zwae&authuser=luca@tri.be&usp=drive_fs) Month view is a good example of what I meant in point 2: it's not always clear when showing/hiding something is due to how the information is presented or due to a clear behavioral choice.

I think this PR should not be the last to tackle how password-protected events show in V2, yet I think it's a solid first one.
The next one should come after a "tour" of our existing Views and a clear definition, where V1 existing implementation is not a clear guide, of what should show/hide where.

[TEC-2989]: https://moderntribe.atlassian.net/browse/TEC-2989

[TEC-3033]: https://moderntribe.atlassian.net/browse/TEC-3033