### PR TITLE
Removal of non required variable

### DIFF
--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -23,14 +23,12 @@ class Tribe__Events__Importer__Column_Mapper {
 				$this->column_names = $this->get_organizer_column_names();
 				break;
 			default:
-				$column_names = array();
-
 				/**
 				 * Filters the column names that will be available for a custom import type.
 				 *
 				 * @param array $column_names
 				 */
-				$this->column_names = apply_filters( "tribe_event_import_{$import_type}_column_names", $column_names );
+				$this->column_names = apply_filters( "tribe_event_import_{$import_type}_column_names", [] );
 				break;
 		}
 	}


### PR DESCRIPTION
The variable it was never used other than for directly accesing inside
of the filter call, in this case having a variable sitting around for no
use does not provide any additional value.