### PR TITLE
Generate the REST nonce suspending WC filters

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1393,7 +1393,16 @@ class View implements View_Interface {
 			? Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT )
 			: false;
 
-		$template_vars = [
+		/*
+		 * Some plugins, like WooCommerce, will modify the UID of logged out users; avoid that filtering here.
+		 *
+		 * @see TEC-3579
+		 */
+		$rest_nonce = tribe_without_filters( [ 'nonce_user_logged_out' ], static function () {
+			return wp_create_nonce( 'wp_rest' );
+		} );
+
+		$template_vars   = [
 			'title'                => $this->get_title( $events ),
 			'events'               => $events,
 			'url'                  => $this->get_url( true ),
@@ -1408,7 +1417,7 @@ class View implements View_Interface {
 			'now'                  => $this->context->get( 'now', 'now' ),
 			'request_date'         => Dates::build_date_object( $this->context->get( 'event_date', $today ) ),
 			'rest_url'             => tribe( Rest_Endpoint::class )->get_url(),
-			'rest_nonce'           => wp_create_nonce( 'wp_rest' ),
+			'rest_nonce'           => $rest_nonce,
 			'should_manage_url'    => $this->should_manage_url,
 			'today_url'            => $today_url,
 			'prev_label'           => $this->get_link_label( $this->prev_url( false ) ),

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_base_template_if_view_has_no_template__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_base_template_if_view_has_no_template__1.php
@@ -11,6 +11,13 @@
 					<li>Path: <code>/plugins/the-events-calendar/src/views/v2</code></li>
 				</ul>
 			</li>
+					<li>
+				<ul>
+					<li>Id: <code>common</code></li>
+					<li>Priority: <code>100</code></li>
+					<li>Path: <code>/plugins/the-events-calendar/common/src/views/v2</code></li>
+				</ul>
+			</li>
 			</ul>
 	<p>Template context:</p>
 	<pre>


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/TEC-3579

[Screencast](https://drive.google.com/open?id=1CUDUUP10O2N1n9-bm47NTcdpuaE-FXZX&authuser=luca%40tri.be&usp=drive_fs)

This PR fixes the issue that was caused by the following combination:

1. the user is not logged in
2. WooCommerce will filter the `nonce_user_logged_out` filter to set the user id to a hash used for cart tracking
3. the user id is part of the salts used to generated the nonces, including the views nonce, during the PHP initial state render
4. WooCommerc will not filter the `nonce_user_logged_out` filter during AJAx requests
5. during the AJAX requests fired by the Views to fetch the new HTML the nonce provided (salted with the hash user id) will not match the one generated without applying hashes (point 4: WC is not filtering that during AJAX requests)

The fix leverages the `tribe_without_filters` function, introduced in [the common PR](https://github.com/moderntribe/tribe-common/pull/1436) to generate the view REST nonce correctly, suspending filtering that might be applied to it.