### PR TITLE
Fetch checkout at a depth high enough to be able to codesniff | PDTOOLS-67

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -10,7 +10,17 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 100
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
       - uses: moderntribe/action-tribe-phpcs@master
         with:
           github-bot-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
Fetching at a depth of 1 wasn't allowing codesniffing to function due to the number of hashes that were missing for diff purposes.

:ticket: [PDTOOLS-67]

[PDTOOLS-67]: https://moderntribe.atlassian.net/browse/PDTOOLS-67