### PR TITLE
Tweak( template tags): Don't escape.

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -60,7 +60,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The singular version of the Event label, defaults to "Event" (uppercase)
 		 */
-		return apply_filters( 'tribe_event_label_singular', esc_html__( 'Event', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_event_label_singular',
+				__( 'Event', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**
@@ -76,7 +81,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The singular lowercase version of the Event label, defaults to "event" (lowercase)
 		 */
-		return apply_filters( 'tribe_event_label_singular_lowercase', esc_html__( 'event', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_event_label_singular_lowercase',
+				__( 'event', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**
@@ -92,7 +102,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The plural version of the Event label, defaults to "Events" (uppercase)
 		 */
-		return apply_filters( 'tribe_event_label_plural', esc_html__( 'Events', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_event_label_plural',
+				__( 'Events', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**
@@ -108,7 +123,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The plural lowercase version of the Event label, defaults to "events" (lowercase)
 		 */
-		return apply_filters( 'tribe_event_label_plural_lowercase', esc_html__( 'events', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_event_label_plural_lowercase',
+				__( 'events', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -52,6 +52,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * Returns the singular version of the Event Label
 	 *
+	 * @since 3.10
+	 * @since TBD escape later.
+	 *
 	 * @return string
 	 */
 	function tribe_get_event_label_singular() {
@@ -72,6 +75,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * Get Event Label Singular lowercase
 	 *
 	 * Returns the singular version of the Event Label
+	 *
+	 * @since 4.1.1
+	 * @since TBD escape later.
 	 *
 	 * @return string
 	 */
@@ -94,6 +100,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * Returns the plural version of the Event Label
 	 *
+	 * @since 3.10
+	 * @since TBD escape later.
+	 *
 	 * @return string
 	 */
 	function tribe_get_event_label_plural() {
@@ -114,6 +123,9 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * Get Event Label Plural lowercase
 	 *
 	 * Returns the plural version of the Event Label
+	 *
+	 * @since 4.1.1
+	 * @since TBD escape later.
 	 *
 	 * @return string
 	 */

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -48,98 +48,114 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Get Event Label Singular
+	 * Get Event Label Singular.
+	 * Returns the singular version of the Event Label.
 	 *
-	 * Returns the singular version of the Event Label
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 3.10
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The singular version of the Event Label.
 	 */
 	function tribe_get_event_label_singular() {
 		/**
-		 * Allows customization of the singular version of the Event Label
+		 * Allows customization of the singular version of the Event Label.
+		 * Note: the output of this filter is not escaped!
+		 *
+		 * @since 3.10
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The singular version of the Event label, defaults to "Event" (uppercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_event_label_singular',
-				__( 'Event', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_event_label_singular',
+			__( 'Event', 'the-events-calendar' )
 		);
 	}
 
 	/**
-	 * Get Event Label Singular lowercase
+	 * Get Event Label Singular lowercase.
+	 * Returns the lowercase singular version of the Event Label.
 	 *
-	 * Returns the singular version of the Event Label
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 4.1.1
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The lowercase singular version of the Event Label.
 	 */
 	function tribe_get_event_label_singular_lowercase() {
 		/**
-		 * Allows customization of the singular lowercase version of the Event Label
+		 * Allows customization of the singular lowercase version of the Event Label.
+		 * Note: the output of this filter is not escaped!
+		 *
+		 * @since 4.1.1
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The singular lowercase version of the Event label, defaults to "event" (lowercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_event_label_singular_lowercase',
-				__( 'event', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_event_label_singular_lowercase',
+			__( 'event', 'the-events-calendar' )
 		);
 	}
 
 	/**
-	 * Get Event Label Plural
+	 * Get Event Label Plural.
+	 * Returns the plural version of the Event Label.
 	 *
-	 * Returns the plural version of the Event Label
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 3.10
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The plural version of the Event Label.
 	 */
 	function tribe_get_event_label_plural() {
 		/**
-		 * Allows customization of the plural version of the Event Label
+		 * Allows customization of the plural version of the Event Label.
+		 * Note: the output of this filter is not escaped!
+		 *
+		 * @since 3.10
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The plural version of the Event label, defaults to "Events" (uppercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_event_label_plural',
-				__( 'Events', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_event_label_plural',
+			__( 'Events', 'the-events-calendar' )
 		);
 	}
 
 	/**
-	 * Get Event Label Plural lowercase
+	 * Get Event Label Plural lowercase.
+	 * Returns the plural version of the Event Label.
 	 *
-	 * Returns the plural version of the Event Label
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 4.1.1
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The lowercase plural version of the Event Label.
 	 */
 	function tribe_get_event_label_plural_lowercase() {
 		/**
-		 * Allows customization of the plural lowercase version of the Event Label
+		 * Allows customization of the plural lowercase version of the Event Label.
+		 * Note: the output of this filter is not escaped!
+		 *
+		 * @since 4.1.1
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The plural lowercase version of the Event label, defaults to "events" (lowercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_event_label_plural_lowercase',
-				__( 'events', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_event_label_plural_lowercase',
+			__( 'events', 'the-events-calendar' )
 		);
 	}
 

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -109,7 +109,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return string
 	 */
 	function tribe_get_organizer_label_singular() {
-		return apply_filters( 'tribe_organizer_label_singular', esc_html__( 'Organizer', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_organizer_label_singular',
+				__( 'Organizer', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**
@@ -120,7 +125,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return string
 	 */
 	function tribe_get_organizer_label_plural() {
-		return apply_filters( 'tribe_organizer_label_plural', esc_html__( 'Organizers', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_organizer_label_plural',
+				__( 'Organizers', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -102,59 +102,66 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Get Organizer Label Singular
-	 *
+	 * Get Organizer Label Singular.
 	 * Returns the singular version of the Organizer Label.
 	 *
-	 * @since 3.7
-	 * @since TBD escape later.
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
-	 * @return string
+	 * @since 3.7
+	 * @since TBD remove escaping.
+	 *
+	 * @return string The singular version of the Organizer Label.
 	 */
 	function tribe_get_organizer_label_singular() {
 		/**
-		 * Allows customization of the singular version of the Organizer Label
+		 * Allows customization of the singular version of the Organizer Label.
+		 * Note: the output of this filter is not escaped!
 		 *
-		 * @since TBD Added docblock.
+		 * @since 3.7
+		 * @since TBD Added docblock, remove escaping.
 		 *
 		 * @param string $label The singular version of the Organizer label, defaults to "Organizer" (uppercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_organizer_label_singular',
-				__( 'Organizer', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_organizer_label_singular',
+			__( 'Organizer', 'the-events-calendar' )
 		);
 	}
 
 	/**
 	 * Get Organizer Label Plural
-	 *
 	 * Returns the plural version of the Organizer Label.
 	 *
-	 * @since 3.7
-	 * @since TBD escape later.
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
-	 * @return string
+	 * @since 3.7
+	 * @since TBD remove escaping.
+	 *
+	 * @return string The plural version of the Organizer Label.
 	 */
 	function tribe_get_organizer_label_plural() {
 		/**
-		 * Allows customization of the plural version of the Organizer Label
+		 * Allows customization of the plural version of the Organizer Label.
+		 * Note: the output of this filter is not escaped!
 		 *
-		 * @since TBD Added docblock.
+		 * @since 3.7
+		 * @since TBD Added docblock, remove escaping.
 		 *
-		 * @param string $label The plural version of the Organizer label, defaults to "Organizers" (uppercase)
+		 * @param string $label The plural version of the Organizer label, defaults to "Organizers" (uppercase).
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_organizer_label_plural',
-				__( 'Organizers', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_organizer_label_plural',
+			__( 'Organizers', 'the-events-calendar' )
 		);
 	}
 
 	/**
-	 * Get the organizer label
+	 * Get the organizer label.
+	 *
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @param bool $singular TRUE to return the singular label, FALSE to return plural.
 	 *

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -106,9 +106,19 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * Returns the singular version of the Organizer Label.
 	 *
+	 * @since 3.7
+	 * @since TBD escape later.
+	 *
 	 * @return string
 	 */
 	function tribe_get_organizer_label_singular() {
+		/**
+		 * Allows customization of the singular version of the Organizer Label
+		 *
+		 * @since TBD Added docblock.
+		 *
+		 * @param string $label The singular version of the Organizer label, defaults to "Organizer" (uppercase)
+		 */
 		return esc_html(
 			apply_filters(
 				'tribe_organizer_label_singular',
@@ -122,9 +132,19 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 *
 	 * Returns the plural version of the Organizer Label.
 	 *
+	 * @since 3.7
+	 * @since TBD escape later.
+	 *
 	 * @return string
 	 */
 	function tribe_get_organizer_label_plural() {
+		/**
+		 * Allows customization of the plural version of the Organizer Label
+		 *
+		 * @since TBD Added docblock.
+		 *
+		 * @param string $label The plural version of the Organizer label, defaults to "Organizers" (uppercase)
+		 */
 		return esc_html(
 			apply_filters(
 				'tribe_organizer_label_plural',

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -127,7 +127,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	/**
 	 * Returns the singular version of the Venue Label
 	 *
-	 * @since ??
+	 * @since 3.7
+	 * @since TBD escape later.
 	 *
 	 * @return string
 	 */
@@ -136,7 +137,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 * Allows customization of the singular version of the Venue Label
 		 *
 		 * @since ??
-		 * @since 4.5.12 Added docblock
+		 * @since 4.5.12 Added docblock.
 		 *
 		 * @param string $label The singular version of the Venue label, defaults to "Venue" (uppercase)
 		 */
@@ -151,7 +152,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	/**
 	 * Returns the plural version of the Venue Label
 	 *
-	 * @since ??
+	 * @since 3.7
+	 * @since TBD escape later.
 	 *
 	 * @return string
 	 */

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -125,52 +125,58 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Returns the singular version of the Venue Label
+	 * Returns the singular version of the Venue Label.
+	 *
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 3.7
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The singular version of the Venue Label.
 	 */
 	function tribe_get_venue_label_singular() {
 		/**
-		 * Allows customization of the singular version of the Venue Label
+		 * Allows customization of the singular version of the Venue Label.
+		 * Note: the output of this filter is not escaped!
 		 *
-		 * @since ??
+		 * @since 3.7
 		 * @since 4.5.12 Added docblock.
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The singular version of the Venue label, defaults to "Venue" (uppercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_venue_label_singular',
-				__( 'Venue', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_venue_label_singular',
+			__( 'Venue', 'the-events-calendar' )
 		);
 	}
 
 	/**
-	 * Returns the plural version of the Venue Label
+	 * Returns the plural version of the Venue Label.
+	 *
+	 * Note: the output of this function is not escaped.
+	 * You should escape it wherever you use it!
 	 *
 	 * @since 3.7
-	 * @since TBD escape later.
+	 * @since TBD remove escaping.
 	 *
-	 * @return string
+	 * @return string The plural version of the Venue Label.
 	 */
 	function tribe_get_venue_label_plural() {
 		/**
-		 * Allows customization of the plural version of the Venue Label
+		 * Allows customization of the plural version of the Venue Label.
+		 * Note: the output of this filter is not escaped!
 		 *
-		 * @since ??
+		 * @since 3.7
 		 * @since 4.5.12 Added docblock
+		 * @since TBD Remove escaping.
 		 *
 		 * @param string $label The plural version of the Venue label, defaults to "Venues" (uppercase)
 		 */
-		return esc_html(
-			apply_filters(
-				'tribe_venue_label_plural',
-				__( 'Venues', 'the-events-calendar' )
-			)
+		return apply_filters(
+			'tribe_venue_label_plural',
+			__( 'Venues', 'the-events-calendar' )
 		);
 	}
 

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -140,7 +140,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The singular version of the Venue label, defaults to "Venue" (uppercase)
 		 */
-		return apply_filters( 'tribe_venue_label_singular', esc_html__( 'Venue', 'the-events-calendar' ) );
+		return esc_html(
+			apply_filters(
+				'tribe_venue_label_singular',
+				__( 'Venue', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**
@@ -159,7 +164,12 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The plural version of the Venue label, defaults to "Venues" (uppercase)
 		 */
-		return apply_filters( 'tribe_venue_label_plural', esc_html__( 'Venues', 'the-events-calendar' ) );
+		return  esc_html(
+			apply_filters(
+				'tribe_venue_label_plural',
+				__( 'Venues', 'the-events-calendar' )
+			)
+		);
 	}
 
 	/**

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -164,7 +164,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string $label The plural version of the Venue label, defaults to "Venues" (uppercase)
 		 */
-		return  esc_html(
+		return esc_html(
 			apply_filters(
 				'tribe_venue_label_plural',
 				__( 'Venues', 'the-events-calendar' )


### PR DESCRIPTION
Remove the esc_html, add comments to the docblocks that we do not escape and all output should be escaped.

Not part of this ticket, but following CR [comments and new direction forward](https://github.com/moderntribe/events-virtual/pull/161#discussion_r462097152) from it.
[VE-136]

[VE-136]: https://moderntribe.atlassian.net/browse/VE-136