### PR TITLE
Disable restv1 suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,5 +140,6 @@ script:
   - codecept run -f muintegration
   - codecept run -f wpunit
   - codecept run -f aggregatorv1
-  - codecept run -f restv1
+  # Disabled on 2020/08/18 due to inconsistent failures.
+  # - codecept run -f restv1
   # - codecept run acceptance


### PR DESCRIPTION
This PR disables the `restv1` suite, covering the REST API v1 implementation from the acceptance level, as it became inconsistent in its failures over the last period.

The PR is **NOT** a permanent disable of the suite, I'm just taking it down for maintenance with the intent of cleaning up the build outputs of intermittent failures, unblocking devs and working on the issue(s) of the suite with more time.