### PR TITLE
Do not cast types when sorting

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -2216,7 +2216,7 @@ class View implements View_Interface {
 		// Flatten Views such as Month and Week that have an array values.
 		$first_value = reset( $events );
 		if ( is_array( $first_value ) ) {
-			$events = array_unique( array_merge( ...array_values( $events ) ) );
+			$events = array_unique( array_merge( ...array_values( $events ) ), SORT_REGULAR );
 		}
 
 		/**


### PR DESCRIPTION
Issue: n/a

[Screencast](https://drive.google.com/open?id=1FxWxbIlNkuWSxyK2VKKeq7enXGMQrWeT&authuser=luca%40tri.be&usp=drive_fs)

This PR fixes an issue where caused by the fact that trying to sort/prune `WP_Post` objects using the `array_unique` function would try and cast them to `string`; the function should be used using the `SORT_REGULAR` flag to avoid this kind of issues.