### PR TITLE
Revert "Point to the correct branch on moderntribe/tribe-testing-facilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "phpunit/phpunit": "~6.0",
     "scotteh/php-dom-wrapper": "0.7.3",
     "facebook/webdriver": "1.6.0",
-    "moderntribe/tribe-testing-facilities": "dev-spotfix/include-views-exclusion-for-data-attr-breakpoints"
+    "moderntribe/tribe-testing-facilities": "dev-master"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,


### PR DESCRIPTION
This reverts commit c0f86cc0e31df271d8642db09fd0a6a2d07e98e8.

@lucatume - When we've figured out how to sort out https://github.com/lucatume/wp-snapshot-assertions/pull/2 vs https://github.com/moderntribe/tribe-testing-facilities/pull/22, we can revert this commit.

Related:
* https://github.com/moderntribe/tribe-common/pull/1283
* https://github.com/moderntribe/events-pro/pull/1492