### PR TITLE
refactor(By_Day_View.php) use overlap logic for day filtering

### DIFF
--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -254,14 +254,13 @@ abstract class By_Day_View extends View {
 				$start = tribe_beginning_of_day( $day->format( Dates::DBDATETIMEFORMAT ) );
 				$end   = tribe_end_of_day( $day->format( Dates::DBDATETIMEFORMAT ) );
 
-				$results_in_day = array_filter( $day_results, static function( $event ) use ( $start, $end ) {
-					return (
-						( $start >= $event->start_date && $end <= $event->end_date )
-						|| ( $start >= $event->start_date && $start <= $event->end_date && $end >= $event->end_date )
-						|| ( $start < $event->start_date && $end >= $event->end_date )
-						|| ( $start < $event->start_date && $end <= $event->end_date && $end >= $event->start_date )
-					);
-				} );
+				// Events overlap a day if Event start date <= Day End AND Event end date >= Day Start.
+				$results_in_day = array_filter(
+					$day_results,
+					static function ( $event ) use ( $start, $end ) {
+						return $event->start_date <= $end && $event->end_date >= $start;
+					}
+				);
 
 				$day_event_ids = array_map( 'absint', array_column( $results_in_day, 'ID' ) );
 				$day_event_ids = array_slice( $day_event_ids, 0, $events_per_day );


### PR DESCRIPTION
Ticket: n/a

This is a small refactoring of the `By_Day_View.php` code that filters the events to detect if those are happening on a given day or not.  
Applying the same logic used in other parts of the code, this is an "overlaps" check: the event overlaps the date if event start lte day end and event end gte day start.