### PR TITLE
fix(Views v2) filter the View query arg slug

### DIFF
--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -10,6 +10,7 @@
 namespace Tribe\Events\Service_Providers;
 
 use Tribe\Events\Views\V2\Utils;
+use Tribe\Events\Views\V2\View;
 use Tribe__Context;
 use Tribe__Date_Utils as Dates;
 use Tribe__Events__Main as TEC;
@@ -44,32 +45,33 @@ class Context extends \tad_DI52_ServiceProvider {
 	 * @return array The modified context locations.
 	 */
 	public function filter_context_locations( array $locations = [] ) {
-		$locations = array_merge(
+		$view_query_var = View::query_var();
+		$locations      = array_merge(
 			$locations,
 			[
-				'event_display'        => [
+				'event_display'      => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR        => 'eventDisplay',
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR   => 'eventDisplay',
 					],
 				],
-				'view'                 => [
+				$view_query_var      => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR   => [ 'tribe_view', 'eventDisplay' ],
 					],
 				],
@@ -171,14 +173,14 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::QUERY_VAR   => 'tribe_remove_date_filters',
 					],
 				],
-				'event_display_mode'   => [
+				'event_display_mode' => [
 					/**
 					 * We use the `eventDisplay` query var with duplicity: when parsed from the path it represents the View, when
 					 * appended as a query var it represents the "view mode". Here we invert the order to read the appended query
 					 * var first and get, from its position, a clean variable we can consume in Views.
 					 */
 					'read' => [
-						Tribe__Context::REQUEST_VAR => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::WP_PARSED   => [ 'eventDisplay', 'tribe_event_display' ],
 						Tribe__Context::QUERY_VAR   => [ 'eventDisplay', 'tribe_event_display' ],
 					],
@@ -370,11 +372,11 @@ class Context extends \tad_DI52_ServiceProvider {
 						],
 					],
 				],
-				'view_request'         => [
+				'view_request'       => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 					],
 				],

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -46,6 +46,7 @@ class Context extends \tad_DI52_ServiceProvider {
 	 */
 	public function filter_context_locations( array $locations = [] ) {
 		$view_query_var = View::query_var();
+
 		$locations      = array_merge(
 			$locations,
 			[
@@ -62,7 +63,7 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::QUERY_VAR   => 'eventDisplay',
 					],
 				],
-				$view_query_var      => [
+				'view'      => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -47,32 +47,52 @@ class Context extends \tad_DI52_ServiceProvider {
 	public function filter_context_locations( array $locations = [] ) {
 		$view_query_var = View::query_var();
 
-		$locations      = array_merge(
+		$locations = array_merge(
 			$locations,
 			[
-				'event_display'      => [
+				'event_display'        => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::QUERY_VAR        => 'eventDisplay',
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::QUERY_VAR   => 'eventDisplay',
 					],
 				],
-				'view'      => [
+				'view'                 => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::QUERY_VAR   => [ 'tribe_view', 'eventDisplay' ],
 					],
 				],
@@ -150,8 +170,8 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::WP_MATCHED_QUERY => 'featured',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR      => 'featured',
-						Tribe__Context::QUERY_VAR        => 'featured',
+						Tribe__Context::REQUEST_VAR => 'featured',
+						Tribe__Context::QUERY_VAR   => 'featured',
 					],
 				],
 				TEC::TAXONOMY          => [
@@ -174,24 +194,29 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::QUERY_VAR   => 'tribe_remove_date_filters',
 					],
 				],
-				'event_display_mode' => [
+				'event_display_mode'   => [
 					/**
 					 * We use the `eventDisplay` query var with duplicity: when parsed from the path it represents the View, when
 					 * appended as a query var it represents the "view mode". Here we invert the order to read the appended query
 					 * var first and get, from its position, a clean variable we can consume in Views.
 					 */
 					'read' => [
-						Tribe__Context::REQUEST_VAR => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::WP_PARSED   => [ 'eventDisplay', 'tribe_event_display' ],
 						Tribe__Context::QUERY_VAR   => [ 'eventDisplay', 'tribe_event_display' ],
 					],
 				],
-				'tribe_event_display'   => [
+				'tribe_event_display'  => [
 					/**
 					 * On V1 we depend on `tribe_event_display` to handle Plain permalink usage of `past` events.
 					 * The context need to be aware of where to read and write this from.
 					 */
-					'read' => [
+					'read'  => [
 						Tribe__Context::REQUEST_VAR => [ 'tribe_event_display' ],
 						Tribe__Context::WP_PARSED   => [ 'tribe_event_display' ],
 						Tribe__Context::QUERY_VAR   => [ 'tribe_event_display' ],
@@ -203,12 +228,12 @@ class Context extends \tad_DI52_ServiceProvider {
 				],
 				'keyword'              => [
 					'read' => [
-						Tribe__Context::FUNC        => [
+						Tribe__Context::FUNC          => [
 							static function () {
 								return Utils\View::get_data( 'bar-keyword', Tribe__Context::NOT_FOUND );
 							},
 						],
-						Tribe__Context::REQUEST_VAR => [ 's', 'search', 'tribe-bar-search' ],
+						Tribe__Context::REQUEST_VAR   => [ 's', 'search', 'tribe-bar-search' ],
 						Tribe__Context::LOCATION_FUNC => [
 							'view_data',
 							static function ( $data ) {
@@ -244,8 +269,8 @@ class Context extends \tad_DI52_ServiceProvider {
 					'read' => [
 						Tribe__Context::FUNC => static function () {
 							return Dates::build_date_object()
-										->setTime( 0, 0, 0 )
-										->format( Dates::DBDATETIMEFORMAT );
+							            ->setTime( 0, 0, 0 )
+							            ->format( Dates::DBDATETIMEFORMAT );
 						},
 					],
 				],
@@ -283,6 +308,7 @@ class Context extends \tad_DI52_ServiceProvider {
 										[ TEC::POSTTYPE, Venue::POSTTYPE, Organizer::POSTTYPE, ]
 									)
 								);
+
 								return $found ?: Tribe__Context::NOT_FOUND;
 							},
 						],
@@ -292,7 +318,8 @@ class Context extends \tad_DI52_ServiceProvider {
 					'read' => [
 						Tribe__Context::FUNC          => [
 							static function () {
-								return ! empty( tribe_get_request_var( TEC::POSTTYPE, false ) ) ?: Tribe__Context::NOT_FOUND;
+								return ! empty( tribe_get_request_var( TEC::POSTTYPE,
+									false ) ) ?: Tribe__Context::NOT_FOUND;
 							},
 						],
 						Tribe__Context::LOCATION_FUNC => [
@@ -307,7 +334,8 @@ class Context extends \tad_DI52_ServiceProvider {
 					'read' => [
 						Tribe__Context::FUNC          => [
 							static function () {
-								return ! empty( tribe_get_request_var( Venue::POSTTYPE, false ) ) ?: Tribe__Context::NOT_FOUND;
+								return ! empty( tribe_get_request_var( Venue::POSTTYPE,
+									false ) ) ?: Tribe__Context::NOT_FOUND;
 							},
 						],
 						Tribe__Context::LOCATION_FUNC => [
@@ -322,7 +350,8 @@ class Context extends \tad_DI52_ServiceProvider {
 					'read' => [
 						Tribe__Context::FUNC          => [
 							static function () {
-								return ! empty( tribe_get_request_var( Organizer::POSTTYPE, false ) ) ?: Tribe__Context::NOT_FOUND;
+								return ! empty( tribe_get_request_var( Organizer::POSTTYPE,
+									false ) ) ?: Tribe__Context::NOT_FOUND;
 							},
 						],
 						Tribe__Context::LOCATION_FUNC => [
@@ -354,7 +383,8 @@ class Context extends \tad_DI52_ServiceProvider {
 								$date_k = 'tribe-bar-date';
 
 								return is_array( $data ) && isset( $data[ $date_k ] )
-									? add_query_arg( [ $date_k => $data[ $date_k ] ], tribe_get_request_var( 'url', home_url() ) )
+									? add_query_arg( [ $date_k => $data[ $date_k ] ],
+										tribe_get_request_var( 'url', home_url() ) )
 									: Tribe__Context::NOT_FOUND;
 							},
 						],
@@ -373,11 +403,16 @@ class Context extends \tad_DI52_ServiceProvider {
 						],
 					],
 				],
-				'view_request'       => [
-					'read'  => [
+				'view_request'         => [
+					'read' => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
-						Tribe__Context::REQUEST_VAR      => [ $view_query_var, 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
+						Tribe__Context::REQUEST_VAR      => [
+							$view_query_var,
+							'tribe_view',
+							'tribe_event_display',
+							'eventDisplay'
+						],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 					],
 				],

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -58,7 +58,7 @@ class Context extends \tad_DI52_ServiceProvider {
 							$view_query_var,
 							'tribe_view',
 							'tribe_event_display',
-							'eventDisplay'
+							'eventDisplay',
 						],
 						Tribe__Context::QUERY_VAR        => 'eventDisplay',
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
@@ -68,7 +68,7 @@ class Context extends \tad_DI52_ServiceProvider {
 							$view_query_var,
 							'tribe_view',
 							'tribe_event_display',
-							'eventDisplay'
+							'eventDisplay',
 						],
 						Tribe__Context::QUERY_VAR   => 'eventDisplay',
 					],
@@ -81,7 +81,7 @@ class Context extends \tad_DI52_ServiceProvider {
 							$view_query_var,
 							'tribe_view',
 							'tribe_event_display',
-							'eventDisplay'
+							'eventDisplay',
 						],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
@@ -91,7 +91,7 @@ class Context extends \tad_DI52_ServiceProvider {
 							$view_query_var,
 							'tribe_view',
 							'tribe_event_display',
-							'eventDisplay'
+							'eventDisplay',
 						],
 						Tribe__Context::QUERY_VAR   => [ 'tribe_view', 'eventDisplay' ],
 					],
@@ -205,7 +205,7 @@ class Context extends \tad_DI52_ServiceProvider {
 							$view_query_var,
 							'tribe_view',
 							'tribe_event_display',
-							'eventDisplay'
+							'eventDisplay',
 						],
 						Tribe__Context::WP_PARSED   => [ 'eventDisplay', 'tribe_event_display' ],
 						Tribe__Context::QUERY_VAR   => [ 'eventDisplay', 'tribe_event_display' ],

--- a/src/Tribe/Views/V2/Url.php
+++ b/src/Tribe/Views/V2/Url.php
@@ -107,7 +107,7 @@ class Url {
 			return $slug;
 		}
 
-		return Arr::get_first_set( $this->get_query_args(), [ 'view', 'tribe_view', 'eventDisplay' ], $slug );
+		return Arr::get_first_set( $this->get_query_args(), [ View::query_var(), 'tribe_view', 'eventDisplay' ], $slug );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -537,9 +537,9 @@ class View implements View_Interface {
 	 * @return string The filtered query argument to use to identify a View request, defaults to "view".
 	 */
 	public static function query_var() {
-		$value = tribe_get_var( 'tribe_views_v2_view_query_var', false );
+		$value = tribe_get_var( 'tribe_views_v2_view_query_var' );
 
-		if ( false !== $value ) {
+		if ( ! empty( $value ) ) {
 			return $value;
 		}
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -246,7 +246,7 @@ class View implements View_Interface {
 			$params['prev_url'] = untrailingslashit( $params['prev_url'] );
 		}
 
-		$slug       = Arr::get( $params, View::query_var(), false );
+		$slug       = Arr::get( $params, static::query_var(), false );
 		$url_object = Url::from_url_and_params( Arr::get( $params, 'url' ), $params );
 
 		$url = $url_object->__toString();

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -14,7 +14,6 @@ use Tribe\Events\Views\V2\Utils;
 use Tribe\Events\Views\V2\Views\Traits\Breakpoint_Behavior;
 use Tribe\Events\Views\V2\Views\Traits\HTML_Cache;
 use Tribe\Events\Views\V2\Views\Traits\Json_Ld_Data;
-use Tribe\Events\Views\V2\Views\Traits\List_Behavior;
 use Tribe__Container as Container;
 use Tribe__Context as Context;
 use Tribe__Date_Utils as Dates;
@@ -247,7 +246,7 @@ class View implements View_Interface {
 			$params['prev_url'] = untrailingslashit( $params['prev_url'] );
 		}
 
-		$slug       = Arr::get( $params, 'view', false );
+		$slug       = Arr::get( $params, View::query_var(), false );
 		$url_object = Url::from_url_and_params( Arr::get( $params, 'url' ), $params );
 
 		$url = $url_object->__toString();
@@ -523,6 +522,39 @@ class View implements View_Interface {
 	 */
 	public static function set_container( Container $container ) {
 		static::$container = $container;
+	}
+
+	/**
+	 * Returns the filtered query variable to use to identify a View request in URLs.
+	 *
+	 * If a plugin conflict arises about the use of the default "view" query argument, then this is the filter to use
+	 * to solve that issue.
+	 * To avoid over-head the value is filtered once per request, its value is then cached and returned for any further
+	 * request fetch.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The filtered query argument to use to identify a View request, defaults to "view".
+	 */
+	public static function query_var() {
+		$value = tribe_get_var( 'tribe_views_v2_view_query_var', false );
+
+		if ( false !== $value ) {
+			return $value;
+		}
+
+		/**
+		 * Filters the query argument to use to identify a request.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $view_query_arg The query argument to use to identify a View request in the URL; def. "view".
+		 */
+		$value = apply_filters( 'tribe_views_v2_view_query_var', 'view' );
+
+		tribe_set_var( 'tribe_views_v2_view_query_var', $value );
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/BTRIA-271

This commit allows filtering the query argument we use to detect a View
request in the URL.

Some other plugins might use `view` for their own purposes and our
usages, and detection of View requests, might be offset or wrong.

The commit adds the filtering function and upates the code where it was
using the query arg directly.

The changes are small as 99% of Views v2 code does not look up the query
arg directly and relies, instead, on the Context.