### PR TITLE
Updated 'Read more' string

### DIFF
--- a/src/Tribe/Google/Maps_API_Key.php
+++ b/src/Tribe/Google/Maps_API_Key.php
@@ -74,7 +74,7 @@ class Tribe__Events__Google__Maps_API_Key {
 						'the-events-calendar'
 					),
 					'<a href="https://developers.google.com/maps/documentation/javascript/get-api-key" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Google Maps API key', 'the-events-calendar' ) . '</a>',
-					'<a href="https://theeventscalendar.com/knowledgebase/setting-up-your-google-maps-api-key/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Read More', 'the-events-calendar' ) . '</a>'
+					'<a href="https://theeventscalendar.com/knowledgebase/setting-up-your-google-maps-api-key/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Read more', 'the-events-calendar' ) . '</a>'
 				) . '</p>',
 			),
 


### PR DESCRIPTION
While going through translations I discovered that we have the string 'Read more' in several different ways in the code:

- Read more (twice, which I took as the correct one)
- Read More
- Read more.
- Read More.

In this PR, and another one in tribe common I have unified these to all say 'Read more'. If there is a period after the string, that has been moved out, so it does not show up in the translation.

Jira: https://moderntribe.atlassian.net/browse/BTRIA-307