### PR TITLE
TEC-3255, EA-152: Respect EA value for "post_status" when not set

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,8 +221,10 @@ Remember to always make a backup of your database and files before updating!
 == Changelog ==
 
 = [5.0.3] TBD =
+
 * Tweak - Minify the Freemius svg assets. [TEC-3215]
 * Tweak - Remove "(beta)" label from URL source type of import. [TEC-3289]
+* Fix - Respect EA `post_status` from settings when an event does not have a defined value. [TEC-3255]
 
 = [5.0.2.1] 2020-02-25 =
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1613,7 +1613,11 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 						if ( ! $venue_id ) {
 							$event['Venue']['ShowMap']     = $show_map_setting;
 							$event['Venue']['ShowMapLink'] = $show_map_setting;
-							$venue_id = $event['EventVenueID'] = Tribe__Events__Venue::instance()->create( $event['Venue'], $event['post_status'] );
+
+							$venue_id = $event['EventVenueID'] = Tribe__Events__Venue::instance()->create(
+								$event['Venue'],
+								Tribe__Utils__Array::get( $event, 'post_status', $args['post_status'] )
+							);
 
 							$found_venues[ $event['EventVenueID'] ] = $event['Venue']['Venue'];
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1368,14 +1368,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 		$initial_created_events = $activity->count( Tribe__Events__Main::POSTTYPE );
 		$expected_created_events = $initial_created_events + count( $items );
 
-		$args = array(
-			'post_status' => 'draft',
-		);
-
-		if ( ! empty( $this->meta['post_status'] ) && 'do_not_override' !== $this->meta['post_status'] ) {
-			$args['post_status'] = $this->meta['post_status'];
-		}
-
 		$unique_field = $this->get_unique_field();
 		$existing_ids = $this->get_existing_ids_from_import_data( $items );
 
@@ -1390,6 +1382,14 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 
 		$import_settings = tribe( 'events-aggregator.settings' )->default_settings_import( $origin );
 		$should_import_settings = tribe_is_truthy( $import_settings ) ? true : false;
+
+		$args = [
+			'post_status' => tribe( 'events-aggregator.settings' )->default_post_status( $origin ),
+		];
+
+		if ( ! empty( $this->meta['post_status'] ) && 'do_not_override' !== $this->meta['post_status'] ) {
+			$args['post_status'] = $this->meta['post_status'];
+		}
 
 		/**
 		 * When an event/venue/organizer is being updated/inserted in the context of an import then any change


### PR DESCRIPTION
If an event does not set the value for "post_status" fallback to the settings value from EA, based on the origin.

Tickets: 

- [TEC-3255]
- [EA-152]

[TEC-3255]: https://moderntribe.atlassian.net/browse/TEC-3255
[EA-152]: https://moderntribe.atlassian.net/browse/EA-152