### PR TITLE
Fix for filter_admin_post_thumbnail_html() checking post type during AJAX calls

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -396,8 +396,8 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @return string The modified html, if required.
 	 */
 	public function filter_admin_post_thumbnail_html( $html ) {
-
-		if ( TEC::POSTTYPE !== get_current_screen()->post_type ) {
+		$current_screen = get_current_screen();
+		if ( $current_screen === null || TEC::POSTTYPE !== $current_screen->post_type ) {
 			return $html;
 		}
 


### PR DESCRIPTION
During AJAX calls `get_current_screen()` returns `null`, causing `get_current_screen()->post_type` to fail with error `Trying to get property ‘post_type’ of non-object`. This causes featured image management to fail.

This error is invisible without changing `ini_set( 'display_errors', 0)` to `ini_set( 'display_errors', 1`) at the end of `wp-includes/load.php::wp_debug_mode()`, after which it will be visible in the network response to the AJAX request after pressing "Set featured image" or "Remove featured image".