### PR TITLE
Normalize Views v2 data attribute before usage

### DIFF
--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -621,6 +621,25 @@ tribe.events.views.manager = {};
 	}
 
 	/**
+	 * Normalizes the View data attribute contents unescaping it and replacing various forms of double quotes with
+	 * standard double quotes.
+	 *
+	 * When the data is rendered in the context of a shortcode or widget, then the data HTML code will go through
+	 * filters applied to post content that will escape it. This function will run before any other function in the
+	 * object tries to access and manipulate the data to avoid `JSON.parse` errors.
+	 *
+	 * @since TBD
+	 */
+	obj.normalizeData = function () {
+		var $data = $( obj.selectors.dataScript );
+		var raw = $.trim( $data.text() );
+		var tempDoc = new DOMParser().parseFromString( raw, "text/html" );
+		var unescaped = tempDoc.documentElement.textContent;
+		var normalized = unescaped.replace( /[\u201c\u201d\u201e\u201f\u2033]/g, '"' );
+		$data.text( normalized );
+	};
+
+	/**
 	 * Handles the initialization of the manager when Document is ready.
 	 *
 	 * @since  4.9.2
@@ -629,6 +648,7 @@ tribe.events.views.manager = {};
 	 */
 	obj.ready = function() {
 		obj.selectContainers();
+		obj.normalizeData();
 		obj.$containers.each( obj.setup );
 	};
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -133,6 +133,7 @@ tribe.events.views.manager = {};
 	 */
 	obj.setup = function( index, container ) {
 		var $container = $( container );
+		obj.normalizeData( $container );
 		var $form = $container.find( obj.selectors.form );
 		var $data = $container.find( obj.selectors.dataScript );
 		var data  = {};
@@ -629,9 +630,11 @@ tribe.events.views.manager = {};
 	 * object tries to access and manipulate the data to avoid `JSON.parse` errors.
 	 *
 	 * @since TBD
+	 *
+	 * @param  {jQuery} $container The jQuery object built on the container whose data needs to be normalized.
 	 */
-	obj.normalizeData = function () {
-		var $data = $( obj.selectors.dataScript );
+	obj.normalizeData = function ( $container ) {
+		var $data = $container.find( obj.selectors.dataScript );
 		var raw = $.trim( $data.text() );
 		var tempDoc = new DOMParser().parseFromString( raw, "text/html" );
 		var unescaped = tempDoc.documentElement.textContent;
@@ -648,7 +651,6 @@ tribe.events.views.manager = {};
 	 */
 	obj.ready = function() {
 		obj.selectContainers();
-		obj.normalizeData();
 		obj.$containers.each( obj.setup );
 	};
 


### PR DESCRIPTION
Issues:

* https://moderntribe.atlassian.net/browse/ECP-376
* https://moderntribe.atlassian.net/browse/ECP-374 

This PR supports the work done to make Views V2 work correctly
in the context of shortcodes and theme builders.

Why is this required?
When a shortcode is added in the context of a theme builder, then
it will be rendered as a post body and rendered second.
That rendering is **not** in our control, it's in the control of the
theme builder.
In that process the `data-js` attribute contents, that we use in Views
v2 to hydrate a number of functionalities, will be escaped.
The code in `manager.js` will, then, try to `JSON.parse` it and fail.

Normally:

post -> shortcode -> print HTML

In theme builder:

post -> render shortcode -> escape -> print HTML

The fix is simply one where we normalized the contents of that data attribute
before any `manager.js` function accesses it to make sure any successive call
will find it parse-able.

[Screencap](https://drive.google.com/open?id=1A0KePyri-OWy6K2BFnWEpfrQySTk259F&authuser=luca%40tri.be&usp=drive_fs)