### PR TITLE
Cache inline scripts working with breakpoints

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,7 +217,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [5.0.0.2] 2020-02-06 =
 
-
+* Fix - New views mobile breakpoints interactions with Caching plugins resolved. [TEC-3221]
 
 = [5.0.0.1] 2020-01-31 =
 

--- a/src/Tribe/Integrations/Manager.php
+++ b/src/Tribe/Integrations/Manager.php
@@ -1,5 +1,5 @@
 <?php
-
+use \Tribe\Events\Integrations\WP_Rocket;
 
 /**
  * Class Tribe__Events__Integrations__Manager
@@ -38,6 +38,7 @@ class Tribe__Events__Integrations__Manager {
 		$this->load_twenty_seventeen_integration();
 		$this->load_wpml_integration();
 		$this->load_X_theme_integration();
+		$this->load_wp_rocket_integration();
 	}
 
 	/**
@@ -128,6 +129,21 @@ class Tribe__Events__Integrations__Manager {
 		}
 
 		Tribe__Events__Integrations__X_Theme__X_Theme::instance()->hook();
+
+		return true;
+	}
+
+	/**
+	 * Loads our WP Rocket plugin integration.
+	 *
+	 * @return bool
+	 */
+	private function load_wp_rocket_integration() {
+		if ( ! defined( 'WP_ROCKET_VERSION' ) ) {
+			return false;
+		}
+
+		tribe( WP_Rocket::class )->hook();
 
 		return true;
 	}

--- a/src/Tribe/Integrations/WP_Rocket.php
+++ b/src/Tribe/Integrations/WP_Rocket.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Handles compatibility with WP Rocket plugin.
+ *
+ * @package Tribe\Events\Integrations
+ * @since 5.0.0.2
+ */
+namespace Tribe\Events\Integrations;
+
+/**
+ * Integrations with WP Rocket plugin.
+ *
+ * @package Tribe\Events\Integrations
+ * @since 5.0.0.2
+ */
+class WP_Rocket {
+
+	/**
+	 * Hooks all the required methods for WP_Rocket usage on our code.
+	 *
+	 * @since 5.0.0.2
+	 */
+	public function hook() {
+		if ( ! tribe_events_views_v2_is_enabled() ) {
+			return;
+		}
+		add_filter( 'rocket_excluded_inline_js_content', [ $this, 'filter_excluded_inline_js_concat' ] );
+	}
+
+	/**
+	 * Filters the content of the WP Rocket excluded inline JS concat.
+	 *
+	 * @since 5.0.0.2
+	 *
+	 * @param array $excluded_inline Items to be excluded by WP Rocket.
+	 *
+	 * @return array Excluded inline scripts after adding the breakpoint code.
+	 */
+	public function filter_excluded_inline_js_concat( array $excluded_inline ) {
+		$excluded_inline[] = 'data-view-breakpoint-pointer';
+		return $excluded_inline;
+	}
+}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -565,6 +565,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			// Integrations
 			tribe_singleton( 'tec.integrations.twenty-seventeen', 'Tribe__Events__Integrations__Twenty_Seventeen', array( 'hook' ) );
+			tribe_singleton( \Tribe\Events\Integrations\WP_Rocket::class, \Tribe\Events\Integrations\WP_Rocket::class );
 
 			// Linked Posts
 			tribe_singleton( 'tec.linked-posts', 'Tribe__Events__Linked_Posts' );

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1386,6 +1386,7 @@ class View implements View_Interface {
 			'is_past'                => 'past' === $this->context->get( 'event_display_mode', false ),
 			'show_datepicker_submit' => $this->get_show_datepicker_submit(),
 			'breakpoints'            => $this->get_breakpoints(),
+			'breakpoint_pointer'     => $this->get_breakpoint_pointer(),
 			'is_initial_load'        => $this->context->doing_php_initial_state(),
 			'public_views'           => $this->get_public_views( $url_event_date ),
 		];

