### PR TITLE
TEC-3253 - fix regression when using the default page template

### DIFF
--- a/src/Tribe/Views/V2/Template/Page.php
+++ b/src/Tribe/Views/V2/Template/Page.php
@@ -43,7 +43,8 @@ class Page {
 		// If there wasn't any defined we fetch the Index.
 		if ( empty( $template ) ) {
 			$template = get_index_template();
-		} elseif ( 'default' === $template ) {
+		} elseif ( 'page' === $template ) {
+			// We check for page as default is converted to page in Tribe\Events\Views\V2\Template_Bootstrap->in get_template_setting().
 			$template = get_page_template();
 		} else {
 			// Admin setting set to a custom template.


### PR DESCRIPTION
_Ref:_ [TEC-3253](https://moderntribe.atlassian.net/browse/TEC-3253)

Readme is in the previous PR, this fixes a regression when using the Default Page Template.

https://github.com/moderntribe/the-events-calendar/pull/3083