### PR TITLE
fix(Month_View.php) is_start_of_week var

### DIFF
--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -351,7 +351,7 @@ class Month_View extends By_Day_View {
 
 			$day_data = [
 				'date'             => $day_date,
-				'is_start_of_week' => $start_of_week === $date_object->format( 'w' ),
+				'is_start_of_week' => (int) $start_of_week === (int) $date_object->format( 'w' ),
 				'year_number'      => $date_object->format( 'Y' ),
 				'month_number'     => $date_object->format( 'm' ),
 				'day_number'       => $date_object->format( 'j' ),

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -346,12 +346,13 @@ class Month_View extends By_Day_View {
 			);
 
 			$start_of_week = get_option( 'start_of_week', 0 );
+			$is_start_of_week = (int)$start_of_week === (int)$date_object->format( 'w' );
 
 			$day_url = tribe_events_get_url( [ 'eventDisplay' => 'day', 'eventDate' => $day_date ] );
 
-			$day_data = [
+			$day_data         = [
 				'date'             => $day_date,
-				'is_start_of_week' => (int) $start_of_week === (int) $date_object->format( 'w' ),
+				'is_start_of_week' => $is_start_of_week,
 				'year_number'      => $date_object->format( 'Y' ),
 				'month_number'     => $date_object->format( 'm' ),
 				'day_number'       => $date_object->format( 'j' ),


### PR DESCRIPTION
Ticket: n/a

This PR fixes an issue where the Month View would not correctly display events overlapping the start of the week.

[Screencap](https://drive.google.com/open?id=10qAp97sSGc6Fg9YJ2ncprSGrtXcJx-Ng&authuser=luca@tri.be&usp=drive_fs)