### PR TITLE
Fix Event ORM SQL to order events by date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - phpenv config-rm xdebug.ini
 
   # The installation will include wp-cli as well as it's a requirement of wp-browser.
-  - composer update --prefer-dist
+  - composer install
 
   # Let's ensure common autoload files are there.
   - (cd common; composer install --no-dev)

--- a/composer.lock
+++ b/composer.lock
@@ -288,20 +288,23 @@
         },
         {
             "name": "codeception/lib-innerbrowser",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/lib-innerbrowser.git",
-                "reference": "2123542b1325cc349ac68868abe74638bcb32ab6"
+                "reference": "7bdcee4cf654cfeeedd00405edd4f06f85255659"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/2123542b1325cc349ac68868abe74638bcb32ab6",
-                "reference": "2123542b1325cc349ac68868abe74638bcb32ab6",
+                "url": "https://api.github.com/repos/Codeception/lib-innerbrowser/zipball/7bdcee4cf654cfeeedd00405edd4f06f85255659",
+                "reference": "7bdcee4cf654cfeeedd00405edd4f06f85255659",
                 "shasum": ""
             },
             "require": {
                 "codeception/codeception": "*@dev",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
                 "php": ">=5.6.0 <8.0",
                 "symfony/browser-kit": ">=2.7 <6.0",
                 "symfony/dom-crawler": ">=2.7 <6.0"
@@ -337,7 +340,7 @@
             "keywords": [
                 "codeception"
             ],
-            "time": "2020-02-20T14:46:50+00:00"
+            "time": "2020-07-05T14:21:45+00:00"
         },
         {
             "name": "codeception/module-asserts",
@@ -541,23 +544,26 @@
         },
         {
             "name": "codeception/module-phpbrowser",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-phpbrowser.git",
-                "reference": "fbf585c8562e4e4875f351f5392bcb2b1a633cbe"
+                "reference": "c1962657504a2a476b8dbd1f1ee05e0c912e5645"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-phpbrowser/zipball/fbf585c8562e4e4875f351f5392bcb2b1a633cbe",
-                "reference": "fbf585c8562e4e4875f351f5392bcb2b1a633cbe",
+                "url": "https://api.github.com/repos/Codeception/module-phpbrowser/zipball/c1962657504a2a476b8dbd1f1ee05e0c912e5645",
+                "reference": "c1962657504a2a476b8dbd1f1ee05e0c912e5645",
                 "shasum": ""
             },
             "require": {
-                "codeception/codeception": "4.0.x-dev | ^4.0",
-                "codeception/lib-innerbrowser": "^1.0",
-                "guzzlehttp/guzzle": "^6.3.0",
+                "codeception/codeception": "*@dev",
+                "codeception/lib-innerbrowser": "^1.3.2",
+                "guzzlehttp/guzzle": "^6.3.0|^7.0.0",
                 "php": ">=5.6.0 <8.0"
+            },
+            "conflict": {
+                "codeception/codeception": "<4.0"
             },
             "require-dev": {
                 "codeception/module-rest": "dev-master | ^1.0",
@@ -591,20 +597,20 @@
                 "functional-testing",
                 "http"
             ],
-            "time": "2019-10-10T14:25:59+00:00"
+            "time": "2020-07-05T15:29:32+00:00"
         },
         {
             "name": "codeception/module-rest",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/module-rest.git",
-                "reference": "c86417af517bb1fb5b88550455d823a7c9fc167e"
+                "reference": "3664989d35003e182631cd9f4bc055fec009f5be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/module-rest/zipball/c86417af517bb1fb5b88550455d823a7c9fc167e",
-                "reference": "c86417af517bb1fb5b88550455d823a7c9fc167e",
+                "url": "https://api.github.com/repos/Codeception/module-rest/zipball/3664989d35003e182631cd9f4bc055fec009f5be",
+                "reference": "3664989d35003e182631cd9f4bc055fec009f5be",
                 "shasum": ""
             },
             "require": {
@@ -642,7 +648,7 @@
                 "codeception",
                 "rest"
             ],
-            "time": "2020-02-01T19:23:56+00:00"
+            "time": "2020-07-05T15:40:45+00:00"
         },
         {
             "name": "codeception/module-webdriver",
@@ -867,16 +873,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.10.7",
+            "version": "1.10.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "956608ea4f7de9e58c53dfb019d85ae62b193c39"
+                "reference": "56e0e094478f30935e9128552188355fa9712291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/956608ea4f7de9e58c53dfb019d85ae62b193c39",
-                "reference": "956608ea4f7de9e58c53dfb019d85ae62b193c39",
+                "url": "https://api.github.com/repos/composer/composer/zipball/56e0e094478f30935e9128552188355fa9712291",
+                "reference": "56e0e094478f30935e9128552188355fa9712291",
                 "shasum": ""
             },
             "require": {
@@ -895,12 +901,11 @@
                 "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
             },
             "conflict": {
-                "symfony/console": "2.8.38",
-                "symfony/phpunit-bridge": "3.4.40"
+                "symfony/console": "2.8.38"
             },
             "require-dev": {
                 "phpspec/prophecy": "^1.10",
-                "symfony/phpunit-bridge": "^3.4"
+                "symfony/phpunit-bridge": "^4.2"
             },
             "suggest": {
                 "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
@@ -944,7 +949,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2020-06-03T08:03:56+00:00"
+            "time": "2020-06-24T19:23:30+00:00"
         },
         {
             "name": "composer/semver",
@@ -2182,16 +2187,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "83fc32b65ba4720ba07c41109cc5d9348085d210"
+                "reference": "e9797f2fc919ffe246b66ecfef517b895ed158e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/83fc32b65ba4720ba07c41109cc5d9348085d210",
-                "reference": "83fc32b65ba4720ba07c41109cc5d9348085d210",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/e9797f2fc919ffe246b66ecfef517b895ed158e6",
+                "reference": "e9797f2fc919ffe246b66ecfef517b895ed158e6",
                 "shasum": ""
             },
             "require": {
@@ -2261,7 +2266,7 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2020-06-19T08:46:27+00:00"
+            "time": "2020-06-30T10:46:22+00:00"
         },
         {
             "name": "lucatume/wp-snaphot-assertions",
@@ -2310,16 +2315,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.10.3",
+            "version": "v1.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "6d1100f39f684c9e004f808b27f6c824b083d8d8"
+                "reference": "e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/6d1100f39f684c9e004f808b27f6c824b083d8d8",
-                "reference": "6d1100f39f684c9e004f808b27f6c824b083d8d8",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d",
+                "reference": "e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d",
                 "shasum": ""
             },
             "require": {
@@ -2331,7 +2336,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.3-dev"
+                    "dev-master": "1.10.4-dev"
                 }
             },
             "autoload": {
@@ -2351,7 +2356,7 @@
                 }
             ],
             "description": "Peast is PHP library that generates AST for JavaScript code",
