### PR TITLE
Update the conditional checks for the new live update radios.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tests/_output
 node_modules
 compiler.jar
 *.ps1
+*.code-workspace
 
 wpml-config.xml
 .env.testing

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Freemius Opt-out workflow now present on all occasions [TEC-3171]
 * Tweak - Freemius updated to the latest version 2.3.2 [TEC-3171]
 * Tweak - Remove the "Default stylesheet - full" option from display settings, for the new views. [TEC-3125]
+* Tweak - Change the live refresh option to a radio, adjust conditional checks to accomodate. [TEC-3072]
 * Fix - Freemius activation URL send via email works as expected [TEC-3218]
 * Fix - Improve compatibility from Updated Views V2 with Beaver Builder plugins [TEC-3248]
 * Fix - More robust handling of `hide_from_listings` in REST API v2, thanks @maxm123

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1056,7 +1056,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 
 			$data_attributes = array(
-				'live_ajax'         => tribe_get_option( 'liveFiltersUpdate', true ) ? 1 : 0,
+				'live_ajax'         => 'automatic' === tribe_get_option( 'liveFiltersUpdate', 'automatic' ) ? 1 : 0,
 				'datepicker_format' => \Tribe__Date_Utils::get_datepicker_format_index(),
 				'category'          => $category,
 				'featured'          => tribe( 'tec.featured_events' )->is_featured_query(),
@@ -1852,7 +1852,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function body_class( $classes ) {
 			if ( get_query_var( 'post_type' ) == self::POSTTYPE ) {
-				if ( ! is_admin() && tribe_get_option( 'liveFiltersUpdate', true ) ) {
+				if ( ! is_admin() && 'automatic' === tribe_get_option( 'liveFiltersUpdate', 'automatic' ) ) {
 					$classes[] = 'tribe-filter-live';
 				}
 			}

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1417,7 +1417,7 @@ class View implements View_Interface {
 			'after_events'           => tribe( Advanced_Display::class )->get_after_events_html( $this ),
 			'display_events_bar'     => $this->filter_display_events_bar( $this->display_events_bar ),
 			'disable_event_search'   => tribe_is_truthy( tribe_get_option( 'tribeDisableTribeBar', false ) ),
-			'live_refresh'           => tribe_is_truthy( tribe_get_option( 'liveFiltersUpdate', true ) ),
+			'live_refresh'           => tribe_is_truthy( 'automatic' === tribe_get_option( 'liveFiltersUpdate', 'automatic' ) ),
 			'ical'                   => $this->get_ical_data(),
 			'container_classes'      => $this->get_html_classes(),
 			'container_data'         => $this->get_container_data(),
@@ -1984,7 +1984,7 @@ class View implements View_Interface {
 	 * @return bool
 	 */
 	protected function get_show_datepicker_submit() {
-		$live_refresh       = tribe_is_truthy( tribe_get_option( 'liveFiltersUpdate', true ) );
+		$live_refresh       = tribe_is_truthy( 'automatic' === tribe_get_option( 'liveFiltersUpdate', 'automatic' ) );
 		$disable_events_bar = tribe_is_truthy( tribe_get_option( 'tribeDisableTribeBar', false ) );
 
 		$show_datepicker_submit = empty( $live_refresh ) && ! empty( $disable_events_bar );

--- a/tests/_support/Modules/Options.php
+++ b/tests/_support/Modules/Options.php
@@ -22,7 +22,7 @@ class Options extends \Codeception\Module {
 			'latest_ecp_version'               => '4.0beta2',
 			'donate-link'                      => false,
 			'postsPerPage'                     => '10',
-			'liveFiltersUpdate'                => true,
+			'liveFiltersUpdate'                => 'automatic',
 			'showComments'                     => false,
 			'showEventsInMainLoop'             => false,
 			'eventsSlug'                       => 'events',


### PR DESCRIPTION
[TEC-3072]

We changed the live update to a radio - this ensures all the checks against the option are correct now (it was originally a boolean/checkbox).

📷 http://p.tri.be/ClOYUS (submit button shows on "manual")
📸 http://p.tri.be/bnke7V (no button and "live reload" on "automatic")

Related: https://github.com/moderntribe/events-filterbar/pull/236

[TEC-3072]: https://moderntribe.atlassian.net/browse/TEC-3072