### PR TITLE
fix(ignored-posts): Filter wp_count_posts() ...

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 = [5.1.2] 2020-05-27 =
 
 * Tweak - Prevent undefined errors when using tribe_get_events and forcing a cache refresh.
-* Fix - Prevent `E_ERROR` on for `Tribe__Events__Meta__Save` construct when dealing with revisions, which some WP Engine customers was seeing.
+* Fix - Prevent `E_ERROR` for `Tribe__Events__Meta__Save` construct when dealing with revisions, which some WP Engine customers were seeing.
 * Language - 0 new strings added, 49 updated, 0 fuzzied, and 0 obsoleted
 
 = [5.1.1] 2020-05-11 =

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -977,7 +977,7 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 			 */
 			tribe_notice( 'legacy-ignored-events', array( $this, 'render_notice_legacy' ), 'dismiss=1&type=warning' );
 
-			add_filter( 'wp_count_posts', [ $this, 'patch_count_posts' ], 10, 3 );
+			add_filter( 'wp_count_posts', [ $this, 'patch_count_posts' ], 10 );
 
 			return true;
 		}
@@ -990,15 +990,13 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 		 *
 		 * @since TBD
 		 *
-		  * @param object $counts       An object containing the current post_type's post
-		 *                              counts by status.
-		 * @param string $unused_type   Post type.
-		 * @param string $unused_perm   The permission to determine if the posts are 'readable'
-		 *                              by the current user.
-		 * @return object $counts       The modified object containing the current post_type's post
-		 *                              counts by status.
+		 * @param object $counts An object containing the current post_type's post
+		 *                       counts by status.
+		 *
+		 * @return object $counts The modified object containing the current post_type's post
+		 *                        counts by status.
 		 */
-		public function patch_count_posts( $counts, $unused_type, $unused_perm ) {
+		public function patch_count_posts( $counts ) {
 			$status = $this::$ignored_status;
 
 			if ( ! isset( $counts->$status ) ) {

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -78,9 +78,11 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 		 * @return  array
 		 */
 		public function filter_bulk_actions( $actions ) {
+
 			if ( ! isset( $_GET['post_status'] ) || self::$ignored_status !== $_GET['post_status'] ) {
 				return $actions;
 			}
+
 
 			$post_type_obj = get_post_type_object( Tribe__Events__Main::POSTTYPE );
 
@@ -975,7 +977,32 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 			 */
 			tribe_notice( 'legacy-ignored-events', array( $this, 'render_notice_legacy' ), 'dismiss=1&type=warning' );
 
+			add_filter( 'wp_count_posts', [ $this, 'patch_count_posts' ], 10, 3 );
+
 			return true;
+		}
+
+		/**
+		 * Patch post-list-table queries to include ignored status,
+		 * as WP just accesses the stati without checking if they exist.
+		 *
+		 * @see wp-admin/includes/class-wp-posts-list-table.php->get_views()
+		 *
+		 * @since TBD
+		 *
+		 * @param [type] $counts
+		 * @param [type] $type
+		 * @param [type] $perm
+		 * @return void
+		 */
+		public function patch_count_posts( $counts, $type, $perm ) {
+			$status = $this::$ignored_status;
+
+			if ( ! isset( $counts->$status ) ) {
+				$counts->$status = 0;
+			}
+
+			return $counts;
 		}
 	}
 }

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -990,12 +990,15 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param [type] $counts
-		 * @param [type] $type
-		 * @param [type] $perm
-		 * @return void
+		  * @param object $counts       An object containing the current post_type's post
+		 *                              counts by status.
+		 * @param string $unused_type   Post type.
+		 * @param string $unused_perm   The permission to determine if the posts are 'readable'
+		 *                              by the current user.
+		 * @return object $counts       The modified object containing the current post_type's post
+		 *                              counts by status.
 		 */
-		public function patch_count_posts( $counts, $type, $perm ) {
+		public function patch_count_posts( $counts, $unused_type, $unused_perm ) {
 			$status = $this::$ignored_status;
 
 			if ( ! isset( $counts->$status ) ) {

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -997,7 +997,7 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 		 *                        counts by status.
 		 */
 		public function patch_count_posts( $counts ) {
-			$status = $this::$ignored_status;
+			$status = self::$ignored_status;
 
 			if ( ! isset( $counts->$status ) ) {
 				$counts->$status = 0;

--- a/src/Tribe/Ignored_Events.php
+++ b/src/Tribe/Ignored_Events.php
@@ -977,7 +977,7 @@ if ( ! class_exists( 'Tribe__Events__Ignored_Events' ) ) {
 			 */
 			tribe_notice( 'legacy-ignored-events', array( $this, 'render_notice_legacy' ), 'dismiss=1&type=warning' );
 
-			add_filter( 'wp_count_posts', [ $this, 'patch_count_posts' ], 10 );
+			add_filter( 'wp_count_posts', [ $this, 'patch_count_posts' ] );
 
 			return true;
 		}


### PR DESCRIPTION
…to include a dummy count for tribe-ignored status to prevent notices.

By making the status available in `show_in_admin_status_list` we tell WP to handle it for every post table - but WP doesn't check to ensure it's actually there.
So it tries to access a non-existent property and throws a notice. This hooks into `wp_count_posts()` and adds a dummy (0) value for it to prevent notices.