### PR TITLE
Ensure Organizer ID meta is unpacked on write by ORM

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correctly store Event Organizer meta when using the ORM.
+
 = [5.1.2] 2020-05-27 =
 
 * Tweak - Prevent undefined errors when using tribe_get_events and forcing a cache refresh.

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1225,7 +1225,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 * @return array The filtered event post array.
 	 */
 	protected function update_linked_post_meta( array $postarr ) {
-		// @todo crete linked posts here?! Using ORM?
+		// @todo create linked posts here?! Using ORM?
 		if ( isset( $postarr['meta_input']['_EventVenueID'] ) && ! tribe_is_venue( $postarr['meta_input']['_EventVenueID'] ) ) {
 			unset( $postarr['meta_input']['_EventVenueID'] );
 		}
@@ -1242,6 +1242,8 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			if ( ! count( $valid ) ) {
 				unset( $postarr['meta_input']['_EventOrganizerID'] );
 			} else {
+				$this->unpack_meta_on_update( '_EventOrganizerID' );
+				// Pass this to the function to have this value passed to the closure later.
 				$postarr['meta_input']['_EventOrganizerID'] = $valid;
 			}
 		}

--- a/tests/wpunit/Tribe/Events/ORM/Events/CreateTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/CreateTest.php
@@ -74,7 +74,8 @@ class CreateTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertInstanceOf( \WP_Post::class, $event );
 		$this->assertEquals( $venue, get_post_meta( $event->ID, '_EventVenueID', true ) );
-		$this->assertEquals( [ $organizer ], get_post_meta( $event->ID, '_EventOrganizerID', true ) );
+		$this->assertEquals( [ $organizer ], get_post_meta( $event->ID, '_EventOrganizerID', false ) );
+		$this->assertEquals( $organizer, get_post_meta( $event->ID, '_EventOrganizerID', true ) );
 	}
 
 	/**
@@ -95,7 +96,8 @@ class CreateTest extends \Codeception\TestCase\WPTestCase {
 		$event       = tribe_events()->set_args( $args )->create();
 
 		$this->assertInstanceOf( \WP_Post::class, $event );
-		$this->assertEquals( [ $organizer_1, $organizer_2 ], get_post_meta( $event->ID, '_EventOrganizerID', true ) );
+		$this->assertEquals( [ $organizer_1, $organizer_2 ], get_post_meta( $event->ID, '_EventOrganizerID', false ) );
+		$this->assertEquals( $organizer_1, get_post_meta( $event->ID, '_EventOrganizerID', true ) );
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/moderntribe/tribe-common/pull/1377 

This PR leverages the work done in common.