### PR TITLE
fix(Month/Week View) cache w/ private/protected posts

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="The Events Calendar Coding Standards">
+	<rule ref="TribalScents"></rule>
 	<rule ref="WordPress-VIP-Go"></rule>
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName"/>
@@ -7,7 +8,6 @@
 	<rule ref="WordPress-Extra"></rule>
 	<rule ref="WordPress-Docs"></rule>
 	<rule ref="WordPress-Core"></rule>
-	<rule ref="TribalScents"></rule>
 
 	<rule ref="Generic">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -555,7 +555,10 @@ class View implements View_Interface {
 		$this->repository_args = $repository_args;
 
 		// If HTML_Cache is a class trait and we have content to display, display it.
-		if ( method_exists( $this, 'maybe_get_cached_html' ) && $cached_html = $this->maybe_get_cached_html() ) {
+		if (
+			method_exists( $this, 'maybe_get_cached_html' )
+			&& $cached_html = $this->maybe_get_cached_html()
+		) {
 			return $cached_html;
 		}
 

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -350,7 +350,7 @@ class Month_View extends By_Day_View {
 
 			$day_url = tribe_events_get_url( [ 'eventDisplay' => 'day', 'eventDate' => $day_date ] );
 
-			$day_data         = [
+			$day_data = [
 				'date'             => $day_date,
 				'is_start_of_week' => $is_start_of_week,
 				'year_number'      => $date_object->format( 'Y' ),

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -346,7 +346,7 @@ class Month_View extends By_Day_View {
 			);
 
 			$start_of_week = get_option( 'start_of_week', 0 );
-			$is_start_of_week = (int)$start_of_week === (int)$date_object->format( 'w' );
+			$is_start_of_week = (int) $start_of_week === (int) $date_object->format( 'w' );
 
 			$day_url = tribe_events_get_url( [ 'eventDisplay' => 'day', 'eventDate' => $day_date ] );
 

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -346,12 +346,13 @@ class Month_View extends By_Day_View {
 			);
 
 			$start_of_week = get_option( 'start_of_week', 0 );
+			$is_start_of_week = (int)$start_of_week === (int)$date_object->format( 'w' );
 
 			$day_url = tribe_events_get_url( [ 'eventDisplay' => 'day', 'eventDate' => $day_date ] );
 
-			$day_data = [
+			$day_data         = [
 				'date'             => $day_date,
-				'is_start_of_week' => $start_of_week === $date_object->format( 'w' ),
+				'is_start_of_week' => $is_start_of_week,
 				'year_number'      => $date_object->format( 'Y' ),
 				'month_number'     => $date_object->format( 'm' ),
 				'day_number'       => $date_object->format( 'j' ),

--- a/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
+++ b/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
@@ -9,10 +9,10 @@
 
 namespace Tribe\Events\Views\V2\Views\Traits;
 
+use Tribe__Cache as Cache;
 use Tribe__Cache_Listener as Cache_Listener;
 use Tribe__Context as Context;
 use Tribe__Date_Utils as Dates;
-use Tribe\Events\Views\V2\View;
 
 /**
  * Trait HTML_Cache
@@ -29,12 +29,13 @@ trait HTML_Cache {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return null|string
+	 * @return false|string Either the cached HTML contents, or `false` if the View HTML should not be cached or is not
+	 *                      cached yet.
 	 */
 	public function maybe_get_cached_html() {
 
 		if ( ! $this->should_cache_html() ) {
-			return;
+			return false;
 		}
 
 		$cache_key = $this->get_cache_html_key();
@@ -42,7 +43,7 @@ trait HTML_Cache {
 		$cached_html = tribe( 'cache' )->get_transient( $cache_key, $this->cache_html_triggers() );
 
 		if ( ! $cached_html ) {
-			return;
+			return false;
 		}
 
 		$cached_html = $this->inject_nonces_into_cached_html( $cached_html );
@@ -57,37 +58,46 @@ trait HTML_Cache {
 	 *
 	 * @param string $html HTML markup for view.
 	 *
-	 * @return boolean     If we successfully cached on the transient.
+	 * @return boolean     Whether we successfully cached the View HTML or not.
 	 */
 	public function maybe_cache_html( $html ) {
-		/**
-		 * Filter the cache TTL
-		 *
-		 * @since 5.0.0
-		 *
-		 * @param int      $cache_ttl Cache time to live.
-		 * @param Context  $context   The View current context.
-		 * @param View     $this      The current View instance.
-		 */
-		$cache_expiration = apply_filters( 'tribe_events_views_v2_cache_html_expiration', DAY_IN_SECONDS, $this->get_context(), $this );
-
-		$cache_key = $this->get_cache_html_key();
-
 		if ( ! $this->should_cache_html() ) {
 			return false;
 		}
 
+		/**
+		 * Filter the cache TTL.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param int        $cache_ttl Cache time to live.
+		 * @param Context    $context   The View current context.
+		 * @param HTML_Cache $this      The object using the trait.
+		 */
+		$cache_expiration = apply_filters(
+			'tribe_events_views_v2_cache_html_expiration',
+			DAY_IN_SECONDS,
+			$this->get_context(),
+			$this
+		);
+
+		$cache_key = $this->get_cache_html_key();
+
 		$html = $this->extract_nonces_before_cache( $html );
 
-		return tribe( 'cache' )->set_transient( $cache_key, $html, $cache_expiration, $this->cache_html_triggers() );
+		/** @var Cache $cache */
+		$cache = tribe( 'cache' );
+
+		return $cache->set_transient( $cache_key, $html, $cache_expiration, $this->cache_html_triggers() );
 	}
 
 	/**
-	 * Fetch the HTML cache triggers.
+	 * Fetch the HTML cache invalidation triggers.
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return array
+	 * @return array A list of the triggers, `Tribe__Cache_Listener` constants, that should be used to set the HTML
+	 *               cache invalidation conditions.
 	 */
 	protected function cache_html_triggers() {
 		return [
@@ -102,7 +112,7 @@ trait HTML_Cache {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return bool
+	 * @return bool Whether the View HTML should be cached or not.
 	 */
 	public function should_cache_html() {
 		$context = $this->get_context();
@@ -119,9 +129,9 @@ trait HTML_Cache {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param bool    $should_cache_html Should the current view have its HTML cached?
-		 * @param Context $context           The View current context.
-		 * @param View    $this              The current View instance.
+		 * @param bool       $should_cache_html Should the current view have its HTML cached?
+		 * @param Context    $context           The View current context.
+		 * @param HTML_Cache $this              The object using the trait.
 		 */
 		return (bool) apply_filters( 'tribe_events_views_v2_should_cache_html', $should_cache, $context, $this );
 	}
@@ -131,9 +141,10 @@ trait HTML_Cache {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return bool
+	 * @return string The cache key that should be used to retrieve the the HTML cache.
 	 */
 	public function get_cache_html_key() {
+		/** @var Context $context */
 		$context = $this->get_context();
 		$args    = $context->to_array();
 
@@ -146,9 +157,9 @@ trait HTML_Cache {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param string  $cache_html_key Cache HTML key.
-		 * @param Context $context        The View current context.
-		 * @param View    $this           The current View instance.
+		 * @param string     $cache_html_key Cache HTML key.
+		 * @param Context    $context        The View current context.
+		 * @param HTML_Cache $this           The object using the trait.
 		 */
 		return apply_filters( 'tribe_events_views_v2_cache_html_key', $cache_key, $context, $this );
 	}
@@ -218,9 +229,9 @@ trait HTML_Cache {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param array   $nonces   List of action and field name where the nonce is stored.
-		 * @param Context $context  Context from the current view.
-		 * @param View    $view     Which view instance we are currently rendering.
+		 * @param array      $nonces  List of action and field name where the nonce is stored.
+		 * @param Context    $context Context from the current view.
+		 * @param HTML_Cache $this    The object using the trait.
 		 */
 		return apply_filters( 'tribe_events_views_v2_get_view_nonce_fields', $nonces, $this->get_context(), $this );
 	}
@@ -242,9 +253,9 @@ trait HTML_Cache {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param array   $nonces   List of action and field name where the nonce is stored.
-		 * @param Context $context  Context from the current view.
-		 * @param View    $view     Which view instance we are currently rendering.
+		 * @param array      $nonces  List of action and field name where the nonce is stored.
+		 * @param Context    $context Context from the current view.
+		 * @param HTML_Cache $this    The object using the trait.
 		 */
 		return apply_filters( 'tribe_events_views_v2_get_view_nonce_attributes', $nonces, $this->get_context(), $this );
 	}
@@ -266,9 +277,9 @@ trait HTML_Cache {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param array   $nonces   List of action and field name where the nonce is stored.
-		 * @param Context $context  Context from the current view.
-		 * @param View    $view     Which view instance we are currently rendering.
+		 * @param array      $nonces  List of action and field name where the nonce is stored.
+		 * @param Context    $context Context from the current view.
+		 * @param HTML_Cache $this    The object using the trait.
 		 */
 		return apply_filters( 'tribe_events_views_v2_get_view_nonce_json_properties', $nonces, $this->get_context(), $this );
 	}

--- a/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
+++ b/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
@@ -378,7 +378,7 @@ trait HTML_Cache {
 	 *
 	 * @return int The number of events in the database that have a `post_status` of `private`.
 	 */
-	protected function get_private_events_count(){
+	protected function get_private_events_count() {
 		/** @var \Tribe__Cache $cache */
 		$cache     = tribe( 'cache' );
 		$cache_key = 'tribe_views_v2_cache_private_events_count';
@@ -397,7 +397,7 @@ trait HTML_Cache {
 			$cache->set( $cache_key, $count, WEEK_IN_SECONDS, Cache_Listener::TRIGGER_SAVE_POST );
 		}
 
-		return max( 0, (int)$count );
+		return max( 0, (int) $count );
 	}
 
 	/**
@@ -431,7 +431,7 @@ trait HTML_Cache {
 			$cache->set( $cache_key, $count, WEEK_IN_SECONDS, Cache_Listener::TRIGGER_SAVE_POST );
 		}
 
-		return max( (int)$count, 0 );
+		return max( (int) $count, 0 );
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/HTML_CacheTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/HTML_CacheTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tribe\Events\Views\V2\Views\Traits;
+
+use Tribe\Events\Test\Factories\Event;
+use Tribe\Events\Views\V2\View;
+
+class HTML_CacheTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @var HTML_Cache
+	 */
+	protected $implementation;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::factory()->event = new Event();
+	}
+
+	public function setUp() {
+		parent::setUp();
+		$this->implementation = new class extends View {
+			protected $slug = 'month';
+
+			use HTML_Cache;
+		};
+
+		// Kill straggler events that might be created due to SQL execution delay.
+		while ( tribe_events()->found() ) {
+			tribe_events()->delete();
+		}
+	}
+
+	/**
+	 * It should cache HTML if user is not logged in and there are no pwd-protected events
+	 *
+	 * @test
+	 */
+	public function should_cache_html_if_user_is_not_logged_in_and_there_are_no_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		wp_set_current_user( 0 );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+		$cache_key_salts   = $this->implementation->get_cache_html_key_salts();
+
+		$this->assertTrue( $should_cache_html );
+		$this->assertEqualSets( $cache_key_salts, [ 'current_user_can_read_private_posts' => false ] );
+	}
+
+	/**
+	 * It should not cache HTML if user is not logged in and there are pwd-protected events
+	 *
+	 * @test
+	 */
+	public function should_not_cache_html_if_user_is_not_logged_in_and_there_are_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		static::factory()->event->create( [ 'post_status' => 'publish', 'post_password' => 'secret' ] );
+		wp_set_current_user( 0 );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+
+		$this->assertFalse( $should_cache_html );
+	}
+
+	/**
+	 * It should cache if user is logged in, cannot read private posts, and there are no pwd-protected events
+	 *
+	 * @test
+	 */
+	public function should_cache_if_user_is_logged_in_cannot_read_private_posts_and_there_are_no_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		$subscriber = static::factory()->user->create(['role' => 'subscriber']);
+		wp_set_current_user( $subscriber );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+		$cache_key_salts   = $this->implementation->get_cache_html_key_salts();
+
+		$this->assertTrue( $should_cache_html );
+		$this->assertEqualSets( $cache_key_salts, [ 'current_user_can_read_private_posts' => false ] );
+	}
+
+	/**
+	 * It should not cache if user is logged in, cannot read private posts, and there are pwd-protected events
+	 *
+	 * @test
+	 */
+	public function should_not_cache_if_user_is_logged_in_cannot_read_private_posts_and_there_are_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		static::factory()->event->create( [ 'post_status' => 'publish', 'post_password' => 'secret' ] );
+		$subscriber = static::factory()->user->create(['role' => 'subscriber']);
+		wp_set_current_user( $subscriber );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+
+		$this->assertFalse( $should_cache_html );
+	}
+
+	/**
+	 * It should cache if user is logged in, can read private posts, and there are no pwd-protected-events
+	 *
+	 * @test
+	 */
+	public function should_cache_if_user_is_logged_in_can_read_private_posts_and_there_are_no_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		$administrator = static::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user( $administrator );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+		$cache_key_salts   = $this->implementation->get_cache_html_key_salts();
+
+		$this->assertTrue( $should_cache_html );
+		$this->assertEqualSets( $cache_key_salts, [ 'current_user_can_read_private_posts' => true ] );
+	}
+
+	/**
+	 * It should not cache if user is logged in, can read private posts, and there are pwd-protected events
+	 *
+	 * @test
+	 */
+	public function should_not_cache_if_user_is_logged_in_can_read_private_posts_and_there_are_pwd_protected_events() {
+		static::factory()->event->create( [ 'post_status' => 'publish' ] );
+		static::factory()->event->create( [ 'post_status' => 'private' ] );
+		static::factory()->event->create( [ 'post_status' => 'publish', 'post_password' => 'secret' ] );
+		$administrator = static::factory()->user->create(['role' => 'administrator']);
+		wp_set_current_user( $administrator );
+
+		$should_cache_html = $this->implementation->should_cache_html();
+
+		$this->assertFalse( $should_cache_html );
+	}
+}


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/projects/TEC/issues/TEC-3149

[Screencap](https://drive.google.com/open?id=10yValZTXe7gwIxhTDOICXRbyIhUIorix&authuser=luca@tri.be&usp=drive_fs)

This PR updates the cache system for V2, V1 will be handled in another PR when this is merged, to correctly handle private and password-protected events.

I've slightly modified the logic that @borkweb proposed to this:

1. if there are no password-protected events then cache the HTML in two versions: one for users that can read private posts, one for users that cannot read private posts
2. if there are password-protectec events, then do not cache.

Point 2 is due to the fact that password-protected events have to be checked one-by-one to see if the user (logged in or not) can see all their details.
I've not used the "is user logged in" condition to cache or not as users might be not logged in and yet be able to access passsword-protected events.