### PR TITLE
TEC-3385 - fix Latest Past Events if mobile view is set to default

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -2205,6 +2205,12 @@ class View implements View_Interface {
 		$manager      = tribe( Manager::class );
 		$default_slug = $manager->get_default_view_option();
 
+		// If slug is `default`, get the slug another way.x
+		if ( 'default' === $default_slug ) {
+			$default_class = $manager->get_default_view();
+			$default_slug  = $manager->get_view_slug_by_class( $default_class );
+		}
+
 		// Show Latest Past Events only on the default view.
 		if ( $this->get_slug() !== $default_slug ) {
 			return;

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -2205,7 +2205,7 @@ class View implements View_Interface {
 		$manager      = tribe( Manager::class );
 		$default_slug = $manager->get_default_view_option();
 
-		// If slug is `default`, get the slug another way.x
+		// If the slug is `default`, get the slug another way.
 		if ( 'default' === $default_slug ) {
 			$default_class = $manager->get_default_view();
 			$default_slug  = $manager->get_view_slug_by_class( $default_class );


### PR DESCRIPTION
_Ref:_ [TEC-3385](https://moderntribe.atlassian.net/browse/TEC-3385)

With Pro active you can select the view for Mobile. One of those options is `Default`

This update supports if Default is selected. 