### PR TITLE
Spotfix/ve 150 phpcs changes strip tags

### DIFF
--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -662,11 +662,11 @@ class Tribe__Events__iCal {
 		$item['CREATED']       = 'CREATED:' . $tzoned->created;
 		$item['LAST-MODIFIED'] = 'LAST-MODIFIED:' . $tzoned->modified;
 		$item['UID']           = 'UID:' . $event_post->ID . '-' . $time->start . '-' . $time->end . '@' . wp_parse_url( home_url( '/' ), PHP_URL_HOST );
-		$item['SUMMARY']       = 'SUMMARY:' . $this->replace( strip_tags( $event_post->post_title ) );
+		$item['SUMMARY']       = 'SUMMARY:' . $this->replace( wp_strip_all_tags( $event_post->post_title ) );
 
 		$content = apply_filters( 'the_content', tribe( 'editor.utils' )->exclude_tribe_blocks( $event_post->post_content ) );
 
-		$item['DESCRIPTION'] = 'DESCRIPTION:' . $this->replace( strip_tags( str_replace( '</p>', '</p> ', $content ) ) );
+		$item['DESCRIPTION'] = 'DESCRIPTION:' . $this->replace( wp_strip_all_tags( str_replace( '</p>', '</p> ', $content ) ) );
 
 		$item['URL'] = 'URL:' . get_permalink( $event_post->ID );
 

--- a/tests/wpunit/Tribe/Events/iCalTest.php
+++ b/tests/wpunit/Tribe/Events/iCalTest.php
@@ -306,15 +306,18 @@ multiple lines",
 		$event = get_post( $event );
 		$ical = $sut->generate_ical_feed( $event, false );
 
-		$this->assertContains( "SUMMARY:" . $args['post_title'], $ical );
+		$this->assertContains( "SUMMARY:" . wp_strip_all_tags( $args['post_title'] ), $ical );
 
 		$content = apply_filters( 'the_content', tribe( 'editor.utils' )->exclude_tribe_blocks( $event->post_content ) );
 
 		$content =  str_replace(
 			[  ',', "\n", "\r"  ],
 			[  '\,', '\n', '' ],
-			strip_tags( str_replace( '</p>', '</p> ', $content ) )
+			wp_strip_all_tags( str_replace( '</p>', '</p> ', $content ) )
 		);
+
+		var_dump($args['post_title']);
+		var_dump($content);
 		$this->assertContains( "DESCRIPTION:" . $content, $ical );
 	}
 

--- a/tests/wpunit/Tribe/Events/iCalTest.php
+++ b/tests/wpunit/Tribe/Events/iCalTest.php
@@ -316,8 +316,6 @@ multiple lines",
 			wp_strip_all_tags( str_replace( '</p>', '</p> ', $content ) )
 		);
 
-		var_dump($args['post_title']);
-		var_dump($content);
 		$this->assertContains( "DESCRIPTION:" . $content, $ical );
 	}
 


### PR DESCRIPTION
_Ref:_ [VE-150](https://moderntribe.atlassian.net/browse/VE-150)

This PR is to address a PHPCS comment:
https://github.com/moderntribe/the-events-calendar/pull/3260/files#r470175531

Instead of an artifact, this is what the change does per our automated tests:

The original `strip_tags` left the newline at the end:
"Sample\nText\nWITH\nmultiple lines \n"

With  `wp_strip_all_tags` it removes it:
"Sample\nText\nWITH\nmultiple lines"

Tests are updated and passing. 

**Should we merge this now in B20.08 or wait until B20.09?**
