### PR TITLE
Allow the accordion script to run out of FE context

### DIFF
--- a/src/resources/js/views/accordion.js
+++ b/src/resources/js/views/accordion.js
@@ -298,6 +298,11 @@ tribe.events.views.accordion = {};
 	 * @return {void}
 	 */
 	obj.ready = function() {
+		if ( ! tribe.events.views.manager ) {
+			// The script might  be used outside of the Views v2 context, if that is the case, skip the auto-binding.
+			return;
+		}
+
 		$document.on( 'afterSetup.tribeEvents', tribe.events.views.manager.selectors.container, obj.bindEvents );
 	};
 

--- a/src/resources/js/views/accordion.js
+++ b/src/resources/js/views/accordion.js
@@ -299,7 +299,7 @@ tribe.events.views.accordion = {};
 	 */
 	obj.ready = function() {
 		if ( ! tribe.events.views.manager ) {
-			// The script might  be used outside of the Views v2 context, if that is the case, skip the auto-binding.
+			// The script might be used outside of the Views v2 context, if that is the case, skip the auto-binding.
 			return;
 		}
 


### PR DESCRIPTION
This PR modifies the auto-binding function of the accordion script to avoid issues when not using it in the Views Front-end context.