### PR TITLE
This leverages new Date_Utils method for fetching datepickerFormat index

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -217,7 +217,7 @@ Still not happy? Shoot us an email to support@theeventscalendar.com or tweet to 
 
 = [5.0.0.2] 2020-02-06 =
 
-
+* Fix - Datepicker format now properly defaults to the correct value when Display Settings have not been saved. [TEC-3229]
 
 = [5.0.0.1] 2020-01-31 =
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -714,7 +714,7 @@ class Tribe__Events__Assets {
 			'date_with_year'          => tribe_get_date_option( 'dateWithYearFormat', Tribe__Date_Utils::DBDATEFORMAT ),
 			'date_no_year'            => tribe_get_date_option( 'dateWithoutYearFormat', Tribe__Date_Utils::DBDATEFORMAT ),
 			'datepicker_format'       => Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ),
-			'datepicker_format_index' => tribe_get_option( 'datepickerFormat' ),
+			'datepicker_format_index' => Tribe__Date_Utils::get_datepicker_format_index(),
 			'days'              => array(
 				__( 'Sunday' ),
 				__( 'Monday' ),

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			$data_attributes = array(
 				'live_ajax'         => tribe_get_option( 'liveFiltersUpdate', true ) ? 1 : 0,
-				'datepicker_format' => \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ),
+				'datepicker_format' => \Tribe__Date_Utils::get_datepicker_format_index(),
 				'category'          => $category,
 				'featured'          => tribe( 'tec.featured_events' )->is_featured_query(),
 			);
@@ -4391,7 +4391,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$value = $_REQUEST['tribe-bar-date'];
 			}
 
-			$datepicker_format = tribe_get_option( 'datepickerFormat' );
+			$datepicker_format = \Tribe__Date_Utils::get_datepicker_format_index();
 
 			$caption = esc_html__( 'Date', 'the-events-calendar' );
 			$format  = Tribe__Utils__Array::get( $formats_full, $datepicker_format, $formats_full[0] );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			$data_attributes = array(
 				'live_ajax'         => tribe_get_option( 'liveFiltersUpdate', true ) ? 1 : 0,
-				'datepicker_format' => tribe_get_option( 'datepickerFormat' ),
+				'datepicker_format' => \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ),
 				'category'          => $category,
 				'featured'          => tribe( 'tec.featured_events' )->is_featured_query(),
 			);

--- a/src/admin-views/aggregator/page.php
+++ b/src/admin-views/aggregator/page.php
@@ -1,5 +1,5 @@
 <?php
-$datepicker_format = tribe_get_option( 'datepickerFormat' );
+$datepicker_format = \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
 
 $state_class = 'tribe-aggregator-inactive';
 if ( tribe( 'events-aggregator.main' )->is_service_active() ) {

--- a/src/admin-views/aggregator/page.php
+++ b/src/admin-views/aggregator/page.php
@@ -1,5 +1,5 @@
 <?php
-$datepicker_format = \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
+$datepicker_format = \Tribe__Date_Utils::get_datepicker_format_index();
 
 $state_class = 'tribe-aggregator-inactive';
 if ( tribe( 'events-aggregator.main' )->is_service_active() ) {

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -25,7 +25,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 	do_action( 'tribe_events_post_errors', $event->ID, true );
 	?>
 </div>
-<div id='eventDetails' class="inside eventForm" data-datepicker_format="<?php echo esc_attr( \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ) ); ?>">
+<div id='eventDetails' class="inside eventForm" data-datepicker_format="<?php echo esc_attr( \Tribe__Date_Utils::get_datepicker_format_index() ); ?>">
 	<?php
 	/**
 	 * Fires inside the opening #eventDetails div of The Events Calendar meta box

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -25,7 +25,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 	do_action( 'tribe_events_post_errors', $event->ID, true );
 	?>
 </div>
-<div id='eventDetails' class="inside eventForm" data-datepicker_format="<?php echo esc_attr( tribe_get_option( 'datepickerFormat' ) ); ?>">
+<div id='eventDetails' class="inside eventForm" data-datepicker_format="<?php echo esc_attr( \Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ) ); ?>">
 	<?php
 	/**
 	 * Fires inside the opening #eventDetails div of The Events Calendar meta box

--- a/src/deprecated/Tribe__Events__Asset__Dynamic.php
+++ b/src/deprecated/Tribe__Events__Asset__Dynamic.php
@@ -21,7 +21,7 @@ class Tribe__Events__Asset__Dynamic extends Tribe__Events__Asset__Abstract_Asset
 			'date_with_year'          => tribe_get_date_option( 'dateWithYearFormat', Tribe__Date_Utils::DBDATEFORMAT ),
 			'date_no_year'            => tribe_get_date_option( 'dateWithoutYearFormat', Tribe__Date_Utils::DBDATEFORMAT ),
 			'datepicker_format'       => Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ),
-			'datepicker_format_index' => tribe_get_option( 'datepickerFormat' ),
+			'datepicker_format_index' => Tribe__Date_Utils::get_datepicker_format_index(),
 			'days'              => array(
 				__( 'Sunday' ),
 				__( 'Monday' ),


### PR DESCRIPTION
This prevents datepicker formats on the event edit page, JSON vars, aggregator datepicker, etc from defaulting the datepickerFormat index to a blank string. Our default is `1`.

Related: https://github.com/moderntribe/tribe-common/pull/1280

🎥
* Event Edit: http://p.tri.be/NHqoXF
* Aggregator: http://p.tri.be/VkkDoC
* Calendar View: http://p.tri.be/ewgdS7

🎫 [TEC-3229]

[TEC-3229]: https://moderntribe.atlassian.net/browse/TEC-3229

