### PR TITLE
Fix Cost_Utils to correctly handle empty costs

### DIFF
--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -66,7 +66,7 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 		$costs = array_filter(
 			(array) $costs,
 			static function ( $cost ) {
-				return $cost !== '';
+				return '' !== $cost;
 			}
 		);
 

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -63,6 +63,10 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 
 		$costs = tribe_get_event_meta( $event->ID, '_EventCost', false );
 
+		$costs = array_filter( (array) $costs, static function ( $cost ) {
+			return $cost !== '';
+		} );
+
 		$parsed_costs = array();
 
 		foreach ( $costs as $index => $value ) {

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -63,9 +63,12 @@ class Tribe__Events__Cost_Utils extends Tribe__Cost_Utils {
 
 		$costs = tribe_get_event_meta( $event->ID, '_EventCost', false );
 
-		$costs = array_filter( (array) $costs, static function ( $cost ) {
-			return $cost !== '';
-		} );
+		$costs = array_filter(
+			(array) $costs,
+			static function ( $cost ) {
+				return $cost !== '';
+			}
+		);
 
 		$parsed_costs = array();
 


### PR DESCRIPTION
While working on other code I found out the `Cost_Utils` class would incorrectly handle, in the `get_event_costs` method, new posts that will have a meta value set to `''`.

This PR makes sure we cast and filter the array before treating it as such.