### PR TITLE
Preventing redirects from updated Views V2 to be too broad

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,7 +222,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.0.4] TBD =
 
-* Fix - Preventing redirects from updated Views V2 to be too broad and end up catching requests from other Plugins, reported by Gravity View team on Gravity Forms bug with imports.
+* Fix - Preventing redirects from updated Views V2 to be too broad and end up catching requests from other Plugins, reported by GravityView team on Gravity Forms bug with imports.
 
 = [5.0.3.1] 2020-03-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -222,7 +222,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.0.4] TBD =
 
-
+* Fix - Preventing redirects from updated Views V2 to be too broad and end up catching requests from other Plugins, reported by Gravity View team on Gravity Forms bug with imports.
 
 = [5.0.3.1] 2020-03-23 =
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -420,6 +420,11 @@ class Hooks extends \tad_DI52_ServiceProvider {
 
 		$context = tribe_context();
 
+		// Bail with the original redirect if we are not dealing with a CPT from TEC.
+		if ( ! $context->is( 'tec_post_type' ) ) {
+			return $redirect_url;
+		}
+
 		$view = $context->get( 'view_request', null );
 
 		if ( 'embed' === $view ) {


### PR DESCRIPTION
A simple fix reported by the GravityView team when trying to do Gravity Forms Imports it would fail due to our redirect catching their request.

They have already tested that fix on their side, it works, I already tested this piece with the Embeds and Mobile redirects that this piece of code interacts with.

Not a lot to Screencast here, I this should be tested on our normal full pass.