### PR TITLE
fix(Models/Post_Types/Event.php) tz perf and all-day

### DIFF
--- a/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
+++ b/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
@@ -28,8 +28,33 @@ use Tribe__Date_Utils as Dates;
  * To keep the calendar accessible, in the context of a week, we'll print the event only on either its first day
  * or the first day of the week.
  */
-$should_display = $event->dates->start_display->format( 'Y-m-d' ) === $day_date
+// @todo @bordoni move it into Tribe__Date__Utils::start_end_of_day_for_date($date);
+$calc            = function ( DateTimeInterface $date ) {
+	$begin = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $date->format( 'Y-m-d' ) ) );
+	$end   = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $date->format( 'Y-m-d' ) ) );
+	if ( $begin > $date ) {
+		$one_day = Tribe__Date_Utils::interval( 'P1D' );
+		$begin   = $begin->sub( $one_day );
+		$end     = $end->sub( $one_day );
+	}
+
+	return [ $begin, $end ];
+};
+
+// @todo @bordoni this stuff stays here, and clean up.
+list( $begin, $end ) = $calc( $event->dates->start_display );
+$this_day_cutoff = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $day_date ) );
+//$start_day_date = $event->dates->start_display->format( 'Y-m-d' ) > $day_date ? $day_date : $event->dates->start_display->format( 'Y-m-d' );
+//$start_begin = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $start_day_date ) );
+//$start_end = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $start_day_date ) );
+$should_display = ( $this_day_cutoff >= $begin && $this_day_cutoff <= $end )
                   || $is_start_of_week;
+//$should_display = ( $this_day_cutoff > $event->dates->start_display && $this_day_cutoff < $event->dates->end_display )
+//                  || $is_start_of_week;
+//$should_display = ( $event->dates->start_display < $this_day_cutoff )
+//                  || $is_start_of_week;
+//$should_display = $event->dates->start_display->format( 'Y-m-d' ) === $day_date
+//                  || $is_start_of_week;
 
 $classes = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 

--- a/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
+++ b/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
@@ -41,20 +41,36 @@ $calc            = function ( DateTimeInterface $date ) {
 	return [ $begin, $end ];
 };
 
+	$calc_tribe_day_for_datetime = function( DateTimeInterface $date ) {
+		$one_day = Tribe__Date_Utils::interval( 'P1D' );
+
+		$begin_adjusted = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $date->format( 'Y-m-d' ) ) );
+		$end_adjusted   = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $date->format( 'Y-m-d' ) ) );
+
+		$begin_minus_one = Tribe__Date_Utils::build_date_object( $date->sub( $one_day )->format( 'Y-m-d' ) );
+		$end_minus_one = Tribe__Date_Utils::build_date_object( $date->sub( $one_day )->format( 'Y-m-d' ) );
+
+		$begin = Tribe__Date_Utils::build_date_object( $date->format( 'Y-m-d' ) );
+		$end   = Tribe__Date_Utils::build_date_object( $date->format( 'Y-m-d' ) );
+
+		$begin_plus_one = Tribe__Date_Utils::build_date_object( $date->add( $one_day )->format( 'Y-m-d' ) );
+		$end_plus_one = Tribe__Date_Utils::build_date_object( $date->add( $one_day )->format( 'Y-m-d' ) );
+
+		if ( ! ( $end_adjusted < $begin_minus_one || $begin_adjusted > $end_minus_one ) ) {
+			return [ $begin_minus_one, $end_minus_one ];
+		} elseif ( ! ( $end_adjusted < $begin || $begin_adjusted > $end ) ) {
+			return [ $begin, $end ];
+		} elseif ( ! ( $end_adjusted < $begin_plus_one || $begin_adjusted > $end_plus_one ) ) {
+			return [ $begin_plus_one, $end_plus_one ];
+		}
+	};
+
 // @todo @bordoni this stuff stays here, and clean up.
-list( $begin, $end ) = $calc( $event->dates->start_display );
-$this_day_cutoff = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $day_date ) );
-//$start_day_date = $event->dates->start_display->format( 'Y-m-d' ) > $day_date ? $day_date : $event->dates->start_display->format( 'Y-m-d' );
-//$start_begin = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $start_day_date ) );
-//$start_end = Tribe__Date_Utils::build_date_object( tribe_end_of_day( $start_day_date ) );
-$should_display = ( $this_day_cutoff >= $begin && $this_day_cutoff <= $end )
+list( $begin, $end ) = $calc_tribe_day_for_datetime( $event->dates->start_display );
+list( $this_day_cutoff_begin, $this_day_cutoff_end ) = $calc_tribe_day_for_datetime( Tribe__Date_Utils::build_date_object( $day_date ) );
+
+$should_display = ( ! ( $end < $this_day_cutoff_begin || $begin > $this_day_cutoff_end ) )
                   || $is_start_of_week;
-//$should_display = ( $this_day_cutoff > $event->dates->start_display && $this_day_cutoff < $event->dates->end_display )
-//                  || $is_start_of_week;
-//$should_display = ( $event->dates->start_display < $this_day_cutoff )
-//                  || $is_start_of_week;
-//$should_display = $event->dates->start_display->format( 'Y-m-d' ) === $day_date
-//                  || $is_start_of_week;
 
 $classes = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/TEC-3209

This fix adds logic, in the Event model, to handle the instance where:

* the timezone setting is "site wide"
* an event has a diff. timezone from the site one
* the event is an all-day one

When the above scenario is fullfilled, then all-day events have a chance
of becoming multi-day events too.

E.g. with a cut-off of 00:00, a New York (UTC-5), all-day event on 1/29
will start at UTC 1/29 5am and end on UTC 1/30 4:59AM, making it a
2-day, multiday event in a site that uses UTC timezone.

The fix includes logic to handle end-of-day cutoffs too; in the previous
example, given a 6am end-of-day cutoff, the event would NOT be
multi-day.