-            "time": "2020-04-03T09:06:20+00:00"
+            "time": "2020-06-21T17:16:08+00:00"
         },
         {
             "name": "mikemclin/laravel-wp-password",
@@ -5235,16 +5240,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
                 "shasum": ""
             },
             "require": {
@@ -5257,6 +5262,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5289,20 +5298,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "3bff59ea7047e925be6b7f2059d60af31bb46d6a"
+                "reference": "a57f8161502549a742a63c09f0a604997bf47027"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/3bff59ea7047e925be6b7f2059d60af31bb46d6a",
-                "reference": "3bff59ea7047e925be6b7f2059d60af31bb46d6a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a57f8161502549a742a63c09f0a604997bf47027",
+                "reference": "a57f8161502549a742a63c09f0a604997bf47027",
                 "shasum": ""
             },
             "require": {
@@ -5317,6 +5326,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5351,20 +5364,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c"
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fa79b11539418b02fc5e1897267673ba2c19419c",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7110338d81ce1cbc3e273136e4574663627037a7",
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7",
                 "shasum": ""
             },
             "require": {
@@ -5377,6 +5390,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5410,7 +5427,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -5848,16 +5865,16 @@
         },
         {
             "name": "wp-cli/cache-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cache-command.git",
-                "reference": "d3264aecf0e981b61adc020f5f6664f6538b7434"
+                "reference": "f6c2678c960b60bddaded01d5a33eb0a012451f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cache-command/zipball/d3264aecf0e981b61adc020f5f6664f6538b7434",
-                "reference": "d3264aecf0e981b61adc020f5f6664f6538b7434",
+                "url": "https://api.github.com/repos/wp-cli/cache-command/zipball/f6c2678c960b60bddaded01d5a33eb0a012451f6",
+                "reference": "f6c2678c960b60bddaded01d5a33eb0a012451f6",
                 "shasum": ""
             },
             "require": {
@@ -5913,20 +5930,20 @@
             ],
             "description": "Manages object and transient caches.",
             "homepage": "https://github.com/wp-cli/cache-command",
-            "time": "2019-11-12T01:43:12+00:00"
+            "time": "2020-06-12T00:17:09+00:00"
         },
         {
             "name": "wp-cli/checksum-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/checksum-command.git",
-                "reference": "7db66668ec116c5ccef7bc27b4354fa81b85018a"
+                "reference": "6b2648b01cd016044e2862afc96d3cb2028f2fee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/7db66668ec116c5ccef7bc27b4354fa81b85018a",
-                "reference": "7db66668ec116c5ccef7bc27b4354fa81b85018a",
+                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/6b2648b01cd016044e2862afc96d3cb2028f2fee",
+                "reference": "6b2648b01cd016044e2862afc96d3cb2028f2fee",
                 "shasum": ""
             },
             "require": {
@@ -5968,20 +5985,20 @@
             ],
             "description": "Verifies file integrity by comparing to published checksums.",
             "homepage": "https://github.com/wp-cli/checksum-command",
-            "time": "2019-04-25T00:28:02+00:00"
+            "time": "2020-06-10T13:24:38+00:00"
         },
         {
             "name": "wp-cli/config-command",
-            "version": "v2.0.5",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/config-command.git",
-                "reference": "9530dc42eebcae1fde10ad9e4aad312e06267eb9"
+                "reference": "f204bc62c557adb08f32a84683cc1dbfd23e6d96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/9530dc42eebcae1fde10ad9e4aad312e06267eb9",
-                "reference": "9530dc42eebcae1fde10ad9e4aad312e06267eb9",
+                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/f204bc62c557adb08f32a84683cc1dbfd23e6d96",
+                "reference": "f204bc62c557adb08f32a84683cc1dbfd23e6d96",
                 "shasum": ""
             },
             "require": {
@@ -6037,24 +6054,24 @@
             ],
             "description": "Generates and reads the wp-config.php file.",
             "homepage": "https://github.com/wp-cli/config-command",
-            "time": "2019-11-12T01:43:26+00:00"
+            "time": "2020-06-11T00:17:12+00:00"
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.0.8",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "be62a9364c77a99698364a888362a8c8b9414f2f"
+                "reference": "a2eb072919b252b3c8859f4c9b68fdbb9601099d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/be62a9364c77a99698364a888362a8c8b9414f2f",
-                "reference": "be62a9364c77a99698364a888362a8c8b9414f2f",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/a2eb072919b252b3c8859f4c9b68fdbb9601099d",
+                "reference": "a2eb072919b252b3c8859f4c9b68fdbb9601099d",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
+                "composer/semver": "^1.4 || ^2 || ^3",
                 "wp-cli/wp-cli": "^2.4"
             },
             "require-dev": {
@@ -6104,20 +6121,20 @@
             ],
             "description": "Downloads, installs, updates, and manages a WordPress installation.",
             "homepage": "https://github.com/wp-cli/core-command",
-            "time": "2019-11-12T15:31:38+00:00"
+            "time": "2020-07-05T13:48:05+00:00"
         },
         {
             "name": "wp-cli/cron-command",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cron-command.git",
-                "reference": "184ce82dfd6e7284a73f039ae39cf51a5f73174e"
+                "reference": "f4e1d02642fc56d84504dd012aeb64adee0aae8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/184ce82dfd6e7284a73f039ae39cf51a5f73174e",
-                "reference": "184ce82dfd6e7284a73f039ae39cf51a5f73174e",
+                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/f4e1d02642fc56d84504dd012aeb64adee0aae8c",
+                "reference": "f4e1d02642fc56d84504dd012aeb64adee0aae8c",
                 "shasum": ""
             },
             "require": {
@@ -6167,7 +6184,7 @@
             ],
             "description": "Tests, runs, and deletes WP-Cron events; manages WP-Cron schedules.",
             "homepage": "https://github.com/wp-cli/cron-command",
-            "time": "2019-12-17T17:53:36+00:00"
+            "time": "2020-07-04T07:16:56+00:00"
         },
         {
             "name": "wp-cli/db-command",
@@ -6241,16 +6258,16 @@
         },
         {
             "name": "wp-cli/embed-command",
-            "version": "v2.0.4",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/embed-command.git",
-                "reference": "f67fd41a056c6cb847e8601e058fa836b9e5d325"
+                "reference": "7186d8f969de31324dd2b54a18e5718f2c5db3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/embed-command/zipball/f67fd41a056c6cb847e8601e058fa836b9e5d325",
-                "reference": "f67fd41a056c6cb847e8601e058fa836b9e5d325",
+                "url": "https://api.github.com/repos/wp-cli/embed-command/zipball/7186d8f969de31324dd2b54a18e5718f2c5db3e5",
+                "reference": "7186d8f969de31324dd2b54a18e5718f2c5db3e5",
                 "shasum": ""
             },
             "require": {
@@ -6300,7 +6317,7 @@
             ],
             "description": "Inspects oEmbed providers, clears embed cache, and more.",
             "homepage": "https://github.com/wp-cli/embed-command",
-            "time": "2019-11-12T01:43:50+00:00"
+            "time": "2020-07-05T19:16:43+00:00"
         },
         {
             "name": "wp-cli/entity-command",
@@ -6510,16 +6527,16 @@
         },
         {
             "name": "wp-cli/eval-command",
-            "version": "v2.0.6",
+            "version": "v2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/eval-command.git",
-                "reference": "d379732f9899387a6a631ccea5116b3da6f16300"
+                "reference": "390627d0cb5d991ad341c367de1e8e4534edc5ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/d379732f9899387a6a631ccea5116b3da6f16300",
-                "reference": "d379732f9899387a6a631ccea5116b3da6f16300",
+                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/390627d0cb5d991ad341c367de1e8e4534edc5ad",
+                "reference": "390627d0cb5d991ad341c367de1e8e4534edc5ad",
                 "shasum": ""
             },
             "require": {
@@ -6560,20 +6577,20 @@
             ],
             "description": "Executes arbitrary PHP code or files.",
             "homepage": "https://github.com/wp-cli/eval-command",
