### PR TITLE
Dont prevent non-page make it an exact check for event template settings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,7 +222,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.0.4] TBD =
 
-
+* Fix - Selecting other Page templates from Settings > Display now loads the correct template properly, to display events.
 
 = [5.0.3.1] 2020-03-23 =
 

--- a/src/Tribe/Views/V2/Template/Page.php
+++ b/src/Tribe/Views/V2/Template/Page.php
@@ -44,7 +44,7 @@ class Page {
 		if ( empty( $template ) ) {
 			$template = get_index_template();
 		} elseif ( 'page' === $template ) {
-			// We check for page as default is converted to page in Tribe\Events\Views\V2\Template_Bootstrap->in get_template_setting().
+			// We check for page as default is convertwed to page in Tribe\Events\Views\V2\Template_Bootstrap->in get_template_setting().
 			$template = get_page_template();
 		} else {
 			// Admin setting set to a custom template.
@@ -357,8 +357,8 @@ class Page {
 				$should_hijack = false;
 			}
 
-			// Dont hijack non-page event based.
-			if ( 'page' !== tribe( Template_Bootstrap::class )->get_template_setting() ) {
+			// Dont hijack event based.
+			if ( 'event' === tribe( Template_Bootstrap::class )->get_template_setting() ) {
 				$should_hijack = false;
 			}
 

--- a/src/Tribe/Views/V2/Template/Page.php
+++ b/src/Tribe/Views/V2/Template/Page.php
@@ -44,7 +44,7 @@ class Page {
 		if ( empty( $template ) ) {
 			$template = get_index_template();
 		} elseif ( 'page' === $template ) {
-			// We check for page as default is convertwed to page in Tribe\Events\Views\V2\Template_Bootstrap->in get_template_setting().
+			// We check for page as default is converted to page in Tribe\Events\Views\V2\Template_Bootstrap->in get_template_setting().
 			$template = get_page_template();
 		} else {
 			// Admin setting set to a custom template.


### PR DESCRIPTION
[Internal Slack conversation detailing the bug report](https://tribe.slack.com/archives/C0258NG6N/p1585246131036200).

This was preventing anything other than page from actually being a template selected, which broke the behavior expected on that setting.