### PR TITLE
Add a provider dedicated to first boot

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Tweak - Improve fresh install experience by setting the default template to the Events one [TEC-3453]
 * Fix - Correctly store Event Organizer meta when using the ORM.
 * Fix - Linked posts (Organizers and Venues) correctly check if the item selected is brand new or existing when edit link is empty. [TEC-3481]
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -632,6 +632,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				tribe_singleton( 'tec.customizer.widget', new Tribe__Events__Customizer__Widget() );
 			}
 
+			// First boot.
+			tribe_register_provider( Tribe\Events\Service_Providers\First_Boot::class );
+
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.
 			 */

--- a/src/Tribe/Service_Providers/First_Boot.php
+++ b/src/Tribe/Service_Providers/First_Boot.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Handles the set up of The Events Calendar plugin on first boot (fresh install) only.
+ *
+ * In place of scattering defaults in redundant checks in the code, this provider should group anything
+ * that fits into a "fresh install".
+ * The provider will not hook any filter if The Events Calendar did init already.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Service_Providers
+ */
+
+namespace Tribe\Events\Service_Providers;
+
+/**
+ * Class First_Boot
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Service_Providers
+ */
+class First_Boot extends \tad_DI52_ServiceProvider {
+
+	/**
+	 * Hooks the filters required to set up The Events Calendar after a fresh install.
+	 *
+	 * @since TBD
+	 */
+	public function register() {
+		$options = \Tribe__Settings_Manager::get_options();
+
+		if ( ! empty( $options['did_init'] ) ) {
+			// If we did init already, bail.
+			return;
+		}
+
+		add_action( 'tribe_events_bound_implementations', [ $this, 'set_default_options' ] );
+
+		/**
+		 * Fires on The Events Calendar first boot.
+		 *
+		 * @since TBD
+		 */
+		do_action( 'tribe_events_first_boot' );
+	}
+
+	/**
+	 * Sets up The Events Calendar default options on first boot.
+	 *
+	 * @since TBD
+	 */
+	public function set_default_options() {
+		$options['did_init'] = true;
+
+		if ( ! isset( $options['tribeEventsTemplate'] ) ) {
+			// Set the Events Template default to "Default Events Template".
+			$options['tribeEventsTemplate'] = '';
+		}
+
+		\Tribe__Settings_Manager::set_options( $options );
+	}
+}

--- a/src/Tribe/Service_Providers/First_Boot.php
+++ b/src/Tribe/Service_Providers/First_Boot.php
@@ -51,6 +51,8 @@ class First_Boot extends \tad_DI52_ServiceProvider {
 	 * @since TBD
 	 */
 	public function set_default_options() {
+		$options = \Tribe__Settings_Manager::get_options();
+
 		$options['did_init'] = true;
 
 		if ( ! isset( $options['tribeEventsTemplate'] ) ) {

--- a/tests/views_wpunit/Tribe/Events/Views/V2/Template_BootstrapTest.php
+++ b/tests/views_wpunit/Tribe/Events/Views/V2/Template_BootstrapTest.php
@@ -3,6 +3,13 @@
 namespace Tribe\Events\Views\V2;
 
 class Template_BootstrapTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		// Let's make sure we do not run "second" tests on a cached value.
+		tribe_set_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME, null );
+	}
+
 	/**
 	 * @test
 	 */


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/TEC-3453 

[Screencap](https://drive.google.com/open?id=18BwF0dUQD5fcQXz9ulNCF4eloZkTIJ7z&authuser=luca%40tri.be&usp=drive_fs)

This PR:

1. Adds a `First_Boot` provider.
2. In that provider set the event template (Events > Settings > Display) to the Events one by default.

While the solution might seem a bit overkill for the issue at hand (set the template to a default value),
it scaffolds an extensible solution to consistently and efficiently handle "fresh installs".
Currently the code contains many places where we make checks like "if this has never been set, then set it
to this value" that could really fit into this provider.

As we model the "fresh install" experience more and more, this provider will grow into a less overkill solution
and one that is managing the whole fresh install checks behind a single option check, not many scattered
in different forms in the code.