### PR TITLE
Adjust the structure of next/prev URLs so they can be properly tested

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,12 +9,12 @@
 	<rule ref="WordPress-Core"></rule>
 	<rule ref="TribalScents"></rule>
 
+	<rule ref="Generic">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule>
+
 	<!--exclude the rule for violation of direct DB calls as some have no alternative-->
 	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<exclude-pattern>src/Test.php</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,4 +13,8 @@
 	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<exclude-pattern>src/Test.php</exclude-pattern>
 	</rule>
+
+	<rule ref="Generic">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	</rule>
 </ruleset>

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -755,17 +755,22 @@ class View implements View_Interface {
 
 		$url = $this->get_url();
 
+		$query_args = [];
+
 		if ( ! empty( $passthru_vars ) ) {
 			// Remove the pass-thru vars, we'll re-apply them to the URL later.
 			$url = remove_query_arg( array_keys( $passthru_vars ), $url );
 		}
 
 		// Make sure the view slug is always set to correctly match rewrites.
-		$url = add_query_arg( [ 'eventDisplay' => $this->slug ], $url );
+		$query_args['eventDisplay'] = $this->slug;
 
-		$url = $this->has_next_event ?
-			add_query_arg( [ $this->page_key => $this->url->get_current_page() + 1 ], $url )
-			: '';
+		if ( $this->has_next_event ) {
+			$query_args[ $this->page_key ] = $this->url->get_current_page() + 1;
+		} else {
+			$query_args = [];
+			$url        = '';
+		}
 
 		if ( ! empty( $url ) && $canonical ) {
 			$url = tribe( 'events.rewrite' )->get_clean_url( $url );
@@ -773,7 +778,14 @@ class View implements View_Interface {
 
 		if ( ! empty( $passthru_vars ) && ! empty( $url ) ) {
 			// Re-apply the pass-thru query arguments.
-			$url = add_query_arg( $passthru_vars, $url );
+			$query_args = array_merge( $query_args, $passthru_vars );
+		}
+
+		$query_args = $this->filter_query_args( $query_args, $url );
+		$query_args = array_filter( $query_args );
+
+		if ( ! empty( $url ) || ! empty( $query_args ) ) {
+			$url = add_query_arg( $query_args, $url );
 		}
 
 		$url = $this->filter_next_url( $canonical, $url );
@@ -793,8 +805,9 @@ class View implements View_Interface {
 
 		$prev_page  = $this->repository->prev()->order_by( '__none' );
 
-		$paged      = $this->url->get_current_page() - 1;
-		$query_args = $paged > 1
+		$paged           = $this->url->get_current_page() - 1;
+		$query_args      = [];
+		$page_query_args = $paged > 1
 			? [ $this->page_key => $paged ]
 			: [];
 
@@ -806,12 +819,18 @@ class View implements View_Interface {
 		}
 
 		// Make sure the view slug is always set to correctly match rewrites.
-		$url = add_query_arg( [ 'eventDisplay' => $this->slug ], $url );
+		$query_args['eventDisplay'] = $this->slug;
 
-		$url = $prev_page->count() > 0 ? add_query_arg( $query_args, $url ) : '';
+		if ( $prev_page->count() > 0 ) {
+			$query_args = array_merge( $query_args, $page_query_args );
+		} else {
+			$query_args = [];
+			$url        = '';
+		}
 
 		if ( ! empty( $url ) && $paged === 1 ) {
 			$url = remove_query_arg( $this->page_key, $url );
+			unset( $query_args[ $this->page_key ] );
 		}
 
 		if ( ! empty( $url ) && $canonical ) {
@@ -820,7 +839,14 @@ class View implements View_Interface {
 
 		if ( ! empty( $passthru_vars ) && ! empty( $url ) ) {
 			// Re-apply the pass-thru query arguments.
-			$url = add_query_arg( $passthru_vars, $url );
+			$query_args = array_merge( $query_args, $passthru_vars );
+		}
+
+		$query_args = $this->filter_query_args( $query_args, $url );
+		$query_args = array_filter( $query_args );
+
+		if ( ! empty( $url ) || ! empty( $query_args ) ) {
+			$url = add_query_arg( $query_args, $url );
 		}
 
 		$url = $this->filter_prev_url( $canonical, $url );

--- a/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
@@ -214,15 +214,15 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 		} );
 		$events = static::factory()->event->create_many( 3 );
 
-		$page_1_view = View::make( 'test' );
-		$page_1_view->setup_the_loop( [ 'paged' => 2, 'posts_per_page' => 2, 'starts_after' => 'now' ] );
-
-		$this->assertEquals( home_url() . "?post_type=tribe_events&eventDisplay=test", $page_1_view->prev_url() );
-
 		$page_2_view = View::make( 'test' );
-		$page_2_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
+		$page_2_view->setup_the_loop( [ 'paged' => 2, 'posts_per_page' => 2, 'starts_after' => 'now' ] );
 
-		$this->assertEquals( '', $page_2_view->prev_url() );
+		$this->assertEquals( home_url() . "?post_type=tribe_events&eventDisplay=test", $page_2_view->prev_url() );
+
+		$page_1_view = View::make( 'test' );
+		$page_1_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
+
+		$this->assertEquals( '', $page_1_view->prev_url() );
 	}
 
 	/**
@@ -236,15 +236,15 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 		} );
 		$events = static::factory()->event->create_many( 3 );
 
-		$page_1_view = View::make( 'test' );
-		$page_1_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now', 'paged' => 2 ] );
-
-		$this->assertEquals( home_url() . '?post_type=tribe_events&eventDisplay=test', $page_1_view->prev_url() );
-
 		$page_2_view = View::make( 'test' );
-		$page_2_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
+		$page_2_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now', 'paged' => 2 ] );
 
-		$this->assertEquals( '', $page_2_view->prev_url() );
+		$this->assertEquals( home_url() . '?post_type=tribe_events&eventDisplay=test', $page_2_view->prev_url() );
+
+		$page_1_view = View::make( 'test' );
+		$page_1_view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
+
+		$this->assertEquals( '', $page_1_view->prev_url() );
 	}
 
 	public function wpSetUpBeforeClass() {


### PR DESCRIPTION
The structure of the next/prev URLs in View were such that tests around the filterability of the query arguments would fail. The slight restructure moves the query arguments to an array that gets filtered rather than adding/removing from the url over and over.

Related: https://github.com/moderntribe/events-filterbar/pull/228

:movie_camera: http://p.tri.be/cXR0UB

:ticket: [FBAR-64] (sorta related)

[FBAR-64]: https://moderntribe.atlassian.net/browse/FBAR-64