--- a/src/Tribe/Views/V2/Views/Traits/Breakpoint_Behavior.php
+++ b/src/Tribe/Views/V2/Views/Traits/Breakpoint_Behavior.php
@@ -55,6 +55,17 @@ trait Breakpoint_Behavior {
 	}
 
 	/**
+	 * Returns a given breakpoint pointer to a safer inline JS execution.
+	 *
+	 * @since 5.0.0.2
+	 *
+	 * @return int   Returns the breakpoint with that given name or 0 when not available.
+	 */
+	public function get_breakpoint_pointer() {
+		return wp_generate_uuid4();
+	}
+
+	/**
 	 * Returns all of the available breakpoints.
 	 *
 	 * @since 5.0.0

--- a/src/resources/js/views/breakpoints.js
+++ b/src/resources/js/views/breakpoints.js
@@ -185,8 +185,12 @@ tribe.events.views.breakpoints = {};
 	 *
 	 * @return {void}
 	 */
-	obj.setup = function( script ) {
-		var $container = $( script ).prev( obj.selectors.container );
+	obj.setup = function( container ) {
+		var $container = $( container );
+
+		if ( ! $container.is( obj.selectors.container ) ) {
+			return;
+		}
 		var $data = $container.find( obj.selectors.dataScript );
 		var data = {};
 

--- a/src/views/v2/components/breakpoints.php
+++ b/src/views/v2/components/breakpoints.php
@@ -39,7 +39,7 @@ if ( ! $is_initial_load ) {
 
 		if ( 'function' !== typeof( window.tribe.events.views.breakpoints.setup ) ) {
 			return;
-			}
+		}
 
 		var container = document.querySelectorAll( '[data-view-breakpoint-pointer="<?php echo esc_js( $breakpoint_pointer ); ?>"]' );
 		if ( ! container ) {

--- a/src/views/v2/components/breakpoints.php
+++ b/src/views/v2/components/breakpoints.php
@@ -21,25 +21,25 @@ if ( ! $is_initial_load ) {
 ?>
 <script class="tribe-events-breakpoints">
 	(function(){
-        if ( 'undefined' === typeof window.tribe ) {
-            return;
-        }
+		if ( 'undefined' === typeof window.tribe ) {
+			return;
+		}
 
-        if ( 'undefined' === typeof window.tribe.events ) {
-            return;
-        }
+		if ( 'undefined' === typeof window.tribe.events ) {
+			return;
+		}
 
-        if ( 'undefined' === typeof window.tribe.events.views ) {
-            return;
-        }
+		if ( 'undefined' === typeof window.tribe.events.views ) {
+			return;
+		}
 
-        if ( 'undefined' === typeof window.tribe.events.views.breakpoints ) {
-            return;
-        }
+		if ( 'undefined' === typeof window.tribe.events.views.breakpoints ) {
+			return;
+		}
 
-        if ( 'function' !== typeof( window.tribe.events.views.breakpoints.setup ) ) {
-            return;
-        }
+		if ( 'function' !== typeof( window.tribe.events.views.breakpoints.setup ) ) {
+			return;
+			}
 
 		var container = document.querySelectorAll( '[data-view-breakpoint-pointer="<?php echo esc_js( $breakpoint_pointer ); ?>"]' );
 		if ( ! container ) {

--- a/src/views/v2/components/breakpoints.php
+++ b/src/views/v2/components/breakpoints.php
@@ -9,9 +9,10 @@
  *
  * @link {INSERT_ARTCILE_LINK_HERE}
  *
- * @version 5.0.0
+ * @version 5.0.0.2
  *
- * @var bool $is_initial_load Boolean on whether view is being loaded for the first time.
+ * @var bool   $is_initial_load    Boolean on whether view is being loaded for the first time.
+ * @var string $breakpoint_pointer String we use as pointer to the current view we are setting up with breakpoints.
  */
 
 if ( ! $is_initial_load ) {
@@ -19,8 +20,32 @@ if ( ! $is_initial_load ) {
 }
 ?>
 <script class="tribe-events-breakpoints">
-	if ( 'undefined' !== typeof window.tribe ) {
-		var scripts = document.getElementsByTagName( 'script' );
-		window.tribe.events.views.breakpoints.setup( scripts[ scripts.length - 1 ] );
-	}
+	(function(){
+        if ( 'undefined' === typeof window.tribe ) {
+            return;
+        }
+
+        if ( 'undefined' === typeof window.tribe.events ) {
+            return;
+        }
+
+        if ( 'undefined' === typeof window.tribe.events.views ) {
+            return;
+        }
+
+        if ( 'undefined' === typeof window.tribe.events.views.breakpoints ) {
+            return;
+        }
+
+        if ( 'function' !== typeof( window.tribe.events.views.breakpoints.setup ) ) {
+            return;
+        }
+
+		var container = document.querySelectorAll( '[data-view-breakpoint-pointer="<?php echo esc_js( $breakpoint_pointer ); ?>"]' );
+		if ( ! container ) {
+			return;
+		}
+
+		window.tribe.events.views.breakpoints.setup( container );
+	})();
 </script>

--- a/src/views/v2/day.php
+++ b/src/views/v2/day.php
@@ -9,7 +9,7 @@
  *
  * @link {INSERT_ARTCILE_LINK_HERE}
  *
- * @version 5.0.0
+ * @version 5.0.0.2
  *
  * @var array    $events               The array containing the events.
  * @var string   $rest_url             The REST URL.
@@ -36,6 +36,9 @@ if ( empty( $disable_event_search ) ) {
 	<?php foreach ( $container_data as $key => $value ) : ?>
 		data-view-<?php echo esc_attr( $key ) ?>="<?php echo esc_attr( $value ) ?>"
 	<?php endforeach; ?>
+	<?php if ( ! empty( $breakpoint_pointer ) ) : ?>
+		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
+	<?php endif; ?>
 >
 	<div class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>

--- a/src/views/v2/day.php
+++ b/src/views/v2/day.php
@@ -18,6 +18,7 @@
  * @var string[] $container_classes    Classes used for the container of the view.
  * @var bool     $should_manage_url    Whether the view should manage the URL or not.
  * @var array    $container_data       An additional set of container `data` attributes.
+ * @var string   $breakpoint_pointer   String we use as pointer to the current view we are setting up with breakpoints.
  */
 
 $header_classes = [ 'tribe-events-header' ];

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -9,7 +9,7 @@
  *
  * @link {INSERT_ARTCILE_LINK_HERE}
  *
- * @version 5.0.0
+ * @version 5.0.0.2
  *
  * @var array    $events               The array containing the events.
  * @var string   $rest_url             The REST URL.
@@ -18,6 +18,7 @@
  * @var bool     $disable_event_search Boolean on whether to disable the event search.
  * @var string[] $container_classes    Classes used for the container of the view.
  * @var array    $container_data       An additional set of container `data` attributes.
+ * @var string   $breakpoint_pointer   String we use as pointer to the current view we are setting up with breakpoints.
  */
 
 $header_classes = [ 'tribe-events-header' ];
@@ -34,6 +35,9 @@ if ( empty( $disable_event_search ) ) {
 	<?php foreach ( $container_data as $key => $value ) : ?>
 		data-view-<?php echo esc_attr( $key ) ?>="<?php echo esc_attr( $value ) ?>"
 	<?php endforeach; ?>
+	<?php if ( ! empty( $breakpoint_pointer ) ) : ?>
+		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
+	<?php endif; ?>
 >
 	<div class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>

--- a/src/views/v2/month.php
+++ b/src/views/v2/month.php
@@ -9,7 +9,7 @@
  *
  * @link {INSERT_ARTCILE_LINK_HERE}
  *
- * @version 5.0.0
+ * @version 5.0.0.2
  *
  * @var string   $rest_url             The REST URL.
  * @var string   $rest_nonce           The REST nonce.

--- a/src/views/v2/month.php
+++ b/src/views/v2/month.php
@@ -17,6 +17,7 @@
  * @var bool     $disable_event_search Boolean on whether to disable the event search.
  * @var string[] $container_classes    Classes used for the container of the view.
  * @var array    $container_data       An additional set of container `data` attributes.
+ * @var string   $breakpoint_pointer   String we use as pointer to the current view we are setting up with breakpoints.
  */
 
 $header_classes = [ 'tribe-events-header' ];
@@ -33,6 +34,9 @@ if ( empty( $disable_event_search ) ) {
 	<?php foreach ( $container_data as $key => $value ) : ?>
 		data-view-<?php echo esc_attr( $key ) ?>="<?php echo esc_attr( $value ) ?>"
 	<?php endforeach; ?>
+	<?php if ( ! empty( $breakpoint_pointer ) ) : ?>
+		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
+	<?php endif; ?>
 >
 	<div class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>


### PR DESCRIPTION
🎟 [TEC-3221]
---
When dealing with inline script concatenation the usage of `<script>` tags could lead to bugs with some of the major plugins for caching.

The changes suggested here will modify the code to no longer rely on the inline script tag to being inside of the container.

[TEC-3221]: https://moderntribe.atlassian.net/browse/TEC-3221