### PR TITLE
Modify when and how we do our activation process flush of permalinks.

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2988,14 +2988,17 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return;
 			}
 
-			self::flushRewriteRules();
-
 			if ( ! class_exists( 'Tribe__Events__Editor__Compatibility' ) ) {
 				require_once $plugin_path . '/src/Tribe/Editor/Compatibility.php';
 			}
 
 			$editor_compatibility = new Tribe__Events__Editor__Compatibility();
 			$editor_compatibility->deactivate_gutenberg_extension_plugin();
+
+			if ( ! is_network_admin()  ) {
+				// We set with a string to avoid having to include a file here.
+				set_transient( '_tribe_events_delayed_flush_rewrite_rules', 'yes', 0 );
+			}
 
 			if ( ! is_network_admin() && ! isset( $_GET['activate-multi'] ) ) {
 				set_transient( '_tribe_events_activation_redirect', 1, 30 );

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -10,6 +10,20 @@ use Tribe__Main as Common;
  * Permalinks magic Happens over here!
  */
 class Tribe__Events__Rewrite extends Tribe__Rewrite {
+
+	/**
+	 * Constant holding the transient key for delayed triggered flush from activation.
+	 *
+	 * If this value is updated make sure you look at the method in the main class of TEC.
+	 *
+	 * @see TEC::activate
+	 *
+	 * @since 5.0.0.1
+	 *
+	 * @var string
+	 */
+	const KEY_DELAYED_FLUSH_REWRITE_RULES = '_tribe_events_delayed_flush_rewrite_rules';
+
 	/**
 	 * After creating the Hooks on WordPress we lock the usage of the function
 	 * @var boolean
@@ -389,6 +403,30 @@ class Tribe__Events__Rewrite extends Tribe__Rewrite {
 		add_action( 'tribe_events_pre_rewrite', array( $this, 'generate_core_rules' ) );
 		add_filter( 'post_type_link', array( $this, 'filter_post_type_link' ), 15, 2 );
 		add_filter( 'url_to_postid', array( $this, 'filter_url_to_postid' ) );
+		add_action( 'wp_loaded', [ $this, 'maybe_delayed_flush_rewrite_rules' ] );
+	}
+
+	/**
+	 * When dealing with flush of rewrite rules we cannot do it from the activation process due to not all classes being
+	 * loaded just yet. We flag a transient without expiration on activation so that on the next page load we flush the
+	 * permalinks for the website.
+	 *
+	 * @see TEC::activate()
+	 *
+	 * @since 5.0.0.1
+	 *
+	 * @return void
+	 */
+	public function maybe_delayed_flush_rewrite_rules() {
+		$should_flush_rewrite_rules = tribe_is_truthy( get_transient( static::KEY_DELAYED_FLUSH_REWRITE_RULES ) );
+
+		if ( ! $should_flush_rewrite_rules ) {
+			return;
+		}
+
+		delete_transient( static::KEY_DELAYED_FLUSH_REWRITE_RULES );
+
+		flush_rewrite_rules();
 	}
 
 	/**


### PR DESCRIPTION
🎟 [TEC-3211]
---
When dealing with non-network admin updates we need to have a delayed trigger of the flush of rewrite rules required for a plugin activation.

To avoid including a new class to activation methods we flag a transient and on `wp_loaded` which is early enough to properly find the paths and prevent 404s.

[TEC-3211]: https://moderntribe.atlassian.net/browse/TEC-3211