### PR TITLE
Ensure that pagination-less views show all events

### DIFF
--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -74,29 +74,36 @@ class Event extends Base {
 			 * An event is multi-day if its end date is after the end-of-day cutoff of the start date.
 			 * We add one second to make sure events ending at end-of-day, same day, cutoff are not marked as multi-day.
 			 */
-			$is_multiday = $end_of_day_object->add( $one_second ) < $end_date_object;
-			$multiday    = false;
+			$multiday = false;
+
+			if ( $all_day ) {
+				$start_end_diff = $start_date_object->diff( $end_date_object );
+				$is_multiday    = $start_end_diff->days > 1;
+				$multiday       = $is_multiday ? $start_end_diff->days : false;
+			} else {
+				$is_multiday = $end_of_day_object->add( $one_second ) < $end_date_object;
+
+				// Multi-day events will span at least two days: the day they start on and the following one.
+				if ( $is_multiday ) {
+					/*
+					 * Count the number of cut-offs happening before the end date and add 1.
+					 * Do not add 1 for all-day events as they span cut-off to cut-off.
+					 */
+					$multiday = 1;
+
+					// The end date should be inclusive, since it's not in the DatePeriod we work-around it adding a second.
+					$period = new DatePeriod( $end_of_day_object, $one_day, $end_date_object );
+					foreach ( $period as $date ) {
+						++ $multiday;
+					};
+				}
+			}
 
 			// Without a context these values will not make sense; we'll set them if the `$filter` argument is a date.
 			$starts_this_week   = null;
 			$ends_this_week     = null;
 			$happens_this_week  = null;
 			$this_week_duration = null;
-
-			// Multi-day events will span at least two days: the day they start on and the following one.
-			if ( $is_multiday ) {
-				/*
-				 * Count the number of cut-offs happening before the end date and add 1.
-				 * Do not add 1 for all-day events as they span cut-off to cut-off.
-				 */
-				$multiday = $all_day ? 0 : 1;
-
-				// The end date should be inclusive, since it's not in the DatePeriod we work-around it adding a second.
-				$period = new DatePeriod( $end_of_day_object, $one_day, $end_date_object );
-				foreach ( $period as $date ) {
-					++ $multiday;
-				};
-			}
 
 			if ( Dates::is_valid_date( $filter ) ) {
 				list( $week_start, $week_end ) = Dates::get_week_start_end( $filter );

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -95,7 +95,7 @@ class Event extends Base {
 					$period = new DatePeriod( $end_of_day_object, $one_day, $end_date_object );
 					foreach ( $period as $date ) {
 						++ $multiday;
-					};
+					}
 				}
 			}
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1274,7 +1274,6 @@ class View implements View_Interface {
 
 		$events = (array) $this->repository->all();
 
-		// are we paginating
 		$is_paginated = isset( $this->repository_args['posts_per_page'] ) && -1 !== $this->repository_args['posts_per_page'];
 
 		/*

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1274,6 +1274,9 @@ class View implements View_Interface {
 
 		$events = (array) $this->repository->all();
 
+		// are we paginating
+		$is_paginated = isset( $this->repository_args['posts_per_page'] ) && -1 !== $this->repository_args['posts_per_page'];
+
 		/*
 		 * To optimize the determination of whether there are future events, we
 		 * increased events_per_page by +1 during setup_repository_args. Because of that
@@ -1282,7 +1285,7 @@ class View implements View_Interface {
 		 *
 		 * @since 5.0.0
 		 */
-		if ( $this->has_next_event( $events ) ) {
+		if ( $is_paginated && $this->has_next_event( $events ) ) {
 			array_pop( $events );
 		}
 

--- a/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
+++ b/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
@@ -92,7 +92,7 @@ trait List_Behavior {
 			}
 			$end = $last_event instanceof \WP_Post ? $last_event->dates->start_display : $user_date;
 
-			// never let the start of the range be lower than the top bar date
+			// Never let the start of the range be lower than the top bar date.
 			if ( $start < $user_date ) {
 				$start = $user_date;
 			}
@@ -101,7 +101,7 @@ trait List_Behavior {
 			$end   = $last_event instanceof \WP_Post ? $last_event->dates->start_display : $user_date;
 		}
 
-		// never let the start of the range exceed the start
+		// Never let the start of the range exceed the start.
 		if ( $start > $end ) {
 			$end = $user_date;
 		}

--- a/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
+++ b/src/Tribe/Views/V2/Views/Traits/List_Behavior.php
@@ -91,9 +91,19 @@ trait List_Behavior {
 				$start = $first_event instanceof \WP_Post ? $first_event->dates->start_display : $user_date;
 			}
 			$end = $last_event instanceof \WP_Post ? $last_event->dates->start_display : $user_date;
+
+			// never let the start of the range be lower than the top bar date
+			if ( $start < $user_date ) {
+				$start = $user_date;
+			}
 		} else {
 			$start = $first_event instanceof \WP_Post ? $first_event->dates->start_display : $user_date;
 			$end   = $last_event instanceof \WP_Post ? $last_event->dates->start_display : $user_date;
+		}
+
+		// never let the start of the range exceed the start
+		if ( $start > $end ) {
+			$end = $user_date;
 		}
 
 		$is_first_past_page = $is_past && 1 === $page;


### PR DESCRIPTION
This PR actually tackles three things.

1. On the views where the posts_per_page is -1, we shouldn't pop off an event
1. When navigating forward and backward in list views, the datepicker's date range was jumping around based on the start date of the first event in the list. That shouldn't always happen. Now, if we are on a page > 0 while navigating _forward_ in time (not a past pagination), we will defer to the top bar's date rather than the first event.
1. Update the multiday calculation logic to work with all day events and not be a slave to timezones.

:movie_camera: http://p.tri.be/1W9h5D

:ticket: [TEC-3154]

[TEC-3154]: https://moderntribe.atlassian.net/browse/TEC-3154