### PR TITLE
Update label for EA other URL import

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.0.3] TBD =
 * Tweak - Minify the Freemius svg assets. [TEC-3215]
+* Tweak - Remove "(beta)" label from URL source type of import. [TEC-3289]
 
 = [5.0.2.1] 2020-02-25 =
 

--- a/src/Tribe/Aggregator/API/Origins.php
+++ b/src/Tribe/Aggregator/API/Origins.php
@@ -67,10 +67,10 @@ class Tribe__Events__Aggregator__API__Origins extends Tribe__Events__Aggregator_
 				'upsell' => true,
 			),
 			'url' => (object) array(
-				'id' => 'url',
-				'name' => __( 'Other URL', 'the-events-calendar' ),
+				'id'       => 'url',
+				'name'     => __( 'Other URL', 'the-events-calendar' ),
 				'disabled' => true,
-				'upsell' => true,
+				'upsell'   => true,
 			),
 		);
 

--- a/src/Tribe/Aggregator/API/Origins.php
+++ b/src/Tribe/Aggregator/API/Origins.php
@@ -68,7 +68,7 @@ class Tribe__Events__Aggregator__API__Origins extends Tribe__Events__Aggregator_
 			),
 			'url' => (object) array(
 				'id' => 'url',
-				'name' => __( 'Other URL (beta)', 'the-events-calendar' ),
+				'name' => __( 'Other URL', 'the-events-calendar' ),
 				'disabled' => true,
 				'upsell' => true,
 			),


### PR DESCRIPTION
Removal of the "beta" label as has been a while that the label is there,
as requested.

Ticket: [TEC-3289]
Ticket: [EA-140]

[TEC-3289]: https://moderntribe.atlassian.net/browse/TEC-3289
[EA-140]: https://moderntribe.atlassian.net/browse/EA-140