### PR TITLE
Code that fixes the incorrect data being passed.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,9 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+Fix - Correct bad defaults from `Template->attr()` and ensure that the timezone info is correctly hydrated in the case of an unchanged block. [TEC-2964]
+
 = [5.1.0] 2020-04-23 =
 
 * Feature - Add a "fast forward" link to Month and Day views when there are no events to show. [TEC-3400]

--- a/src/Tribe/Editor/Template.php
+++ b/src/Tribe/Editor/Template.php
@@ -50,7 +50,7 @@ class Tribe__Events__Editor__Template extends Tribe__Template {
 	 */
 	public function attr( $index, $default = null ) {
 
-		$attribute = $this->get( array_merge( array( 'attributes' ), (array) $index ), array(), $default );
+		$attribute = $this->get( array_merge( array( 'attributes' ), (array) $index ), $default );
 
 		return $attribute;
 

--- a/src/views/blocks/event-datetime.php
+++ b/src/views/blocks/event-datetime.php
@@ -34,21 +34,28 @@ $use_yearless_format = apply_filters( 'tribe_events_event_block_datetime_use_yea
 	$event
 );
 
-$time_format = tribe_get_time_format();
-$date_format = tribe_get_date_format( $use_yearless_format );
-
-$timezone = get_post_meta( $event_id, '_EventTimezone', true );
+$time_format    = tribe_get_time_format();
+$date_format    = tribe_get_date_format( $use_yearless_format );
+$timezone       = get_post_meta( $event_id, '_EventTimezone', true );
 $show_time_zone = $this->attr( 'showTimeZone' );
+
+if ( is_null( $show_time_zone ) ) {
+	$show_time_zone = tribe_get_option( 'tribe_events_timezones_show_zone', false );
+}
+
 $time_zone_label = $this->attr( 'timeZoneLabel' );
+
+if ( is_null( $time_zone_label ) ) {
+	$time_zone_label = Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
+}
 
 
 $formatted_start_date = tribe_get_start_date( $event_id, false, $date_format );
 $formatted_start_time = tribe_get_start_time( $event_id, $time_format );
-$formatted_end_date = tribe_get_end_date( $event_id, false, $date_format );
-$formatted_end_time = tribe_get_end_time( $event_id, $time_format );
-
-$separator_date = get_post_meta( $event_id, '_EventDateTimeSeparator', true );
-$separator_time = get_post_meta( $event_id, '_EventTimeRangeSeparator', true );
+$formatted_end_date   = tribe_get_end_date( $event_id, false, $date_format );
+$formatted_end_time   = tribe_get_end_time( $event_id, $time_format );
+$separator_date       = get_post_meta( $event_id, '_EventDateTimeSeparator', true );
+$separator_time       = get_post_meta( $event_id, '_EventTimeRangeSeparator', true );
 
 if ( empty( $separator_time ) ) {
 	$separator_time = tribe_get_option( 'timeRangeSeparator', ' - ' );

--- a/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
+++ b/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace Tribe\Events\Editor;
+
+use Tribe__Events__Editor__Template;
+
+
+class TemplateTest extends \Codeception\TestCase\WPTestCase {
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+	/**
+	 * @return Tribe__Events__Editor__Template
+	 */
+	private function make_instance() {
+		return new Tribe__Events__Editor__Template();
+	}
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( 'Tribe__Events__Editor__Template', $sut );
+	}
+
+	/**
+	 * @test
+	 * it should return default when value not set
+	 */
+	public function it_should_return_default_when_value_not_set() {
+		$sut = $this->make_instance();
+
+		$attr = $sut->attr( 'nonexistent_attribute', null );
+
+		$this->assertNull( $attr, 'Failed passing null as default.' );
+
+		$attr = $sut->attr( 'nonexistent_attribute', 'default' );
+
+		$this->assertEquals( $attr, 'default', 'Failed passing string as default.' );
+	}
+
+	/**
+	 * @test
+	 * it should return set local value with get()
+	 *
+	 * @return void
+	 */
+	public function it_should_return_set_local_value_with_get() {
+		$sut = $this->make_instance();
+
+		$sut->set( 'test_index', 'fnord' );
+		$attr = $sut->get( 'test_index', 'default' );
+
+		$this->assertEquals( $attr, 'fnord', 'Failed getting set local value with get().' );
+	}
+
+	/**
+	 * @test
+	 * it should return set global value with get()
+	 *
+	 * @return void
+	 */
+	public function it_should_return_set_global_value_with_get() {
+		$sut = $this->make_instance();
+
+		$sut->set( 'test_index', 'fnord', false );
+		$attr = $sut->get( 'test_index', 'default', false );
+
+		$this->assertEquals( $attr, 'fnord', 'Failed getting set global value with get().' );
+	}
+
+	/**
+	 * @test
+	 * it should return set attribute with attr()
+	 *
+	 * @return void
+	 */
+	public function it_should_return_set_attribute_with_attr() {
+		$sut = $this->make_instance();
+
+		// Attributes are set one-deep in the 'attributes' array.
+		$sut->set( [ 'attributes', 'test_index' ], 'fnord' );
+		$attr = $sut->attr( 'test_index', 'default' );
+
+		$this->assertEquals( $attr, 'fnord', 'Failed getting set local value with attr()' );
+	}
+}

--- a/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
+++ b/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
@@ -94,6 +94,21 @@ class TemplateTest extends \Codeception\TestCase\WPTestCase {
 		$sut->set( [ 'attributes', 'test_index' ], 'fnord' );
 		$attr = $sut->attr( 'test_index', 'default' );
 
-		$this->assertEquals( $attr, 'fnord', 'Failed getting set local value with attr()' );
+		$this->assertEquals( $attr, 'fnord', 'Failed getting set value with attr()' );
+	}
+
+	/**
+	 * @test
+	 * it should return default for an unset attribute with attr()
+	 *
+	 * @return void
+	 */
+	public function it_should_return_default_for_an_unset_attribute_with_attr() {
+		$sut = $this->make_instance();
+
+		// Attributes are set one-deep in the 'attributes' array.
+		$attr = $sut->attr( 'test_index', 'default' );
+
+		$this->assertEquals( $attr, 'default', 'Failed getting default value with attr()' );
 	}
 }

--- a/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
+++ b/tests/wpunit/Tribe/Events/Editor/TemplateTest.php
@@ -5,19 +5,6 @@ use Tribe__Events__Editor__Template;
 
 
 class TemplateTest extends \Codeception\TestCase\WPTestCase {
-	public function setUp() {
-		// before
-		parent::setUp();
-
-		// your set up methods here
-	}
-
-	public function tearDown() {
-		// your tear down methods here
-
-		// then
-		parent::tearDown();
-	}
 	/**
 	 * @return Tribe__Events__Editor__Template
 	 */


### PR DESCRIPTION
And code that checks for site data if event data is missing.

The attr() function was being passed an extra param, so it was returning incorrect default values.
The timezone info is saved to the block as attributes - so it's not saved to meta and it's not saved if the block isn't changed. This means that if we get a default value back, we have to check for it in Event->Settings->General.

[TEC-2964]

[TEC-2964]: https://moderntribe.atlassian.net/browse/TEC-2964