### PR TITLE
Ensure List View displays in ASC order

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,7 +224,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.2.0] 2020-09-28 =
 
-* Fix - Fix a PHP error that would arise when during the translation, by the WPML plugin, of some strings. [TEC-3454]
+* Fix - Fix the order of the List View when the PRO is set to show only the first instance of a Recurring Event. [ECP-467]
+* Fix - Fix a PHP error that would arise when during the translation, by the WPML plugin, of some strings. [TEC-3454, TEC-3578]
 * Fix - Fix a compatibility issue with the WPML plugin that would prevent some options from being translated correctly. [TEC-3454]
 * Fix - Generation and usage of translated strings that would cause issues with the WPML plugin. [TEC-3454]
 * Tweak - Use the `border-small` class for the today button, add new border button styles to customizer. [FBAR-143]

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -241,6 +241,7 @@ class List_View extends View {
 
 		if ( 'past' !== $event_display ) {
 			$args['ends_after'] = $date;
+			$args['order']      = 'ASC';
 		} else {
 			$orderby             = Arr::get_first_set( $args, [ 'orderby', 'order_by' ], [] );
 			$orderby             = tribe_normalize_orderby( $orderby );


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/ECP-467 

[Screencast](https://drive.google.com/open?id=1Fi6u79JEMep5HskfRIVZmQI7uoAAWNzD&authuser=luca%40tri.be&usp=drive_fs)
[Screeenshot of PRO tests passing](https://drive.google.com/open?id=1FWKM3vg9ETuWLyXevCuZzycf13syLmPV&authuser=luca%40tri.be&usp=drive_fs)

This PR fixes an issue where List View would not display events in ASCending order when the PRO setting "Recurring Event Instances" > "Show only the first instance of each recurring event" is activated.
The issue originated from the fact that List View would assume the default repository order direction would be set to ASC (correct in most cases), but would not enforce it.
The order would, but, be DESC when that setting is activated (due to how that setting works) and List View would neither check nor enforce that.

Since the fix for a PRO issue is in TEC, I've provided a screenshot of the passing tests on PRO to show that nothing is breaking there.

The fix simply enforces that order.
