### PR TITLE
Filter the today_url like we filter prev/next

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1450,6 +1450,8 @@ class View implements View_Interface {
 		// Handle the `eventDisplay` query arg due to its particular usage to indicate the mode too.
 		$query_args['eventDisplay'] = $this->slug;
 
+		$query_args = $this->filter_query_args( $query_args, $canonical );
+
 		$ugly_url = add_query_arg( $query_args, $this->get_url( false ) );
 		$ugly_url = remove_query_arg( $to_remove, $ugly_url );
 


### PR DESCRIPTION
Adding the filtering of query args will allow filters to be properly injected and removed.

:movie_camera: http://p.tri.be/oF2nQk

:ticket: [FBAR-64]

[FBAR-64]: https://moderntribe.atlassian.net/browse/FBAR-64