-            "time": "2020-02-06T11:24:47+00:00"
+            "time": "2020-06-13T00:17:03+00:00"
         },
         {
             "name": "wp-cli/export-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/export-command.git",
-                "reference": "a31b1777a199a8437127ad3db1b6b92e9cb5cd9b"
+                "reference": "d1b280be8a7d806e345bb4c6965bc85ef0a8bb8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/export-command/zipball/a31b1777a199a8437127ad3db1b6b92e9cb5cd9b",
-                "reference": "a31b1777a199a8437127ad3db1b6b92e9cb5cd9b",
+                "url": "https://api.github.com/repos/wp-cli/export-command/zipball/d1b280be8a7d806e345bb4c6965bc85ef0a8bb8a",
+                "reference": "d1b280be8a7d806e345bb4c6965bc85ef0a8bb8a",
                 "shasum": ""
             },
             "require": {
@@ -6618,24 +6635,24 @@
             ],
             "description": "Exports WordPress content to a WXR file.",
             "homepage": "https://github.com/wp-cli/export-command",
-            "time": "2019-07-16T16:39:17+00:00"
+            "time": "2020-06-13T00:17:03+00:00"
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.0.9",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "b6b042fbeb7b3765e28b92e2971739af3d4ee888"
+                "reference": "2bc83433707fa4d2127f2ff48357ccbbee39052f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/b6b042fbeb7b3765e28b92e2971739af3d4ee888",
-                "reference": "b6b042fbeb7b3765e28b92e2971739af3d4ee888",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/2bc83433707fa4d2127f2ff48357ccbbee39052f",
+                "reference": "2bc83433707fa4d2127f2ff48357ccbbee39052f",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
+                "composer/semver": "^1.4 || ^2.0",
                 "wp-cli/wp-cli": "^2"
             },
             "require-dev": {
@@ -6710,20 +6727,20 @@
             ],
             "description": "Manages plugins and themes, including installs, activations, and updates.",
             "homepage": "https://github.com/wp-cli/extension-command",
-            "time": "2020-04-13T14:55:45+00:00"
+            "time": "2020-07-05T08:07:53+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.2.3",
+            "version": "v2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "7a5d483d872dfec1b89d88d348666ecd59454d52"
+                "reference": "9784ff2c074d1765442b618e6d3a43fee2093a05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7a5d483d872dfec1b89d88d348666ecd59454d52",
-                "reference": "7a5d483d872dfec1b89d88d348666ecd59454d52",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/9784ff2c074d1765442b618e6d3a43fee2093a05",
+                "reference": "9784ff2c074d1765442b618e6d3a43fee2093a05",
                 "shasum": ""
             },
             "require": {
@@ -6767,20 +6784,20 @@
             ],
             "description": "Provides internationalization tools for WordPress projects.",
             "homepage": "https://github.com/wp-cli/i18n-command",
-            "time": "2020-06-04T07:07:10+00:00"
+            "time": "2020-06-12T00:17:09+00:00"
         },
         {
             "name": "wp-cli/import-command",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/import-command.git",
-                "reference": "e28a7f55138ceb53f2ff5926874d8e5582c87db8"
+                "reference": "5c5762401b570b95a61152411c4120cd69419001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/import-command/zipball/e28a7f55138ceb53f2ff5926874d8e5582c87db8",
-                "reference": "e28a7f55138ceb53f2ff5926874d8e5582c87db8",
+                "url": "https://api.github.com/repos/wp-cli/import-command/zipball/5c5762401b570b95a61152411c4120cd69419001",
+                "reference": "5c5762401b570b95a61152411c4120cd69419001",
                 "shasum": ""
             },
             "require": {
@@ -6823,20 +6840,20 @@
             ],
             "description": "Imports content from a given WXR file.",
             "homepage": "https://github.com/wp-cli/import-command",
-            "time": "2019-04-19T14:32:57+00:00"
+            "time": "2020-06-11T00:17:12+00:00"
         },
         {
             "name": "wp-cli/language-command",
-            "version": "v2.0.5",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/language-command.git",
-                "reference": "a14a385efffba2060f947afa85f7ffd7e7cda5d7"
+                "reference": "569be810e057cf9df7d7924e62ebe569e440f6b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/a14a385efffba2060f947afa85f7ffd7e7cda5d7",
-                "reference": "a14a385efffba2060f947afa85f7ffd7e7cda5d7",
+                "url": "https://api.github.com/repos/wp-cli/language-command/zipball/569be810e057cf9df7d7924e62ebe569e440f6b1",
+                "reference": "569be810e057cf9df7d7924e62ebe569e440f6b1",
                 "shasum": ""
             },
             "require": {
@@ -6898,20 +6915,20 @@
             ],
             "description": "Installs, activates, and manages language packs.",
             "homepage": "https://github.com/wp-cli/language-command",
-            "time": "2019-11-12T01:33:31+00:00"
+            "time": "2020-06-12T00:17:09+00:00"
         },
         {
             "name": "wp-cli/maintenance-mode-command",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/maintenance-mode-command.git",
-                "reference": "3c80e731e1032607a2e9589ae6b6398e95c05b91"
+                "reference": "5409778b62daf93e2192f43e2774c5d263d7297d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/3c80e731e1032607a2e9589ae6b6398e95c05b91",
-                "reference": "3c80e731e1032607a2e9589ae6b6398e95c05b91",
+                "url": "https://api.github.com/repos/wp-cli/maintenance-mode-command/zipball/5409778b62daf93e2192f43e2774c5d263d7297d",
+                "reference": "5409778b62daf93e2192f43e2774c5d263d7297d",
                 "shasum": ""
             },
             "require": {
@@ -6955,20 +6972,20 @@
             ],
             "description": "Activates, deactivates or checks the status of the maintenance mode of a site.",
             "homepage": "https://github.com/wp-cli/maintenance-mode-command",
-            "time": "2019-11-12T01:32:41+00:00"
+            "time": "2020-06-11T00:17:12+00:00"
         },
         {
             "name": "wp-cli/media-command",
-            "version": "v2.0.8",
+            "version": "v2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/media-command.git",
-                "reference": "5181e5cee2f6cb43cfee6cacf3b08e8fb166b2b5"
+                "reference": "830e72a2cbd3eeec95a97df2c1c17d925d86790d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/5181e5cee2f6cb43cfee6cacf3b08e8fb166b2b5",
-                "reference": "5181e5cee2f6cb43cfee6cacf3b08e8fb166b2b5",
+                "url": "https://api.github.com/repos/wp-cli/media-command/zipball/830e72a2cbd3eeec95a97df2c1c17d925d86790d",
+                "reference": "830e72a2cbd3eeec95a97df2c1c17d925d86790d",
                 "shasum": ""
             },
             "require": {
@@ -7013,7 +7030,7 @@
             ],
             "description": "Imports files as attachments, regenerates thumbnails, or lists registered image sizes.",
             "homepage": "https://github.com/wp-cli/media-command",
-            "time": "2020-05-13T16:21:49+00:00"
+            "time": "2020-06-11T00:17:12+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -7176,16 +7193,16 @@
         },
         {
             "name": "wp-cli/rewrite-command",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/rewrite-command.git",
-                "reference": "3879bcbf7e695f68097cedb8415ed04915a25465"
+                "reference": "5115c82d6c339ac783d5ee9c7d3ce2949ac25a4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/rewrite-command/zipball/3879bcbf7e695f68097cedb8415ed04915a25465",
-                "reference": "3879bcbf7e695f68097cedb8415ed04915a25465",
+                "url": "https://api.github.com/repos/wp-cli/rewrite-command/zipball/5115c82d6c339ac783d5ee9c7d3ce2949ac25a4b",
+                "reference": "5115c82d6c339ac783d5ee9c7d3ce2949ac25a4b",
                 "shasum": ""
             },
             "require": {
@@ -7229,20 +7246,20 @@
             ],
             "description": "Lists or flushes the site's rewrite rules, updates the permalink structure.",
             "homepage": "https://github.com/wp-cli/rewrite-command",
