### PR TITLE
With WPML some strings are loaded in the wrong language.

### DIFF
--- a/src/Tribe/I18n.php
+++ b/src/Tribe/I18n.php
@@ -185,6 +185,17 @@ class I18n {
 		$result = $do( ...$args );
 		remove_filter( 'locale', $force_locale );
 
+		foreach ( (array) $args[1] as $domain => $file ) {
+			// Reload it with the correct language.
+			unload_textdomain( $domain );
+
+			if ( 'default' === $domain ) {
+				load_default_textdomain();
+			} else {
+				Common::instance()->load_text_domain( $domain, $file );
+			}
+		}
+
 		// Restore the `locale` filtering functions.
 		$wp_filter['locale'] = $locale_filters_backup;
 
@@ -270,15 +281,6 @@ class I18n {
 						$strings[ $key ][] = __( ucfirst( $value ), $domain );
 					}
 				}
-			}
-
-			// Reload it with the correct language.
-			unload_textdomain( $domain );
-
-			if ( 'default' === $domain ) {
-				load_default_textdomain();
-			} else {
-				Common::instance()->load_text_domain( $domain, $file );
 			}
 		}
 


### PR DESCRIPTION
# List of affected users

https://wpml.org/de/forums/topic/adminbar-auf-deutsch-zeigt-funktionen-teilweise-auf-franzoesisch
https://wpml.org/forums/topic/admin-bar-isnt-displayed-in-default-language
https://wpml.org/forums/topic/adming-language-showing-in-wrong-language
https://wpml.org/forums/topic/automatically-showing-the-events-page-in-portugues-instead-of-default-english
https://wpml.org/forums/topic/chinese-strings-in-front-end-admin-bar-and-english-home-page
https://wpml.org/forums/topic/modern-tribe-events-calendar-events-page-displaying-french-text-on-english-page
https://wpml.org/forums/topic/string-translations-are-mixedup
https://wpml.org/forums/topic/wpml-chat-support-ticket-by-daniellem-2-1597319479