### PR TITLE
fix(editor/geo-data.js) default country code to empty string

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,7 @@ Remember to always make a backup of your database and files before updating!
 = [5.0.4] TBD =
 
 * Fix - Prevent PHP errors from happening during bulk activation or deactivation of the plugin [TCMN-53]
+* Fix - Do not set the Venue country when creating Venues from the Event Block Editor [TEC-3361]
 
 = [5.0.3.1] 2020-03-23 =
 

--- a/src/modules/editor/utils/geo-data.js
+++ b/src/modules/editor/utils/geo-data.js
@@ -31,7 +31,7 @@ export function getCountries() {
 
 export function getCountryCode( name ) {
 	const result = find( getCountries(), ( country ) => country.name === name );
-	return get( result, 'code', 'US' );
+	return get( result, 'code', '' );
 }
 
 export function getStateCode( countryCode, name ) {


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/TEC-3361

[Screencap](https://drive.google.com/open?id=14rY0aECsSy37iUuXpJdvXvLdYUPexKUU&authuser=luca@tri.be&usp=drive_fs)

This PR fixes the issue where, only in the context of the Event Block Editor, creating a Venue would default the Venue country to US.