### PR TITLE
Task/delay init store

### DIFF
--- a/src/modules/data/index.js
+++ b/src/modules/data/index.js
@@ -9,6 +9,8 @@ import { store } from '@moderntribe/common/store';
 import * as blocks from './blocks';
 import initSagas from './sagas';
 
+const { actions, constants } = plugins;
+
 const setInitialState = ( entityRecord ) => {
 
 };
@@ -37,8 +39,8 @@ export const initStore = () => {
 		const { dispatch, injectReducers } = store;
 
 		initSagas();
-		dispatch( plugins.actions.addPlugin( 'events' ) );
-		injectReducers( { events: reducer } );
+		dispatch( actions.addPlugin( constants.EVENTS_PLUGIN ) );
+		injectReducers( { [ constants.EVENTS_PLUGIN ]: reducer } );
 	} );
 };
 

--- a/src/modules/data/index.js
+++ b/src/modules/data/index.js
@@ -3,17 +3,43 @@
  */
 import reducer from './reducers';
 
-import { plugins } from '@moderntribe/common/data';
+import { globals } from '@moderntribe/common/utils';
+import { editor, plugins } from '@moderntribe/common/data';
 import { store } from '@moderntribe/common/store';
 import * as blocks from './blocks';
 import initSagas from './sagas';
 
-export const initStore = () => {
-	const { dispatch, injectReducers } = store;
+const setInitialState = ( entityRecord ) => {
 
-	initSagas();
-	dispatch( plugins.actions.addPlugin( 'events' ) );
-	injectReducers( { events: reducer } );
+};
+
+export const initStore = () => {
+	const unsubscribe = globals.wpData.subscribe( () => {
+		const coreSelectors = globals.wpData.select( 'core' );
+		const coreEditorSelectors = globals.wpData.select( 'core/editor' );
+
+		/**
+		 * @todo: keep an eye on this, unstable function but is also used in block editor core code.
+		 */
+		if ( ! coreEditorSelectors.__unstableIsEditorReady() ) {
+			return;
+		}
+
+		unsubscribe();
+
+		if ( ! coreEditorSelectors.isCleanNewPost() ) {
+			const postId = coreEditorSelectors.getCurrentPostId();
+			const entityRecord = coreSelectors.getEntityRecord( 'postType', editor.EVENT, postId );
+
+			setInitialState( entityRecord );
+		}
+
+		const { dispatch, injectReducers } = store;
+
+		initSagas();
+		dispatch( plugins.actions.addPlugin( 'events' ) );
+		injectReducers( { events: reducer } );
+	} );
 };
 
 export const getStore = () => store;

--- a/src/modules/data/index.js
+++ b/src/modules/data/index.js
@@ -39,8 +39,8 @@ export const initStore = () => {
 		const { dispatch, injectReducers } = store;
 
 		initSagas();
-		dispatch( actions.addPlugin( constants.EVENTS_PLUGIN ) );
 		injectReducers( { [ constants.EVENTS_PLUGIN ]: reducer } );
+		dispatch( actions.addPlugin( constants.EVENTS_PLUGIN ) );
 	} );
 };
 


### PR DESCRIPTION
[TEC-3339]

This task is the first task of setting up allowing us to set the initial state of our block editor application through the reducer rather than via mounting of the blocks.

Related to:
* https://github.com/moderntribe/tribe-common/pull/1317
* https://github.com/moderntribe/events-pro/pull/1510
* ET PR to come
* ET+ PR to come

[TEC-3339]: https://moderntribe.atlassian.net/browse/TEC-3339