### PR TITLE
TwentyTwenty Navigation was throwing warings due to 0 on date fields

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 * Feature - Add Recent Past Events Views. [TEC-3385]
 * Tweak - Load plugin text domain on the new `tribe_load_text_domains` action hook, which fires on `init` instead of on the `plugins_loaded` hook. [TEC-3406]
 * Tweak - Add a constant `TRIBE_CACHE_VIEWS` to turn off views HTML caching.
+* Fix - Theme navigation warning around `post_date = '0'` no longer happens when using Page template for Updated Views [TEC-3434]
 * Fix - Selecting other Page templates from Settings > Display now loads the correct template properly, to display events.
 * Fix - Preventing redirects from updated Views V2 to be too broad and end up catching requests from other Plugins, reported by GravityView team on Gravity Forms bug with imports.
 * Fix - Prevent PHP errors from happening during bulk activation or deactivation of the plugin [TCMN-53]

--- a/src/Tribe/Views/V2/Template/Page.php
+++ b/src/Tribe/Views/V2/Template/Page.php
@@ -15,6 +15,7 @@ use Tribe\Events\Views\V2\Template_Bootstrap;
 use Tribe__Events__Main as TEC;
 use Tribe__Utils__Array as Arr;
 use WP_Post;
+use Tribe__Date_Utils as Dates;
 use WP_Query;
 
 class Page {
@@ -395,16 +396,17 @@ class Page {
 	 * @return object A Mocked stdClass that mimics a WP_Post.
 	 */
 	protected function get_mocked_page() {
+		$date_string = Dates::build_date_object( 'today' )->format( Dates::DBDATETIMEFORMAT );
 		$page = [
 			'ID'                    => 0,
 			'post_status'           => 'publish',
 			'post_author'           => 0,
 			'post_parent'           => 0,
 			'post_type'             => 'page',
-			'post_date'             => 0,
-			'post_date_gmt'         => 0,
-			'post_modified'         => 0,
-			'post_modified_gmt'     => 0,
+			'post_date'             => $date_string,
+			'post_date_gmt'         => $date_string,
+			'post_modified'         => $date_string,
+			'post_modified_gmt'     => $date_string,
 			'post_content'          => '',
 			'post_title'            => '',
 			'post_excerpt'          => '',


### PR DESCRIPTION
🎟 [TEC-3434]
---
I wasn't able to reproduce the problem, but it seems related to the `date = 0` that we use to mock the page and how navigation will use that post date to figure out next and previous.

[TEC-3434]: https://moderntribe.atlassian.net/browse/TEC-3434