### PR TITLE
Add constant to turn off views HTML caching.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "wp-coding-standards/wpcs": "^2.1",
     "automattic/vipwpcs": "^2.0",
     "moderntribe/TribalScents": "dev-master",
-    "lucatume/wp-browser": "^2.0",
+    "lucatume/wp-browser": "^2.2.37",
     "xamin/handlebars.php": "^0.10.3",
     "mikey179/vfsstream": "^1.6",
     "spatie/phpunit-snapshot-assertions": "^1.2",

--- a/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
+++ b/src/Tribe/Views/V2/Views/Traits/HTML_Cache.php
@@ -116,6 +116,10 @@ trait HTML_Cache {
 	 * @return bool Whether the View HTML should be cached or not.
 	 */
 	public function should_cache_html() {
+		if ( defined( 'TRIBE_CACHE_VIEWS' ) && ! TRIBE_CACHE_VIEWS ) {
+			return false;
+		}
+
 		$context = $this->get_context();
 
 		$cached_views = [


### PR DESCRIPTION
Just allows for turning it off in wp-config instead of having to use the filter.