### PR TITLE
fix(src) filter out empty value from Org/Venue fetch callback

### DIFF
--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -640,7 +640,9 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 		}
 
 		return static function () use ( $event ) {
-			$organizer_ids = array_map( 'absint', (array) get_post_meta( $event, '_EventOrganizerID' ) );
+			$organizer_ids = array_filter(
+				array_map( 'absint', (array) get_post_meta( $event, '_EventOrganizerID' ) )
+			);
 
 			$organizers    = ! empty( $organizer_ids )
 				? array_map( 'tribe_get_organizer', $organizer_ids )

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -641,7 +641,10 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 
 		return static function () use ( $event ) {
 			$organizer_ids = array_filter(
-				array_map( 'absint', (array) get_post_meta( $event, '_EventOrganizerID' ) )
+				array_map(
+					'absint',
+					(array)get_post_meta( $event, '_EventOrganizerID' )
+				)
 			);
 
 			$organizers    = ! empty( $organizer_ids )

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -643,7 +643,7 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 			$organizer_ids = array_filter(
 				array_map(
 					'absint',
-					(array)get_post_meta( $event, '_EventOrganizerID' )
+					(array) get_post_meta( $event, '_EventOrganizerID' )
 				)
 			);
 

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -698,7 +698,9 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 		}
 
 		return static function () use ( $event ) {
-			$venue_ids = array_map( 'absint', (array) get_post_meta( $event, '_EventVenueID' ) );
+			$venue_ids = array_filter(
+				array_map( 'absint', (array) get_post_meta( $event, '_EventVenueID' ) )
+			);
 
 			$venues    = ! empty( $venue_ids )
 				? array_map( 'tribe_get_venue_object', $venue_ids )

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -699,7 +699,10 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 
 		return static function () use ( $event ) {
 			$venue_ids = array_filter(
-				array_map( 'absint', (array) get_post_meta( $event, '_EventVenueID' ) )
+				array_map(
+					'absint',
+					(array)get_post_meta( $event, '_EventVenueID' )
+				)
 			);
 
 			$venues    = ! empty( $venue_ids )

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -701,7 +701,7 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base {
 			$venue_ids = array_filter(
 				array_map(
 					'absint',
-					(array)get_post_meta( $event, '_EventVenueID' )
+					(array) get_post_meta( $event, '_EventVenueID' )
 				)
 			);
 


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/TEC-3165

[Screencap](https://drive.google.com/open?id=10tqy3dht8raSJCio_m2PBtF8LL4Wcwld&authuser=luca@tri.be&usp=drive_fs)

This PR fixes an issue generated by the way block editor saves the linked post data for Venue and Organizer: the fix is to `array_filter` the Venue and Organizer IDs during in the lazy collection call-backs to drop the `0` value added by block editor.