### PR TITLE
Shorten multiday function name.

### DIFF
--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
  *
  * @return array<string> $classes   The classes to add to the multiday event.
  */
-function tribe_events_month_multiday_classes( $event, $day_date, $is_start_of_week, $today_date ) {
+function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_date ) {
 	$classes = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 
 	if ( ! empty( $event->featured ) ) {

--- a/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
+++ b/src/views/v2/month/calendar-body/day/multiday-events/multiday-event.php
@@ -25,7 +25,7 @@
  * @version TBD
  */
 
-$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, $day_date, $is_start_of_week, $today_date );
+$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, $day_date, $is_start_of_week, $today_date );
 
 $start_display_date = $event->dates->start_display->format( 'Y-m-d' );
 

--- a/tests/wpunit/functions/classes/Month_Multiday_ClassesTest.php
+++ b/tests/wpunit/functions/classes/Month_Multiday_ClassesTest.php
@@ -27,7 +27,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 			$event->displays_on = [];
 		}
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, null, null, null );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, null, null, null );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 
 		$this->assertEquals( $expected, $classes, "Classes don't match expected!" );
@@ -45,7 +45,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 
 		$event->featured = true;
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, null, null, null );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, null, null, null );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 		$expected[] = 'tribe-events-calendar-month__multiday-event--featured';
 
@@ -61,7 +61,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 	public function it_should_return_expected_classes_when_passed_a_first_day_event() {
 		$event    = $this->get_mock_event( 'events/single/1.json' );
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, $event->start_date, true, null );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, $event->start_date, true, null );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 		$expected[] = 'tribe-events-calendar-month__multiday-event--width-' . $event->this_week_duration;
 		$expected[] = 'tribe-events-calendar-month__multiday-event--display';
@@ -76,7 +76,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 	public function it_should_return_expected_classes_when_passed_a_first_day_past_event() {
 		$event    = $this->get_mock_event( 'events/single/1.json' );
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, $event->start_date, true, $event->start_date );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, $event->start_date, true, $event->start_date );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 		$expected[] = 'tribe-events-calendar-month__multiday-event--width-' . $event->this_week_duration;
 		$expected[] = 'tribe-events-calendar-month__multiday-event--display';
@@ -93,7 +93,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 		$event    = $this->get_mock_event( 'events/single/1.json' );
 		$event->starts_this_week = true;
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, $event->start_date, true, null );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, $event->start_date, true, null );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 		$expected[] = 'tribe-events-calendar-month__multiday-event--width-' . $event->this_week_duration;
 		$expected[] = 'tribe-events-calendar-month__multiday-event--display';
@@ -110,7 +110,7 @@ class Month_Multiday_ClassesTest extends WPTestCase {
 		$event    = $this->get_mock_event( 'events/single/1.json' );
 		$event->ends_this_week = true;
 
-		$classes = \Tribe\Events\Views\V2\tribe_events_month_multiday_classes( $event, $event->start_date, true, null );
+		$classes = \Tribe\Events\Views\V2\month_multiday_classes( $event, $event->start_date, true, null );
 		$expected = tribe_get_post_class( [ 'tribe-events-calendar-month__multiday-event' ], $event->ID );
 		$expected[] = 'tribe-events-calendar-month__multiday-event--width-' . $event->this_week_duration;
 		$expected[] = 'tribe-events-calendar-month__multiday-event--display';


### PR DESCRIPTION
In #3169 we've introduced a namespaced function that would still be called as if in the global namespace,
the `tribe_events_month_multiday_classes` one.

This PR shortens the function name to stick w/ namespaced functions convention.