### PR TITLE
Spotfix - prevent undefined notices when force cache refresh in tribe…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [5.2] TBD =
+
+* Tweak - Prevent undefined errors when using tribe_get_events and forcing a cache refresh.
+
 = [5.1.1] 2020-05-11 =
 
 * Feature - Move all the featured event icons to templates. [TEC-3441]

--- a/src/functions/template-tags/event.php
+++ b/src/functions/template-tags/event.php
@@ -145,6 +145,8 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			 * @param string  $filter The filter, or context of the fetch.
 			 */
 			$post = apply_filters( 'tribe_get_event', $post, $output, $filter );
+
+			// Dont try to reset cache when forcing.
 			if ( ! $force ) {
 				$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 			}

--- a/src/functions/template-tags/event.php
+++ b/src/functions/template-tags/event.php
@@ -145,8 +145,9 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			 * @param string  $filter The filter, or context of the fetch.
 			 */
 			$post = apply_filters( 'tribe_get_event', $post, $output, $filter );
-
-			$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+			if ( ! $force ) {
+				$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+			}
 		}
 
 		/**


### PR DESCRIPTION
…_get_events

Resolves an issue when force a cache refresh.

Found when Gustavo and I were creating a test and updating an event. 