-            "time": "2019-11-12T01:31:23+00:00"
+            "time": "2020-06-12T00:17:09+00:00"
         },
         {
             "name": "wp-cli/role-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/role-command.git",
-                "reference": "bad54a1b02331ee6460cc6a6f967e37dd91e07a3"
+                "reference": "9f2172988dee5bbeb98e54f291254bee94a556a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/role-command/zipball/bad54a1b02331ee6460cc6a6f967e37dd91e07a3",
-                "reference": "bad54a1b02331ee6460cc6a6f967e37dd91e07a3",
+                "url": "https://api.github.com/repos/wp-cli/role-command/zipball/9f2172988dee5bbeb98e54f291254bee94a556a6",
+                "reference": "9f2172988dee5bbeb98e54f291254bee94a556a6",
                 "shasum": ""
             },
             "require": {
@@ -7291,7 +7308,7 @@
             ],
             "description": "Adds, removes, lists, and resets roles and capabilities.",
             "homepage": "https://github.com/wp-cli/role-command",
-            "time": "2019-11-12T01:30:59+00:00"
+            "time": "2020-06-11T00:17:12+00:00"
         },
         {
             "name": "wp-cli/scaffold-command",
@@ -7358,16 +7375,16 @@
         },
         {
             "name": "wp-cli/search-replace-command",
-            "version": "v2.0.6",
+            "version": "v2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/search-replace-command.git",
-                "reference": "f446ca1f90144b496dbacb373868118ba40df028"
+                "reference": "1104e4fb7dd83e85dedb8a98ed8f0ac30639694b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/f446ca1f90144b496dbacb373868118ba40df028",
-                "reference": "f446ca1f90144b496dbacb373868118ba40df028",
+                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/1104e4fb7dd83e85dedb8a98ed8f0ac30639694b",
+                "reference": "1104e4fb7dd83e85dedb8a98ed8f0ac30639694b",
                 "shasum": ""
             },
             "require": {
@@ -7410,20 +7427,20 @@
             ],
             "description": "Searches/replaces strings in the database.",
             "homepage": "https://github.com/wp-cli/search-replace-command",
-            "time": "2019-12-13T09:13:20+00:00"
+            "time": "2020-06-10T13:24:39+00:00"
         },
         {
             "name": "wp-cli/server-command",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/server-command.git",
-                "reference": "b0c8db803aea2133973a9a35b0d94fb62487b456"
+                "reference": "945b6843d9f130c378869e3277a33af3fceea78d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/server-command/zipball/b0c8db803aea2133973a9a35b0d94fb62487b456",
-                "reference": "b0c8db803aea2133973a9a35b0d94fb62487b456",
+                "url": "https://api.github.com/repos/wp-cli/server-command/zipball/945b6843d9f130c378869e3277a33af3fceea78d",
+                "reference": "945b6843d9f130c378869e3277a33af3fceea78d",
                 "shasum": ""
             },
             "require": {
@@ -7463,20 +7480,20 @@
             ],
             "description": "Launches PHP's built-in web server for a specific WordPress installation.",
             "homepage": "https://github.com/wp-cli/server-command",
-            "time": "2019-11-12T11:32:15+00:00"
+            "time": "2020-06-16T00:17:21+00:00"
         },
         {
             "name": "wp-cli/shell-command",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/shell-command.git",
-                "reference": "293cc82fe6e99c0168bf834787ac5d0e17825723"
+                "reference": "f655611701ed331c336932091860e66839a535f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/shell-command/zipball/293cc82fe6e99c0168bf834787ac5d0e17825723",
-                "reference": "293cc82fe6e99c0168bf834787ac5d0e17825723",
+                "url": "https://api.github.com/repos/wp-cli/shell-command/zipball/f655611701ed331c336932091860e66839a535f3",
+                "reference": "f655611701ed331c336932091860e66839a535f3",
                 "shasum": ""
             },
             "require": {
@@ -7517,20 +7534,20 @@
             ],
             "description": "Opens an interactive PHP console for running and testing PHP code.",
             "homepage": "https://github.com/wp-cli/shell-command",
-            "time": "2019-11-12T01:29:25+00:00"
+            "time": "2020-06-12T00:17:09+00:00"
         },
         {
             "name": "wp-cli/super-admin-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/super-admin-command.git",
-                "reference": "b3f3078d25c17ee586a5f31cb5ce3553613e85b4"
+                "reference": "a4b93491afb74a7e4836ab4ab5c2d8c42fa5e3d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/super-admin-command/zipball/b3f3078d25c17ee586a5f31cb5ce3553613e85b4",
-                "reference": "b3f3078d25c17ee586a5f31cb5ce3553613e85b4",
+                "url": "https://api.github.com/repos/wp-cli/super-admin-command/zipball/a4b93491afb74a7e4836ab4ab5c2d8c42fa5e3d1",
+                "reference": "a4b93491afb74a7e4836ab4ab5c2d8c42fa5e3d1",
                 "shasum": ""
             },
             "require": {
@@ -7574,20 +7591,20 @@
             ],
             "description": "Lists, adds, or removes super admin users on a multisite installation.",
             "homepage": "https://github.com/wp-cli/super-admin-command",
-            "time": "2019-11-12T01:28:59+00:00"
+            "time": "2020-06-10T13:24:39+00:00"
         },
         {
             "name": "wp-cli/widget-command",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/widget-command.git",
-                "reference": "ddbc2c3e9966fae8de05a3200b04e0faf42fe06f"
+                "reference": "1ba59443fc07608450155c7770fe459ddfbc412f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/widget-command/zipball/ddbc2c3e9966fae8de05a3200b04e0faf42fe06f",
-                "reference": "ddbc2c3e9966fae8de05a3200b04e0faf42fe06f",
+                "url": "https://api.github.com/repos/wp-cli/widget-command/zipball/1ba59443fc07608450155c7770fe459ddfbc412f",
+                "reference": "1ba59443fc07608450155c7770fe459ddfbc412f",
                 "shasum": ""
             },
             "require": {
@@ -7637,7 +7654,7 @@
             ],
             "description": "Adds, moves, and removes widgets; lists sidebars.",
             "homepage": "https://github.com/wp-cli/widget-command",
-            "time": "2020-01-18T02:17:30+00:00"
+            "time": "2020-06-16T00:17:21+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
@@ -7773,16 +7790,16 @@
         },
         {
             "name": "wp-cli/wp-config-transformer",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-config-transformer.git",
-                "reference": "1ca98343443a8e4585865db5f50e8e6121fee70b"
+                "reference": "bae1e975ed1277470e3dcc7fd0ef99c2d4f4c7a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/1ca98343443a8e4585865db5f50e8e6121fee70b",
-                "reference": "1ca98343443a8e4585865db5f50e8e6121fee70b",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/bae1e975ed1277470e3dcc7fd0ef99c2d4f4c7a8",
+                "reference": "bae1e975ed1277470e3dcc7fd0ef99c2d4f4c7a8",
                 "shasum": ""
             },
             "require": {
@@ -7790,7 +7807,7 @@
             },
             "require-dev": {
                 "composer/composer": "^1.5.6",
-                "phpunit/phpunit": "^6.5.5",
+                "phpunit/phpunit": "^6.5.5 || ^7.0.0",
                 "wp-coding-standards/wpcs": "^0.14.0 || ^1.0.0 || ^2.0.0"
             },
             "type": "library",
