### PR TITLE
Remove incompatible usage of func_get_args for PHP 7.0 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Adjust templates to show time zone in event details when "Show time zone" is checked. [TEC-2979]
 * Fix - Correct bad defaults from `Template->attr()` and ensure that the timezone info is correctly hydrated in the case of an unchanged block. [TEC-2964]
 * Fix - Event Aggregator imported events when using default status or categories from the Settings Page will now be imported correctly. [TEC-3445]
+* Fix - Prevent problems with `func_get_args()` usage around template inclusion for legacy template files [TEC-3104]
 
 = [5.1.0] 2020-04-23 =
 

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -543,8 +543,8 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 		 **/
 		public static function getTemplateHierarchy( $template, $args = array() ) {
 			if ( ! is_array( $args ) ) {
+				$passed        = [ $template, $args ];
 				$args          = array();
-				$passed        = func_get_args();
 				$backwards_map = array( 'namespace', 'plugin_path' );
 				$count = count( $passed );
 

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -543,7 +543,7 @@ if ( ! class_exists( 'Tribe__Events__Templates' ) ) {
 		 **/
 		public static function getTemplateHierarchy( $template, $args = array() ) {
 			if ( ! is_array( $args ) ) {
-				$passed        = [ $template, $args ];
+				$passed        = func_get_args();
 				$args          = array();
 				$backwards_map = array( 'namespace', 'plugin_path' );
 				$count = count( $passed );


### PR DESCRIPTION
🎟 [TEC-3104]
---
No changes in behavior just add compatibility for version PHP 7.0 and above. 
Originally added here: https://github.com/moderntribe/the-events-calendar/pull/2750

[TEC-3104]: https://moderntribe.atlassian.net/browse/TEC-3104