### PR TITLE
Allow filtering the template display

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Adjust accordion trigger selector to allow multiple space-separated `data-js` attributes. [FBAR-125]
 * Tweak - Adjust spacing on header to prevent screen overflow. [FBAR-132]
 * Tweak - Adjust aria attributes and add loader text to make ajax loading more accessible. [FBAR-147]
+* Tweak - Add the `tribe_events_latest_past_view_display_template` filter to allow controlling the display of templates  in the context of the Latest Past Events View. [FBAR-148]
 
 = [5.1.6] 2020-08-24 =
 

--- a/src/Tribe/Views/V2/Views/Latest_Past_View.php
+++ b/src/Tribe/Views/V2/Views/Latest_Past_View.php
@@ -40,7 +40,7 @@ class Latest_Past_View extends View {
 	 *
 	 * @var array
 	 */
-	protected $whitelist = [
+	protected $safelist = [
 		// Standard View Components.
 		'components/loader',
 		'components/json-ld-data',
@@ -123,6 +123,9 @@ class Latest_Past_View extends View {
 		'latest-past/event/cost',
 		'latest-past/event/date-tag',
 		'latest-past/event/date/meta',
+
+		// Add-ons.
+		'components/filter-bar'
 	];
 
 	/**
@@ -154,7 +157,6 @@ class Latest_Past_View extends View {
 	 * @since 5.1.0
 	 */
 	public function add_view_filters() {
-
 		add_filter( 'tribe_template_html:events/v2/components/messages', [ $this, 'filter_template_done' ] );
 		add_filter( 'tribe_template_html:events/v2/components/ical-link', [ $this, 'add_view' ] );
 	}
@@ -166,8 +168,7 @@ class Latest_Past_View extends View {
 	 * @since 5.1.0
 	 */
 	public function filter_template_done( $html ) {
-
-		add_filter( 'tribe_template_done', [ $this, 'filter_template_display_by_whitelist' ], 10, 4 );
+		add_filter( 'tribe_template_done', [ $this, 'filter_template_display_by_safelist' ], 10, 4 );
 
 		return $html;
 	}
@@ -184,9 +185,22 @@ class Latest_Past_View extends View {
 	 *
 	 * @return string
 	 */
-	public function filter_template_display_by_whitelist( $done, $name, $context, $echo ) {
+	public function filter_template_display_by_safelist( $done, $name, $context, $echo ) {
+		$display = in_array( $name, $this->safelist, true );
 
-		if ( in_array( $name, $this->whitelist, true ) ) {
+		/**
+		 * Filters whether a specific template should show in the context of the Latest Past Events View or not.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool   $display Whether a specified template should display or not.
+		 * @param string $name    The template name.
+		 * @param array  $context The data context for this template inclusion.
+		 * @param bool   $echo    Whether the template inclusion is attempted to then echo to the page, or not.
+		 */
+		$display = apply_filters( 'tribe_events_latest_past_view_display_template', $display, $name, $context, $echo );
+
+		if ( $display ) {
 			return $done;
 		}
 

--- a/src/Tribe/Views/V2/Views/Latest_Past_View.php
+++ b/src/Tribe/Views/V2/Views/Latest_Past_View.php
@@ -125,7 +125,7 @@ class Latest_Past_View extends View {
 		'latest-past/event/date/meta',
 
 		// Add-ons.
-		'components/filter-bar'
+		'components/filter-bar',
 	];
 
 	/**


### PR DESCRIPTION
This PR updates the Latest Past Events view to allow overriding its safelist
at run-time and allow templates to show hide with filter control.

[Screencast showing FBAR support that would not show before](https://drive.google.com/open?id=1D4PpfwChYp9JNe89tPNjwhNx8sTTKQDw&authuser=luca%40tri.be&usp=drive_fs)