@@ -7810,7 +7827,7 @@
                 }
             ],
             "description": "Programmatically edit a wp-config.php file.",
-            "time": "2019-07-23T17:24:43+00:00"
+            "time": "2020-07-05T12:30:35+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3935,7 +3935,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			$args = [
 				'post__not_in'   => [ $post->ID ],
-				'orderby'        => [ 'start_date_clause' => $order, 'ID' => $order ],
+				'orderby'        => [
+					'start_date_clause' => $order,
+					'ID'                => $order,
+				],
 				'posts_per_page' => 1,
 				'meta_query'     => [
 					'start_date_clause'         => [

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3945,7 +3945,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 						'key'     => '_EventStartDate',
 						'value'   => $start_date,
 						'compare' => $direction,
-						'type'    => 'DATETIME'
+						'type'    => 'DATETIME',
 					],
 					'hide_from_upcoming_clause' => [
 						'key'     => '_EventHideFromUpcoming',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3933,24 +3933,24 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			$start_date = get_post_meta( $post->ID, '_EventStartDate', true );
 			$this->_where_start_date = $start_date;
 
-			$args       = array(
-				'post__not_in'   => array( $post->ID ),
-				'meta_key'       => '_EventStartDate',
-				'orderby'        => array( '_EventStartDate' => $order, 'ID' => $order ),
+			$args = [
+				'post__not_in'   => [ $post->ID ],
+				'orderby'        => [ 'start_date_clause' => $order, 'ID' => $order ],
 				'posts_per_page' => 1,
-				'meta_query'     => array(
-					array(
+				'meta_query'     => [
+					'start_date_clause'         => [
 						'key'     => '_EventStartDate',
 						'value'   => $start_date,
 						'compare' => $direction,
-					),
-					array(
+						'type'    => 'DATETIME'
+					],
+					'hide_from_upcoming_clause' => [
 						'key'     => '_EventHideFromUpcoming',
 						'compare' => 'NOT EXISTS',
-					),
-					'relation'    => 'AND',
-				),
-			);
+					],
+					'relation'                  => 'AND',
+				],
+			];
 
 			/**
 			 * Allows the query arguments used when retrieving the next/previous event link

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1605,7 +1605,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 
 		$order = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
 		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, true, $after );
-		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DATETIME) AS {$meta_alias}", $filter_id, true );
+		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DATETIME ) AS {$meta_alias}", $filter_id, true );
 	}
 
 	/**

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1471,23 +1471,28 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 		$loop  = 0;
 
 		foreach ( $check_orderby as $key => $value ) {
-			$loop++;
 			$order_by      = is_numeric( $key ) ? $value : $key;
-			$order         = is_numeric( $key ) ? 'ASC' : $value;
 			$default_order = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
+			$order         = is_numeric( $key ) ? $default_order : $value;
+
+			// Let the first applied ORDER BY clause override the existing ones, then stack the ORDER BY clauses.
+			$override = $loop === 0;
 
 			switch ( $order_by ) {
 				case 'event_date':
-					$this->order_by_date( false, $after );
+					$this->order_by_date( false, $order, $after, $override );
 					break;
 				case 'event_date_utc':
-					$this->order_by_date( true, $after );
+					$this->order_by_date( true, $order, $after, $override );
+					break;
+				case 'event_duration':
+					$this->order_by_duration( $order, $after, $override );
 					break;
 				case 'organizer':
-					$this->order_by_organizer( $after );
+					$this->order_by_organizer( $order, $after, $override );
 					break;
 				case 'venue':
-					$this->order_by_venue( $after );
+					$this->order_by_venue( $order, $after, $override );
 					break;
 				case $timestamp_key:
 					$this->filter_query->orderby( [ $timestamp_key => $default_order ], null, null, $after );
@@ -1543,11 +1548,15 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 * @since 4.9.7
 	 * @since 4.9.11 Added the `$after` parameter.
 	 *
-	 * @param bool $use_utc      Whether to use the events UTC start dates or their localized dates.
-	 * @param bool $after        Whether to append the order by clause to the ones managed by WordPress or not.
+	 * @param bool   $use_utc    Whether to use the events UTC start dates or their localized dates.
+	 * @param string $order      The order direction, either `ASC` or `DESC`; defaults to `null` to use the order
+	 *                           specified in the current query or default arguments.
+	 * @param bool   $after      Whether to append the order by clause to the ones managed by WordPress or not.
 	 *                           Defaults to `false`,to prepend them to the ones managed by WordPress.
+	 * @param bool   $override   Whether to override existing ORDER BY clauses or not; default to `true` to override
+	 *                           existing ORDER BY clauses.
 	 */
-	protected function order_by_date( $use_utc, $after = false ) {
+	protected function order_by_date( $use_utc, $order = null, $after = false, $override = true ) {
 		global $wpdb;
 
 		$meta_alias = 'event_date';
@@ -1603,9 +1612,11 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 			true
 		);
 
-		$order = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
-		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, true, $after );
-		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DATETIME ) AS {$meta_alias}", $filter_id, true );
+		$order = $order === null
+			? Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' )
+			: $order;
+		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, $override, $after );
+		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DATETIME ) AS {$meta_alias}", $filter_id, $override );
 	}
 
 	/**
@@ -1614,10 +1625,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 * @since 4.9.7
 	 * @since 4.9.11 Added the `$after` parameter.
 	 *
-	 * @param bool $after        Whether to append the order by clause to the ones managed by WordPress or not.
+	 * @param string $order      The order direction, either `ASC` or `DESC`; defaults to `null` to use the order
+	 *                           specified in the current query or default arguments.
+	 * @param bool   $after      Whether to append the order by clause to the ones managed by WordPress or not.
 	 *                           Defaults to `false`,to prepend them to the ones managed by WordPress.
+	 * @param bool   $override   Whether to override existing ORDER BY clauses with this one or not; default to
+	 *                           `true` to override existing ORDER BY clauses.
 	 */
-	protected function order_by_organizer( $after = false ) {
+	protected function order_by_organizer( $order = null, $after = false, $override = true ) {
 		global $wpdb;
 
 		$postmeta_table = 'orderby_organizer_meta';
@@ -1641,10 +1656,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 		);
 
 		$filter_id = 'order_by_organizer';
+		$order     = $order === null
+			? Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' )
+			: $order;
 
-		$order = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
-		$this->filter_query->orderby( [ 'organizer' => $order ], $filter_id, true, $after );
-		$this->filter_query->fields( "{$posts_table}.post_title AS organizer", $filter_id, true );
+		$this->filter_query->orderby( [ 'organizer' => $order ], $filter_id, $override, $after );
+		$this->filter_query->fields( "{$posts_table}.post_title AS organizer", $filter_id, $override );
 	}
 
 	/**
@@ -1653,10 +1670,14 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 	 * @since 4.9.7
 	 * @since 4.9.11 Added the `$after` parameter.
 	 *
-	 * @param bool $after        Whether to append the order by clause to the ones managed by WordPress or not.
+	 * @param string $order      The order direction, either `ASC` or `DESC`; defaults to `null` to use the order
+	 *                           specified in the current query or default arguments.
+	 * @param bool   $after      Whether to append the order by clause to the ones managed by WordPress or not.
 	 *                           Defaults to `false`,to prepend them to the ones managed by WordPress.
+	 * @param bool   $override   Whether to override existing ORDER BY clauses with this one or not; default to
+	 *                           `true` to override existing ORDER BY clauses.
 	 */
