### PR TITLE
ECP-528 Correct the today link on shortcodes with category(s).

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure ECP shortcode today button handles categories gracefully. [ECP-492]
+
 = [5.2.1] 2020-10-22 =
 
 * Tweak - Change Views v2 AJAX request method from GET to POST to avoid issues with too long URLs. [TEC-3283]

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1590,6 +1590,13 @@ class View implements View_Interface {
 		// Handle the `eventDisplay` query arg due to its particular usage to indicate the mode too.
 		$query_args['eventDisplay'] = $this->slug;
 
+		$category = $this->context->get( 'event_category', false );
+
+		if ( is_array( $category ) ) {
+			$category = Arr::to_list( reset( $category ) );
+			$query_args['tribe_events_cat'] = $category;
+		}
+
 		$query_args = $this->filter_query_args( $query_args, $canonical );
 
 		$ugly_url = add_query_arg( $query_args, $this->get_url( false ) );

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1593,7 +1593,7 @@ class View implements View_Interface {
 		$category = $this->context->get( 'event_category', false );
 
 		if ( is_array( $category ) ) {
-			$category = Arr::to_list( reset( $category ) );
+			$category                       = Arr::to_list( reset( $category ) );
 			$query_args['tribe_events_cat'] = $category;
 		}
 


### PR DESCRIPTION
While we corrected the prev/next links in [ECP-492] ( see https://github.com/moderntribe/the-events-calendar/pull/3304 ). The issue still remains for the "today" button.
This implements a similar fix for the today button.

I looked for additional instances of this url handling on my local and didn't find any. If anyone knows of another it would make sense to add it to this PR.

[ECP-492]: https://moderntribe.atlassian.net/browse/ECP-492

📷 Broken: http://p.tri.be/uHG5NM
📸  Fixed: http://p.tri.be/rCfKW3

[ECP-528]

[ECP-528]: https://moderntribe.atlassian.net/browse/ECP-528