### PR TITLE
Add doc entry for TEC PR 3272

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Fix a PHP error that would arise when during the translation, by the WPML plugin, of some strings. [TEC-3454]
 * Fix - Fix a compatibility issue with the WPML plugin that would prevent some options from being translated correctly. [TEC-3454]
+* Fix - Generation and usage of translated strings that would cause issues with the WPML plugin. [TEC-3454]
 * Tweak - Use the `border-small` class for the today button, add new border button styles to customizer. [FBAR-143]
 * Tweak - Add missing CSS classes to the Event Categories label on the single event page. [TEC-3478]
 * Tweak - Adjust accordion trigger selector to allow multiple space-separated `data-js` attributes. [FBAR-125]

--- a/src/Tribe/I18n.php
+++ b/src/Tribe/I18n.php
@@ -185,6 +185,17 @@ class I18n {
 		$result = $do( ...$args );
 		remove_filter( 'locale', $force_locale );
 
+		foreach ( (array) $args[1] as $domain => $file ) {
+			// Reload it with the correct language.
+			unload_textdomain( $domain );
+
+			if ( 'default' === $domain ) {
+				load_default_textdomain();
+			} else {
+				Common::instance()->load_text_domain( $domain, $file );
+			}
+		}
+
 		// Restore the `locale` filtering functions.
 		$wp_filter['locale'] = $locale_filters_backup;
 
@@ -270,15 +281,6 @@ class I18n {
 						$strings[ $key ][] = __( ucfirst( $value ), $domain );
 					}
 				}
-			}
-
-			// Reload it with the correct language.
-			unload_textdomain( $domain );
-
-			if ( 'default' === $domain ) {
-				load_default_textdomain();
-			} else {
-				Common::instance()->load_text_domain( $domain, $file );
 			}
 		}
 


### PR DESCRIPTION
This PR is just a repackage of the [original PR from the WPML team](https://github.com/moderntribe/the-events-calendar/pull/3272) to add the changelog entry and test it out locally.
Credit for the fix goes to WPML team!

Issue: https://moderntribe.atlassian.net/browse/TEC-3578

[Screencast (no audio)](https://drive.google.com/open?id=1CRRHxMq5N69jBgN2y1xmWrHas4ZMmK60&authuser=luca%40tri.be&usp=drive_fs)
In the screencast I'm **not** testing the plugin with WPML activated as the WPML Team, that provided [the original PR I am only repackaging](https://github.com/moderntribe/the-events-calendar/pull/3272), has already tested that. In the screencast I am making sure the localization functions keep working correctly when the fix is applied (they do), including permalink localization and filtering.