-	protected function order_by_venue( $after = false ) {
+	protected function order_by_venue( $order = null,$after = false, $override = true ) {
 		global $wpdb;
 
 		$postmeta_table = 'orderby_venue_meta';
@@ -1680,9 +1701,12 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 		);
 
 		$filter_id = 'order_by_venue';
-		$order     = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
-		$this->filter_query->orderby( [ 'venue' => $order ], $filter_id, true, $after );
-		$this->filter_query->fields( "{$posts_table}.post_title AS venue", $filter_id, true );
+		$order     = $order === null
+			? Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' )
+			: $order;
+
+		$this->filter_query->orderby( [ 'venue' => $order ], $filter_id, $override, $after );
+		$this->filter_query->fields( "{$posts_table}.post_title AS venue", $filter_id, $override );
 	}
 
 	/**
@@ -1720,5 +1744,50 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 		}
 
 		$this->by( 'meta_not_exists', '_EventHideFromUpcoming' );
+	}
+
+	/**
+	 * Sets up the query filters to order events by the duration (`_EventDuration`) custom field.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $order      The order direction, either `ASC` or `DESC`; defaults to `null` to use the order
+	 *                           specified in the current query or default arguments.
+	 * @param bool   $after      Whether to append the duration ORDER BY clause to the existing clauses or not;
+	 *                           defaults to `false` to prepend the duration clause to the existing ORDER BY
+	 *                           clauses.
+	 * @param bool   $override   Whether to override existing ORDER BY clauses with this one or not; default to
+	 *                           `true` to override existing ORDER BY clauses.
+	 */
+	protected function order_by_duration( $order = null, $after = false, $override = true ) {
+		global $wpdb;
+
+		$meta_alias = 'event_duration';
+		$meta_key   = '_EventDuration';
+
+		$postmeta_table = "orderby_{$meta_alias}_meta";
+
+		$filter_id = 'order_by_duration';
+
+		$this->filter_query->join(
+			$wpdb->prepare(
+				"
+				LEFT JOIN {$wpdb->postmeta} AS {$postmeta_table}
+					ON (
+						{$postmeta_table}.post_id = {$wpdb->posts}.ID
+						AND {$postmeta_table}.meta_key = %s
+					)
+				",
+				$meta_key
+			),
+			$filter_id,
+			true
+		);
+
+		$order = $order === null
+			? Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' )
+			: $order;
+		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, $override, $after );
+		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DECIMAL ) AS {$meta_alias}", $filter_id, $override );
 	}
 }

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1605,7 +1605,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 
 		$order = Arr::get_in_any( [ $this->query_args, $this->default_args ], 'order', 'ASC' );
 		$this->filter_query->orderby( [ $meta_alias => $order ], $filter_id, true, $after );
