### PR TITLE
Add existing-post to linked post option data and use that to determine if 'new fields' should be shown

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - Correctly store Event Organizer meta when using the ORM.
+* Fix - Linked posts (Organizers and Venues) correctly check if the item selected is brand new or existing when edit link is empty. [TEC-3481]
 
 = [5.1.2] 2020-05-27 =
 

--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -971,6 +971,7 @@ class Tribe__Events__Linked_Posts {
 			<?php selected( $option['selected'] ); ?>
 			value="<?php echo esc_attr( $option['id'] ); ?>"
 			data-edit-link="<?php echo esc_url( $option['edit'] ); ?>"
+			data-existing-post="1"
 		>
 			<?php echo esc_html( $option['text'] ); ?>
 		</option>

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -387,8 +387,6 @@ jQuery( document ).ready( function( $ ) {
 			existingPost = !! $selected.data( 'existingPost' );
 		}
 
-		$edit.hide();
-
 		if (
 			! existingPost &&
 			'-1' !== value &&
@@ -407,6 +405,8 @@ jQuery( document ).ready( function( $ ) {
 			$group.parents( '.tribe-section' ).addClass( 'tribe-is-creating-linked-post' );
 
 		} else {
+
+			$edit.hide();
 			// Hide all fields and remove their values
 			$group.find( '.linked-post' ).hide().find( 'input, select' ).val( '' );
 
@@ -812,5 +812,4 @@ jQuery( document ).ready( function( $ ) {
 			$el.val( tribeDateFormat( $el.datepicker( 'getDate' ), 'tribeQuery' ) );
 		} );
 	} );
-
-});
+} );

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -387,6 +387,8 @@ jQuery( document ).ready( function( $ ) {
 			existingPost = !! $selected.data( 'existingPost' );
 		}
 
+		$edit.hide();
+
 		if (
 			! existingPost &&
 			'-1' !== value &&
@@ -405,8 +407,6 @@ jQuery( document ).ready( function( $ ) {
 			$group.parents( '.tribe-section' ).addClass( 'tribe-is-creating-linked-post' );
 
 		} else {
-			$edit.hide();
-
 			// Hide all fields and remove their values
 			$group.find( '.linked-post' ).hide().find( 'input, select' ).val( '' );
 

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -383,13 +383,13 @@ jQuery( document ).ready( function( $ ) {
 		let editLink = '';
 		let existingPost = false;
 
-		if ( selectedVal == value ) {
+		if ( selectedVal === value ) {
 			editLink = $selected.data( 'editLink' );
-			existingPost = !!$selected.data( 'existingPost' );
+			existingPost = !! $selected.data( 'existingPost' );
 		}
 
 		if (
-			!existingPost
+			! existingPost
 			&& -1 != value && $select.find( ':selected' ).length
 		) {
 			// Apply the New Given Title to the Correct Field

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -374,7 +374,6 @@ jQuery( document ).ready( function( $ ) {
 	var toggle_linked_post_fields = function( event ) {
 
 		const $select = $( this );
-		const selectData = $select.data( 'select2' );
 		const $group = $select.closest( 'tbody' );
 		const $edit = $group.find( '.edit-linked-post-link a' );
 		const value = $select.val();
@@ -389,8 +388,9 @@ jQuery( document ).ready( function( $ ) {
 		}
 
 		if (
-			! existingPost
-			&& -1 != value && $select.find( ':selected' ).length
+			! existingPost &&
+			'-1' !== value &&
+			$selected.length
 		) {
 			// Apply the New Given Title to the Correct Field
 			$group.find( '.linked-post-name' ).val( value ).parents( '.linked-post' ).eq( 0 ).attr( 'data-hidden', true );

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -373,25 +373,24 @@ jQuery( document ).ready( function( $ ) {
 
 	var toggle_linked_post_fields = function( event ) {
 
-		var $select      = $( this );
-		var selectData   = $select.data( 'select2' );
-		var $group       = $select.closest( 'tbody' );
-		var $edit        = $group.find( '.edit-linked-post-link a' );
-		var value        = $select.val();
-		var editLink     = '';
-		var existingPost = false;
-		var $selected    = $select.find( ':selected' );
-		var selectedVal  = $selected.val();
+		const $select = $( this );
+		const selectData = $select.data( 'select2' );
+		const $group = $select.closest( 'tbody' );
+		const $edit = $group.find( '.edit-linked-post-link a' );
+		const value = $select.val();
+		const $selected = $select.find( ':selected' );
+		const selectedVal = $selected.val();
+		let editLink = '';
+		let existingPost = false;
 
 		if ( selectedVal == value ) {
-			editLink     = $selected.data( 'editLink' );
-			existingPost = !! $selected.data( 'existingPost' );
+			editLink = $selected.data( 'editLink' );
+			existingPost = !!$selected.data( 'existingPost' );
 		}
 
 		if (
-			! existingPost
-			&& -1 != value
-			&& $select.find( ':selected' ).length
+			!existingPost
+			&& -1 != value && $select.find( ':selected' ).length
 		) {
 			// Apply the New Given Title to the Correct Field
 			$group.find( '.linked-post-name' ).val( value ).parents( '.linked-post' ).eq( 0 ).attr( 'data-hidden', true );

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -373,19 +373,23 @@ jQuery( document ).ready( function( $ ) {
 
 	var toggle_linked_post_fields = function( event ) {
 
-		var $select    = $( this );
-		var selectData = $select.data( 'select2' );
-		var $group     = $select.closest( 'tbody' );
-		var $edit      = $group.find( '.edit-linked-post-link a' );
-		var value      = $select.val();
-		var editLink   = '';
+		var $select      = $( this );
+		var selectData   = $select.data( 'select2' );
+		var $group       = $select.closest( 'tbody' );
+		var $edit        = $group.find( '.edit-linked-post-link a' );
+		var value        = $select.val();
+		var editLink     = '';
+		var existingPost = false;
+		var $selected    = $select.find( ':selected' );
+		var selectedVal  = $selected.val();
 
-		if ( $select.find( ':selected' ).val() == value ) {
-			editLink = $select.find( ':selected' ).data( 'editLink' );
+		if ( selectedVal == value ) {
+			editLink     = $selected.data( 'editLink' );
+			existingPost = !! $selected.data( 'existingPost' );
 		}
 
 		if (
-			( ! editLink || _.isEmpty( editLink ) )
+			! existingPost
 			&& -1 != value
 			&& $select.find( ':selected' ).length
 		) {


### PR DESCRIPTION
Typically when you are not logged in as the owner of a venue or organizer, you may get an empty edit link for a linked post type. This is more pronounced when you are logged out using the Community Events submission form when anonymous submissions are enabled.

This PR addresses this by introducing a new data attribute to know which options are an existing linked post and which are brand new. Only existing linked posts will get the data attribute as when typing to create a new one will have that attribute not set ensuring it's treated as intended (as a new linked post to create with the fields).

[TEC-3481]

# Screenshots from CE usage

All screenshots below are from the event submission form while logged out (with anonymous submissions enabled).

## The venue dropdown initial state

<img width="422" alt="Screen Shot 2020-06-04 at 8 05 04 PM" src="https://user-images.githubusercontent.com/709662/83825603-630c9000-a69f-11ea-9cc9-fdd360b7ea10.png">

## The venue dropdown with a new venue being typed (not yet marked for creation)

<img width="748" alt="Screen Shot 2020-06-04 at 8 05 23 PM" src="https://user-images.githubusercontent.com/709662/83825851-1d03fc00-a6a0-11ea-957e-f469c58e26ef.png">

## The venue dropdown with a new venue created showing 'new' fields as expected

<img width="653" alt="Screen Shot 2020-06-04 at 8 05 29 PM" src="https://user-images.githubusercontent.com/709662/83825881-2ab98180-a6a0-11ea-9ded-7ed93d3a285c.png">

## The venue dropdown with an existing venue selected showing no fields as expected

<img width="325" alt="Screen Shot 2020-06-04 at 8 05 44 PM" src="https://user-images.githubusercontent.com/709662/83826032-83891a00-a6a0-11ea-89ca-416ccad4eb1a.png">

## BEFORE: The venue dropdown after selecting an existing venue, then going to create a new one showing edit link

![Screen Shot 2020-06-04 at 8 34 48 PM](https://user-images.githubusercontent.com/709662/83827040-fc897100-a6a2-11ea-8e0f-c346bf8f80c4.png)

## AFTER: The venue dropdown after selecting an existing venue, then going to create a new one showing no edit link

![Screen Shot 2020-06-04 at 8 36 45 PM](https://user-images.githubusercontent.com/709662/83827123-25aa0180-a6a3-11ea-836b-213130e8c74c.png)

[TEC-3481]: https://moderntribe.atlassian.net/browse/TEC-3481