### PR TITLE
fix(Query.php) add parent event to query only if available

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -1374,8 +1374,11 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 
 					if ( class_exists( 'Tribe__Events__Pro__Recurrence__Event_Query' ) ) {
 						$recurrence_query = new Tribe__Events__Pro__Recurrence__Event_Query();
-						$recurrence_query->set_parent_event( get_post( $args['post_parent'] ) );
-						add_filter( 'posts_where', array( $recurrence_query, 'include_parent_event' ), 100 );
+						$parent_post      = get_post( $args['post_parent'] );
+						if ( $parent_post instanceof WP_Post ) {
+							$recurrence_query->set_parent_event( $parent_post );
+							add_filter( 'posts_where', array( $recurrence_query, 'include_parent_event' ), 100 );
+						}
 					}
 				}
 


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/ECP-391

No screencapture available as this issue seems to come into play only when the parent event of a series is manually removed from the database, not using our UI.