-		$this->filter_query->fields( "MIN( {$postmeta_table}.meta_value ) AS {$meta_alias}", $filter_id, true );
+		$this->filter_query->fields( "CAST( {$postmeta_table}.meta_value AS DATETIME) AS {$meta_alias}", $filter_id, true );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -207,8 +207,6 @@ abstract class By_Day_View extends View {
 			$view_event_ids = $repo
 				->all();
 
-			error_log('last request: ' . print_r($repo->get_query()->request,true));
-
 			$day_results = [];
 
 			$start_meta_key = '_EventStartDate';

--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -187,14 +187,27 @@ abstract class By_Day_View extends View {
 			$last_grid_day  = $days->end;
 			$end            = tribe_end_of_day( $last_grid_day->format( Dates::DBDATETIMEFORMAT ) );
 
-			$view_event_ids = tribe_events()
+			/*
+			 * Sort events in duration ascending order to make sure events that start on the same date and time
+			 * will be correctly positioned for multi-day, or all-day, parsing.
+			 * If not explicit, then events with the same start date and time would be sorted in the order MySQL
+			 * read them (not guaranteed).
+			 */
+			$order_by                   = tribe_normalize_orderby( $order_by, $order );
+			$order_by['event_duration'] = 'ASC';
+
+			$repo           = tribe_events()
 				->set_found_rows( true )
 				->fields( 'ids' )
 				->by_args( $repository_args )
 				->where( 'date_overlaps', $start, $end, null, 2 )
 				->per_page( - 1 )
-				->order_by( $order_by, $order )
+				->order_by( $order_by, $order );
+
+			$view_event_ids = $repo
 				->all();
+
+			error_log('last request: ' . print_r($repo->get_query()->request,true));
 
 			$day_results = [];
 

--- a/tests/integration/Navigation_Test.php
+++ b/tests/integration/Navigation_Test.php
@@ -103,53 +103,50 @@ class Navigation_Test extends \Codeception\TestCase\WPTestCase {
 	 *   5   2015-12-03 16:00:00
 	 */
 	public function test_closest_event_non_linear() {
-		$main = \Tribe__Events__Main::instance();
+		$main     = \Tribe__Events__Main::instance();
 		$settings = $this->post_example_settings;
 		unset( $settings['EventHideFromUpcoming'] );
 
-		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
-		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
-		$settings['EventStartHour'] = '3';
-		$settings['EventStartMinute'] = '00';
-		$settings['EventStartMeridian'] = 'pm';
-		$settings['EventEndHour'] = '4';
-		$settings['EventEndMinute'] = '00';
-		$settings['EventEndMeridian'] = 'pm';
-
-		$post_id = tribe_create_event( $settings );
-		$post_1 = tribe_get_events( array( 'p' => $post_id ) )[0];
-
-		$settings['post_title'] = 'Test event 2';
-		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
-		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+1 day' ) );
-		$settings['EventStartHour'] = '12';
-		$settings['EventEndHour'] = '1';
-
-		$post_id = tribe_create_event( $settings );
-		$post_2 = tribe_get_events( array( 'p' => $post_id ) )[0];
-
-		$settings['post_title'] = 'Test event 3';
-		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
-		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+2 days' ) );
-		$settings['EventStartHour'] = '3';
-		$settings['EventEndHour'] = '4';
-
-		$post_id = tribe_create_event( $settings );
-		$post_3 = tribe_get_events( array( 'p' => $post_id ) )[0];
-
-		$settings['post_title'] = 'Test event 4';
-
-		$post_id = tribe_create_event( $settings );
-		$post_4 = tribe_get_events( array( 'p' => $post_id ) )[0];
-
-		$settings['post_title'] = 'Test event 5';
-		$settings['EventStartDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
-		$settings['EventEndDate'] = date( 'Y-m-d', strtotime( '+3 days' ) );
-		$settings['EventStartHour'] = '4';
-		$settings['EventEndHour'] = '5';
-
-		$post_id = tribe_create_event( $settings );
-		$post_5 = tribe_get_events( array( 'p' => $post_id ) )[0];
+		$post_1 = tribe_events()
+			->set_args( [
+				'title'      => 'Event 1',
+				'start_date' => '+2 days 15:00:00',
+				'duration'   => HOUR_IN_SECONDS,
+				'status'     => 'publish',
+			] )
+			->create();
+		$post_2 = tribe_events()
+			->set_args( [
+				'title'      => 'Event 2',
+				'start_date' => '+1 days 12:00:00',
+				'duration'   => HOUR_IN_SECONDS,
+				'status'     => 'publish',
+			] )
+			->create();
+		$post_3 = tribe_events()
+			->set_args( [
+				'title'      => 'Event 3',
+				'start_date' => '+2 days 15:00:00',
+				'duration'   => HOUR_IN_SECONDS,
+				'status'     => 'publish',
+			] )
+			->create();
+		$post_4 = tribe_events()
+			->set_args( [
+				'title'      => 'Event 4',
+				'start_date' => '+2 days 15:00:00',
+				'duration'   => HOUR_IN_SECONDS,
+				'status'     => 'publish',
+			] )
+			->create();
+		$post_5 = tribe_events()
+			->set_args( [
+				'title'      => 'Event 5',
+				'start_date' => '+3 days 16:00:00',
+				'duration'   => HOUR_IN_SECONDS,
+				'status'     => 'publish',
+			] )
+			->create();
 
 		$this->assertEquals( $post_2->ID, $main->get_closest_event( $post_1, 'previous' )->ID, "Post 1's previous post should be Post 2" );
 		$this->assertEquals( $post_3->ID, $main->get_closest_event( $post_1, 'next' )->ID, "Post 1's next post should be Post 3" );

--- a/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/FetchByDateTest.php
@@ -604,11 +604,15 @@ class FetchByDateTest extends \Codeception\TestCase\WPTestCase {
 			->collect();
 		codecept_debug( 'Event dates in ASC UTC date order: '
 		                . implode( PHP_EOL, $events->pluck_meta( '_EventStartDateUTC' ) ) );
+		codecept_debug( 'Event dates in ASC non-UTC date order: '
+		                . implode( PHP_EOL, $events->pluck_meta( '_EventStartDate' ) ) );
 
-		$utc_matches = tribe_events()
+		$tribe____repository___ = tribe_events();
+		$utc_matches            = $tribe____repository___
 			->where( 'on_date', '2018-01-10' )
 			->order_by( 'event_date_utc', 'DESC' )
 			->collect();
+		codecept_debug($tribe____repository___->get_query()->request);
 		$this->assertEquals( [
 			'2018-01-10 14:00:00',
 			'2018-01-10 10:00:00',

--- a/tests/wpunit/Tribe/Events/ORM/Events/FetchByDurationTest.php
+++ b/tests/wpunit/Tribe/Events/ORM/Events/FetchByDurationTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tribe\Events\ORM\Events;
+
+use Tribe\Events\Test\Factories\Event;
+
+class FetchByDurationTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		tribe_unset_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+
+		// your set up methods here
+		$this->factory()->event = new Event();
+		// Explicitly set the timezone mode to use the site-wide setting.
+		tribe_update_option( 'tribe_events_timezone_mode', 'site' );
+	}
+
+	/**
+	 * It should allow ordering events by duration in ASC order
+	 *
+	 * @test
+	 */
+	public function should_allow_ordering_events_by_duration_in_asc_order() {
+		$date_times = [
+			'2020-01-01 09:00:00' => 2 * HOUR_IN_SECONDS,
+			'2020-01-01 11:00:00' => 3 * HOUR_IN_SECONDS,
+			'2020-01-01 13:00:00' => HOUR_IN_SECONDS,
+			'2020-01-01 15:00:00' => 1.5 * HOUR_IN_SECONDS,
+			'2020-01-01 17:00:00' => 4 * HOUR_IN_SECONDS,
+		];
+		foreach ( $date_times as $date_time => $duration ) {
+			$event_ids[] = tribe_events()
+				->set_args( [
+					'title'      => $date_time . ' Event',
+					'status'     => 'publish',
+					'start_date' => $date_time,
+					'duration'   => $duration,
+				] )->create()->ID;
+		}
+
+		$fetched = tribe_events()
+			->order_by( 'event_duration', 'ASC' )
+			->collect()
+			->pluck_meta( '_EventDuration' );
+
+		$this->assertEquals( array_values( [
+			'2020-01-01 13:00:00' => HOUR_IN_SECONDS,
+			'2020-01-01 15:00:00' => 1.5 * HOUR_IN_SECONDS,
+			'2020-01-01 09:00:00' => 2 * HOUR_IN_SECONDS,
+			'2020-01-01 11:00:00' => 3 * HOUR_IN_SECONDS,
+			'2020-01-01 17:00:00' => 4 * HOUR_IN_SECONDS,
+		] ), $fetched );
+	}
+
+	/**
+	 * It should allow ordering events by duration in DESC order
+	 *
+	 * @test
+	 */
+	public function should_allow_ordering_events_by_duration_in_desc_order() {
+		$date_times = [
+			'2020-01-01 09:00:00' => 2 * HOUR_IN_SECONDS,
+			'2020-01-01 11:00:00' => 3 * HOUR_IN_SECONDS,
+			'2020-01-01 13:00:00' => HOUR_IN_SECONDS,
+			'2020-01-01 15:00:00' => 1.5 * HOUR_IN_SECONDS,
+			'2020-01-01 17:00:00' => 4 * HOUR_IN_SECONDS,
+		];
+		foreach ( $date_times as $date_time => $duration ) {
+			$event_ids[] = tribe_events()
+				->set_args( [
+					'title'      => $date_time . ' Event',
+					'status'     => 'publish',
+					'start_date' => $date_time,
+					'duration'   => $duration,
+				] )->create()->ID;
+		}
+
+		$fetched = tribe_events()
+			->order_by( 'event_duration', 'DESC' )
+			->collect()
+			->pluck_meta( '_EventDuration' );
+
+		$this->assertEquals( array_values( [
+			'2020-01-01 17:00:00' => 4 * HOUR_IN_SECONDS,
+			'2020-01-01 11:00:00' => 3 * HOUR_IN_SECONDS,
+			'2020-01-01 09:00:00' => 2 * HOUR_IN_SECONDS,
+			'2020-01-01 15:00:00' => 1.5 * HOUR_IN_SECONDS,
+			'2020-01-01 13:00:00' => HOUR_IN_SECONDS,
+		] ), $fetched );
+	}
+
+	public function date_and_direction_order_data_provider() {
+		yield 'date=DESC duration=DESC' => [
+			'DESC',
+			'DESC',
+			[
+				[ '2020-01-02 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', .5 * HOUR_IN_SECONDS ],
+			]
+		];
+
+		yield 'date=ASC duration=DESC' => [
+			'ASC',
+			'DESC',
+			[
+				[ '2020-01-01 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', .5 * HOUR_IN_SECONDS ],
+			]
+		];
+
+		yield 'date=ASC duration=ASC' => [
+			'ASC',
+			'ASC',
+			[
+				[ '2020-01-01 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 4 * HOUR_IN_SECONDS ],
+			]
+		];
+
+		yield 'date=DESC duration=ASC' => [
+			'DESC',
+			'ASC',
+			[
+				[ '2020-01-02 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-02 09:00:00', 4 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', .5 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 2 * HOUR_IN_SECONDS ],
+				[ '2020-01-01 09:00:00', 4 * HOUR_IN_SECONDS ],
+			]
+		];
+	}
+
+	/**
+	 * It should allow ordering event by start date and duration
+	 *
+	 * @test
+	 * @dataProvider date_and_direction_order_data_provider
+	 */
+	public function should_allow_ordering_event_by_start_date_and_duration(
+		string $date_order,
+		string $duration_order,
+		array $expected
+	) {
+		$date_times = [
+			[ '2020-01-01 09:00:00', HOUR_IN_SECONDS ],
+			[ '2020-01-01 09:00:00', 2 * HOUR_IN_SECONDS ],
+			[ '2020-01-01 09:00:00', .5 * HOUR_IN_SECONDS ],
+			[ '2020-01-01 09:00:00', 4 * HOUR_IN_SECONDS ],
+			[ '2020-01-02 09:00:00', 4 * HOUR_IN_SECONDS ],
+			[ '2020-01-02 09:00:00', .5 * HOUR_IN_SECONDS ],
+			[ '2020-01-02 09:00:00', 2 * HOUR_IN_SECONDS ],
+			[ '2020-01-02 09:00:00', HOUR_IN_SECONDS ],
+		];
+		foreach ( $date_times as list( $date_time, $duration ) ) {
+			$event_ids[] = tribe_events()
+				->set_args( [
+					'title'      => sprintf( 'Event %s duration %d', $date_time, $duration ),
+					'status'     => 'publish',
+					'start_date' => $date_time,
+					'duration'   => $duration,
+				] )->create()->ID;
+		}
+
+		$fetched = tribe_events()
+			->order_by( [ 'event_date' => $date_order, 'event_duration' => $duration_order ] )
+			->get_ids();
+
+		$fetched_dates_and_durations = array_map( static function ( int $post_id ) {
+			return [
+				get_post_meta( $post_id, '_EventStartDate', true ),
+				(string) (int) get_post_meta( $post_id, '_EventDuration', true ),
+			];
+		}, $fetched );
+		$this->assertEquals( $expected, $fetched_dates_and_durations );
+	}
+}


### PR DESCRIPTION
This PR fixes an issue brought to light by [Stephen PR](https://github.com/moderntribe/the-events-calendar/pull/3227) (which is in no way responsible for the problem!)
that would cause "strange" failures when fetching events by date, either UTC or the
local-to-the-event-timezone one.

The issue is that, in the SQL we use in the `Tribe__Events__Repositories__Event::order_by_date`
method we build this SQL:
```sql
SELECT  DISTINCT test_posts.ID, MIN( orderby_event_date_utc_meta.meta_value ) AS event_date_utc ...
[...]
GROUP BY test_posts.ID ORDER BY event_date_utc DESC, test_posts.post_date
```
The issue with this code is that `MIN( orderby_event_date_utc_meta.meta_value ) AS event_date_utc`
will not make the `event_date_utc` a date-relevant field to sort events by.

So: why did this work until now?
Due to the second `ORDER BY` clause: `test_posts.post_date`; this would make it so that posts would
be ordered by their creation date that, for the most part and in our tests, would map correctly:
events happening at a later date would usually be created later.

Furthermore, in our Vieews, we apply filtering and ordering functions on top of the "raw" ORM results
that have protected us, until now, from getting events in the wrong order. 

How to test this?

The SQL produced by the ORM before the fix is:

```sql
SELECT DISTINCT test_posts.id, 
	   Min(orderby_event_date_utc_meta.meta_value) AS event_date_utc 
	   FROM   test_posts 
		INNER JOIN test_postmeta 
ON ( test_posts.id = test_postmeta.post_id ) 
		LEFT JOIN test_postmeta AS orderby_event_date_utc_meta 
		ON ( orderby_event_date_utc_meta.post_id = test_posts.id 
						AND orderby_event_date_utc_meta.meta_key = 
						'_EventStartDateUTC' ) 
		WHERE  1 = 1 
		AND (( test_postmeta.meta_key = '_EventStartDateUTC' 
								AND Cast(test_postmeta.meta_value AS datetime) BETWEEN 
								'2018-01-10 00:00:00' AND '2018-01-10 23:59:59' )) 
		AND test_posts.post_type = 'tribe_events' 
		AND (( test_posts.post_status = 'publish' )) 
		GROUP  BY test_posts.id 
		ORDER  BY event_date_utc DESC, 
		test_posts.post_date DESC 
		LIMIT  0, 10 
```

```php
public function test_sql(  ) {
		$before_fix_orm_sql = "SELECT DISTINCT test_posts.id, 
				Min(orderby_event_date_utc_meta.meta_value) AS event_date_utc 
				FROM   test_posts 
				INNER JOIN test_postmeta 
				ON ( test_posts.id = test_postmeta.post_id ) 
				LEFT JOIN test_postmeta AS orderby_event_date_utc_meta 
				ON ( orderby_event_date_utc_meta.post_id = test_posts.id 
								AND orderby_event_date_utc_meta.meta_key = 
								'_EventStartDateUTC' ) 
				WHERE  1 = 1 
				AND (( test_postmeta.meta_key = '_EventStartDateUTC' 
										AND Cast(test_postmeta.meta_value AS datetime) BETWEEN 
										'2020-01-01 00:00:00' AND '2020-01-01 23:59:59' )) 
				AND test_posts.post_type = 'tribe_events' 
				AND (( test_posts.post_status = 'publish' )) 
				GROUP  BY test_posts.id 
				ORDER  BY event_date_utc DESC, 
		test_posts.post_date DESC 
				LIMIT  0, 10 ";
		$after_fix_orm_sql = "SELECT DISTINCT test_posts.id, 
				CAST(orderby_event_date_utc_meta.meta_value AS DATETIME) AS event_date_utc 
				FROM   test_posts 
				INNER JOIN test_postmeta 
				ON ( test_posts.id = test_postmeta.post_id ) 
				LEFT JOIN test_postmeta AS orderby_event_date_utc_meta 
				ON ( orderby_event_date_utc_meta.post_id = test_posts.id 
								AND orderby_event_date_utc_meta.meta_key = 
								'_EventStartDateUTC' ) 
				WHERE  1 = 1 
				AND (( test_postmeta.meta_key = '_EventStartDateUTC' 
										AND Cast(test_postmeta.meta_value AS datetime) BETWEEN 
										'2020-01-01 00:00:00' AND '2020-01-01 23:59:59' )) 
				AND test_posts.post_type = 'tribe_events' 
				AND (( test_posts.post_status = 'publish' )) 
				GROUP  BY test_posts.id 
				ORDER  BY event_date_utc DESC, 
					   test_posts.post_date DESC 
							   LIMIT  0, 10 ";
		$unordered_dates = [
				'2020-01-01 13:00:00',
				'2020-01-01 09:00:00',
				'2020-01-01 11:00:00',
				'2020-01-01 07:00:00',
				'2020-01-01 08:00:00',
		];
		shuffle( $unordered_dates);
		foreach ( $unordered_dates as $date ) {
				tribe_events()
						->set_args( [
										'title'      => "Events on {$date}",
										'status'     => 'publish',
										'start_date' => $date,
										'duration'   => 2 * HOUR_IN_SECONDS,
										'timezone'   => 'UTC',
						] )
						->create();
		}

		$expected_dates = [
				'2020-01-01 13:00:00',
				'2020-01-01 11:00:00',
				'2020-01-01 09:00:00',
				'2020-01-01 08:00:00',
				'2020-01-01 07:00:00',
		];

		global $wpdb;
		$this->assertEquals( $expected_dates, wp_list_pluck( $wpdb->get_results( $after_fix_orm_sql ), 'event_date_utc' ) );
		$this->assertEquals( $expected_dates, wp_list_pluck( $wpdb->get_results( $before_fix_orm_sql ), 'event_date_utc' ) );
}
```

While the first test will consistently pass, the second will pass at 
times, and fail most of the times when the mapping between the post
date and the event date is purposefully broken by the `shuffle`.