### PR TITLE
Switch calls from tribe_[set|get]_var to tribe( 'cache' )

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2617,11 +2617,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Append Events structure
 			$slug = _x( Tribe__Settings_Manager::get_option( 'eventsSlug', 'events' ), 'Archive Events Slug', 'the-events-calendar' );
 
-			$cache_event_url_slugs = tribe_get_var( $cache_var_name, [] );
+			$cache_event_url_slugs = tribe( 'cache' )->get( $cache_var_name, '', [] );
 
 			if ( ! isset( $cache_event_url_slugs[ $slug ] ) ) {
 				$cache_event_url_slugs[ $slug ] = trailingslashit( sanitize_title( $slug ) );
-				tribe_set_var( $cache_var_name, $cache_event_url_slugs );
+				tribe( 'cache' )->set( $cache_var_name, $cache_event_url_slugs, Tribe__Cache::NON_PERSISTENT );
 			}
 
 			$event_url .= $cache_event_url_slugs[ $slug ];
@@ -3814,7 +3814,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public function isVenue( $postId = null ) {
 			static $cache_var_name = __METHOD__;
 
-			$is_venue = tribe_get_var( $cache_var_name, [] );
+			$is_venue = tribe( 'cache' )->get( $cache_var_name, '', [] );
 
 			if ( $postId === null || ! is_numeric( $postId ) ) {
 				global $post;
@@ -3834,7 +3834,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$is_venue[ $postId ] = false;
 			}
 
-			tribe_set_var( $cache_var_name, $is_venue );
+			tribe( 'cache' )->set( $cache_var_name, $is_venue, Tribe__Cache::NON_PERSISTENT );
+
 			return $is_venue[ $postId ];
 		}
 
@@ -3848,7 +3849,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public function isOrganizer( $postId = null ) {
 			static $cache_var_name = __METHOD__;
 
-			$is_organizer = tribe_get_var( $cache_var_name, [] );
+			$is_organizer = tribe( 'cache' )->get( $cache_var_name, '', [] );
 
 			if ( $postId === null || ! is_numeric( $postId ) ) {
 				global $post;
@@ -3868,7 +3869,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$is_organizer[ $postId ] = false;
 			}
 
-			tribe_set_var( $cache_var_name, $is_organizer );
+			tribe( 'cache' )->set( $cache_var_name, $is_organizer, Tribe__Cache::NON_PERSISTENT );
 
 			return $is_organizer[ $postId ];
 		}

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -133,7 +133,7 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 	protected static function get_event_timestamp( $event_id, $type = 'Start', $timezone = null ) {
 		static $cache_var_name = __METHOD__;
 
-		$timestamps = tribe_get_var( $cache_var_name, [] );
+		$timestamps = tribe( 'cache' )->get( $cache_var_name, '', [] );
 
 		$cache_key = "{$event_id}:{$type}:{$timezone}";
 
@@ -176,7 +176,7 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 		$localized = self::to_tz( $datetime, $tzstring );
 		$timestamps[ $cache_key ] = strtotime( $localized );
 
-		tribe_set_var( $cache_var_name, $timestamps );
+		tribe( 'cache' )->set( $cache_var_name, $timestamps, Tribe__Cache::NON_PERSISTENT );
 
 		return $timestamps[ $cache_key ];
 	}

--- a/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
+++ b/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
@@ -9,6 +9,7 @@
 
 namespace Tribe\Events\Views\V2\Views\Traits;
 
+use Tribe__Cache as Cache;
 use Tribe__Cache_Listener as Cache_Listener;
 use Tribe__Context as Context;
 use Tribe__Date_Utils as Dates;
@@ -339,11 +340,11 @@ trait HTML_Cache {
 	 * @return string  Nonce based on action passed.
 	 */
 	protected function maybe_generate_nonce( $action ) {
-		$generated_nonces = tribe_get_var( __METHOD__, [] );
+		$generated_nonces = tribe( 'cache' )->get( __METHOD__, '', [] );
 
 		if ( ! isset( $generated_nonces[ $action ] ) ) {
 			$generated_nonces[ $action ] = wp_create_nonce( $action );
-			tribe_set_var( __METHOD__, $generated_nonces );
+			tribe( 'cache' )->set( __METHOD__, $generated_nonces, Cache::NON_PERSISTENT );
 		}
 
 		return $generated_nonces[ $action ];

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1053,7 +1053,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			return '';
 		}
 
-		$cache_details = tribe_get_var( $cache_var_name, [] );
+		$cache_details = tribe( 'cache' )->get( $cache_var_name, '', [] );
 		$cache_details_key    = "{$event->ID}:{$before}:{$after}:{$html}";
 
 		if ( ! isset( $cache_details[ $cache_details_key ] ) ) {
@@ -1145,7 +1145,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$inner .= $html ? '</span>' : '';
 
 			$cache_details[ $cache_details_key ] = $inner;
-			tribe_set_var( $cache_var_name, $cache_details );
+
+			tribe( 'cache' )->set( $cache_var_name, $cache_details, Tribe__Cache::NON_PERSISTENT );
 		}
 
 		/**
@@ -1465,7 +1466,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	function tribe_events_get_the_excerpt( $post = null, $allowed_html = null, $skip_postdata_manipulation = false ) {
 		static $cache_var_name = __FUNCTION__;
 
-		$cache_excerpts = tribe_get_var( $cache_var_name, [] );
+		$cache_excerpts = tribe( 'cache' )->get( $cache_var_name, '', [] );
 
 		// If post is not numeric or instance of WP_Post it defaults to the current Post ID
 		if ( ! is_numeric( $post ) && ! $post instanceof WP_Post ) {
@@ -1586,7 +1587,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			$cache_excerpts[ $cache_excerpts_key ] = wpautop( $excerpt );
-			tribe_set_var( $cache_var_name, $cache_excerpts );
+
+			tribe( 'cache' )->set( $cache_var_name, $cache_excerpts, Tribe__Cache::NON_PERSISTENT );
 		}
 
 		if ( ! $skip_postdata_manipulation ) {


### PR DESCRIPTION
This essentially does the same thing behind the scenes, only in a way that consolidates all of our caching (non-persistent, transient, and object caching) into a single API.