### PR TITLE
Convert into an inline return and remove non used variable

### DIFF
--- a/src/Tribe/Importer/File_Reader.php
+++ b/src/Tribe/Importer/File_Reader.php
@@ -28,9 +28,8 @@ class Tribe__Events__Importer__File_Reader {
 
 	public function get_header() {
 		$this->file->rewind();
-		$row = $this->file->current();
 
-		return $row;
+		return $this->file->current();
 	}
 
 	public function set_row( $row_number ) {


### PR DESCRIPTION
Remove the need to declare a variable