### PR TITLE
fix(Views v2) use of get_current_screen

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -397,7 +397,13 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	public function filter_admin_post_thumbnail_html( $html ) {
 
-		if ( TEC::POSTTYPE !== get_current_screen()->post_type ) {
+		$screen = get_current_screen();
+
+		if ( ! $screen instanceof \WP_Screen ) {
+			return $html;
+		}
+
+		if ( TEC::POSTTYPE !== $screen->post_type ) {
 			return $html;
 		}
 


### PR DESCRIPTION
This PR fixes our code to make sure we're only using the screen object if it's, actually, a `WP_Screen` instance.

See:  https://tribe.slack.com/archives/CEUHNUF3R/p1587628382029600?thread_ts=1587622497.017900&cid=CEUHNUF3R