### PR TITLE
Add the `tribe_get_organizer_object` function.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,12 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add the `tribe_get_organizer_object` function. [TEC-3645]
+* Tweak - Change the return value of the `tribe_get_event( $event_id )->organizers` from a collection of Organizer names to a collection of Organizer post objects. [TEC-3645s]
+* Tweak - Add the `tribe_get_event( $event_id )->organizer_names` method to return a collection of the Event Organizer names. [TEC-3645]
+
 = [5.2.1] 2020-10-22 =
 
 * Tweak - Change Views v2 AJAX request method from GET to POST to avoid issues with too long URLs. [TEC-3283]

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -163,10 +163,11 @@ class Event extends Base {
 				}
 			}
 
-			$featured        = tribe_is_truthy( isset( $post_meta[ Featured::FEATURED_EVENT_KEY ][0] ) ? $post_meta[ Featured::FEATURED_EVENT_KEY ][0] : null );
-			$sticky          = get_post_field( 'menu_order', $post_id ) === -1;
-			$organizer_fetch = Organizer::get_fetch_callback( $post_id );
-			$venue_fetch     = Venue::get_fetch_callback( $post_id );
+			$featured              = tribe_is_truthy( isset( $post_meta[ Featured::FEATURED_EVENT_KEY ][0] ) ? $post_meta[ Featured::FEATURED_EVENT_KEY ][0] : null );
+			$sticky                = get_post_field( 'menu_order', $post_id ) === - 1;
+			$organizer_names_fetch = Organizer::get_fetch_names_callback( $post_id );
+			$organizer_fetch       = Organizer::get_fetch_callback( $post_id );
+			$venue_fetch           = Venue::get_fetch_callback( $post_id );
 
 			$start_site         = $start_date_object->setTimezone( $site_timezone );
 			$end_site           = $end_date_object->setTimezone( $site_timezone );
@@ -206,8 +207,15 @@ class Event extends Base {
 					},
 					false
 				) )->on_resolve( $cache_this ),
-				'organizers'             => ( new Lazy_Collection( $organizer_fetch ) )->on_resolve( $cache_this ),
-				'venues'                 => ( new Lazy_Post_Collection(
+				'organizer_names'             => ( new Lazy_Collection( $organizer_names_fetch ) )->on_resolve( $cache_this ),
+				'organizers'                  => (
+					new Lazy_Post_Collection(
+						$organizer_fetch,
+						'tribe_get_organizer_object'
+					)
+				)->on_resolve( $cache_this ),
+				'venues'                 => (
+					new Lazy_Post_Collection(
 					$venue_fetch,
 					'tribe_get_venue_object' )
 				)->on_resolve( $cache_this ),

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -200,22 +200,22 @@ class Event extends Base {
 				'displays_on'            => $displays_on,
 				'featured'               => $featured,
 				'sticky'                 => $sticky,
-				'cost'                   =>  tribe_get_cost( $post_id, true ),
+				'cost'                   => tribe_get_cost( $post_id, true ),
 				'excerpt'                => ( new Lazy_String(
 					static function () use ( $post_id ) {
 						return tribe_events_get_the_excerpt( $post_id, wp_kses_allowed_html( 'post' ) );
 					},
 					false
 				) )->on_resolve( $cache_this ),
-				'organizer_names'             => ( new Lazy_Collection( $organizer_names_fetch ) )->on_resolve( $cache_this ),
-				'organizers'                  => (
-					new Lazy_Post_Collection(
-						$organizer_fetch,
-						'tribe_get_organizer_object'
-					)
+				'organizer_names'        => ( new Lazy_Collection( $organizer_names_fetch ) )->on_resolve( $cache_this ),
+				'organizers'             => (
+				new Lazy_Post_Collection(
+					$organizer_fetch,
+					'tribe_get_organizer_object'
+				)
 				)->on_resolve( $cache_this ),
 				'venues'                 => (
-					new Lazy_Post_Collection(
+				new Lazy_Post_Collection(
 					$venue_fetch,
 					'tribe_get_venue_object' )
 				)->on_resolve( $cache_this ),

--- a/src/Tribe/Models/Post_Types/Organizer.php
+++ b/src/Tribe/Models/Post_Types/Organizer.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Models an Organizer.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Models\Post_Types
+ */
+
+namespace Tribe\Events\Models\Post_Types;
+
+use Tribe\Models\Post_Types\Base;
+
+/**
+ * Class Organizer
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Models\Post_Types
+ */
+class Organizer extends Base {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since TBD
+	 */
+	protected function get_cache_slug() {
+		return 'organizers';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since TBD
+	 */
+	protected function build_properties( $filter ) {
+		try {
+			$phone   = tribe_get_organizer_phone( $this->post->ID );
+			$website = tribe_get_organizer_website_url( $this->post->ID );
+			// Do not mangle the email now, it should fall on the client code to apply antispambot filters to it.
+			$email = tribe_get_organizer_email( $this->post->ID, false );
+
+			$properties = [
+				'phone'   => $phone,
+				'website' => $website,
+				'email'   => $email,
+			];
+		} catch ( \Exception $e ) {
+			return [];
+		}
+
+		return $properties;
+	}
+}

--- a/src/Tribe/Models/Post_Types/Venue.php
+++ b/src/Tribe/Models/Post_Types/Venue.php
@@ -9,7 +9,6 @@
 namespace Tribe\Events\Models\Post_Types;
 
 use Tribe\Models\Post_Types\Base;
-use Tribe\Utils\Post_Thumbnail;
 
 /**
  * Class Venue.

--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -618,6 +618,8 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @since TBD Changed the method to return Organizer post objects, not just organizer names.
 	 */
 	public static function get_fetch_callback( $event ) {
 		$event = Tribe__Main::post_id_helper( $event );
@@ -627,11 +629,10 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 		 *
 		 * Returning a non `null` value here will skip the default logic.
 		 *
-		 * @since 4.9.7
+		 * @since TBD
 		 *
 		 * @param callable|null The fetch callback.
 		 * @param int $event The event post ID.
-		 *
 		 */
 		$callback = apply_filters( 'tribe_events_organizers_fetch_callback', null, $event );
 
@@ -647,12 +648,51 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 				)
 			);
 
-			$organizers    = ! empty( $organizer_ids )
-				? array_map( 'tribe_get_organizer', $organizer_ids )
+			$organizers = ! empty( $organizer_ids )
+				? array_map( 'tribe_get_organizer_object', $organizer_ids )
 				: [];
 
 			return array_filter( $organizers );
 		};
 	}
 
+	/**
+	 * Builds and returns a Closure to lazily fetch an event Organizer names.
+	 *
+	 * @since TBD Changed the name of this method from `get_fetch_callback` to `get_fetch_names_callback`.
+	 */
+	public static function get_fetch_names_callback( $event ) {
+		$event = Tribe__Main::post_id_helper( $event );
+
+		/**
+		 * Filters the closure that will fetch an Event Organizers.
+		 *
+		 * Returning a non `null` value here will skip the default logic.
+		 *
+		 * @since 4.9.7
+		 *
+		 * @param callable|null The fetch callback.
+		 * @param int $event The event post ID.
+		 */
+		$callback = apply_filters( 'tribe_events_organizers_fetch_names_callback', null, $event );
+
+		if ( null !== $callback ) {
+			return $callback;
+		}
+
+		return static function () use ( $event ) {
+			$organizer_ids = array_filter(
+				array_map(
+					'absint',
+					(array) get_post_meta( $event, '_EventOrganizerID' )
+				)
+			);
+
+			$organizers = ! empty( $organizer_ids )
+				? array_map( 'tribe_get_organizer', $organizer_ids )
+				: [];
+
+			return array_filter( $organizers );
+		};
+	}
 }

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -6,6 +6,8 @@
  */
 
 // Don't load directly
+use Tribe\Events\Models\Post_Types\Organizer;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
@@ -541,4 +543,85 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return $query->have_posts() ? $query->posts : array();
 	}
 
+	/**
+	 * Fetches and returns a decorated post object representing a Organizer.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|int|WP_Post $organizer  The organizer ID or post object or `null` to use the global one.
+	 * @param string|null      $output The required return type. One of `OBJECT`, `ARRAY_A`, or `ARRAY_N`, which
+	 *                                 correspond to a WP_Post object, an associative array, or a numeric array,
+	 *                                 respectively. Defaults to `OBJECT`.
+	 * @param string           $filter Type of filter to apply. Accepts 'raw'.
+	 * @param bool             $force  Whether to force a re-fetch ignoring cached results or not.
+	 *
+	 * @return array|mixed|void|WP_Post|null {
+	 *                              The Organizer post object or array, `null` if not found.
+	 *
+	 *                              @type string $phone The organizer phone number NOT filtered, apply anti-spambot filters if required.
+	 *                              @type string $website The organizer full website URL.
+	 *                              @type string $email The organizer email address NOT filtered, apply anti-spambot filters if required.
+	 *                          }
+	 */
+	function tribe_get_organizer_object( $organizer = null, $output = OBJECT, $filter = 'raw', $force = false ) {
+		/**
+		 * Filters the organizer result before any logic applies.
+		 *
+		 * Returning a non `null` value here will short-circuit the function and return the value.
+		 * Note: this value will not be cached and the caching of this value is a duty left to the filtering function.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed       $return      The organizer object to return.
+		 * @param mixed       $organizer       The organizer object to fetch.
+		 * @param string|null $output      The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which
+		 *                                 correspond to a `WP_Post` object, an associative array, or a numeric array,
+		 *                                 respectively. Defaults to `OBJECT`.
+		 * @param string      $filter      Type of filter to apply. Accepts 'raw'.
+		 */
+		$return = apply_filters( 'tribe_get_organizer_object_before', null, $organizer, $output, $filter );
+
+		if ( null !== $return ) {
+			return $return;
+		}
+
+		$post = false;
+		if ( ! $force ) {
+			$cache_key = 'tribe_get_organizer_object_' . md5( json_encode( [ $organizer, $output, $filter ] ) );
+			/** @var Tribe__Cache $cache */
+			$cache = tribe( 'cache' );
+			$post  = $cache->get( $cache_key, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+		}
+
+		if ( false === $post ) {
+			$post = Organizer::from_post( $organizer )->to_post( $output, $filter );
+
+			if ( empty( $post ) ) {
+				return null;
+			}
+
+			/**
+			 * Filters the organizer post object before caching it and returning it.
+			 *
+			 * Note: this value will be cached; as such this filter might not run on each request.
+			 * If you need to filter the output value on each call of this function then use the `tribe_get_organizer_object_before`
+			 * filter.
+			 *
+			 * @since TBD
+			 *
+			 * @param WP_Post $post   The organizer post object, decorated with a set of custom properties.
+			 * @param string  $output The output format to use.
+			 * @param string  $filter The filter, or context of the fetch.
+			 */
+			$post = apply_filters( 'tribe_get_organizer_object', $post, $output, $filter );
+
+			$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+		}
+
+		if ( OBJECT !== $output ) {
+			$post = ARRAY_A === $output ? (array) $post : array_values( (array) $post );
+		}
+
+		return $post;
+	}
 }

--- a/tests/wpunit/functions/template-tags/eventTest.php
+++ b/tests/wpunit/functions/template-tags/eventTest.php
@@ -256,10 +256,21 @@ class eventTest extends WPTestCase {
 		remove_filter( 'tribe_get_organizer', $fail );
 
 		$this->assertEquals( [], $wo_organizer_event->organizers->all() );
-		$this->assertEquals( [ tribe_get_organizer( $organizer_1 ) ], tribe_get_event( $w_organizer_1 )->organizers->all() );
+		$this->assertEquals(
+			[ tribe_get_organizer( $organizer_1 ) ],
+			tribe_get_event( $w_organizer_1 )->organizer_names->all()
+		);
+		$this->assertEquals(
+			[ tribe_get_organizer_object( $organizer_1 ) ],
+			tribe_get_event( $w_organizer_1 )->organizers->all()
+		);
 		$this->assertEqualSets( [
 			tribe_get_organizer( $organizer_1 ),
 			tribe_get_organizer( $organizer_2 )
+		], tribe_get_event( $w_both_organizers )->organizer_names->all() );
+		$this->assertEqualSets( [
+			tribe_get_organizer_object( $organizer_1 ),
+			tribe_get_organizer_object( $organizer_2 )
 		], tribe_get_event( $w_both_organizers )->organizers->all() );
 	}
 

--- a/tests/wpunit/functions/template-tags/organizerTest.php
+++ b/tests/wpunit/functions/template-tags/organizerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace TEC\Test\functions\template_tags;
 
+use Tribe\Events\Test\Factories\Organizer;
 use Tribe\Events\Test\Testcases\Events_TestCase;
 
 class organizerTest extends Events_TestCase {
@@ -84,5 +85,87 @@ class organizerTest extends Events_TestCase {
 		$this->assertEquals( [ 1, 2, 3, 4, 5, 6 ], tribe_sanitize_organizers( [ 4, 2, 5, 1, 3, 6 ], [ 1, 2, 3 ] ) );
 		// Test only a single ordered value the remaining are placed are entered
 		$this->assertEquals( [ 2, 1, 3, 4, 5, 6 ], tribe_sanitize_organizers( [ 1, 2, 3, 4, 5, 6 ], [ 2 ] ) );
+	}
+
+	/**
+	 * It should allow getting an organizer decorated post object
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_an_organizer_decorated_post_object() {
+		$this->assertNull( tribe_get_organizer_object( PHP_INT_MAX ) );
+
+		$organizer_id       = $this->given_an_organizer();
+		$organizer    = tribe_get_organizer_object( $organizer_id );
+
+		$this->assertInstanceOf( \WP_Post::class, $organizer );
+		$this->assertEquals('Indiana Jones', $organizer->post_title);
+		$this->assertEquals('11223344', $organizer->phone);
+		$this->assertEquals('http://the.org/anizer', $organizer->website);
+		$this->assertEquals('indy@the.org', $organizer->email);
+	}
+
+	/**
+	 * It should return the data of the global organizer when set
+	 *
+	 * @test
+	 */
+	public function should_return_the_data_of_the_global_organizer_when_set() {
+		$organizer_id       = $this->given_an_organizer();
+		$GLOBALS['post'] = get_post($organizer_id);
+		$GLOBALS['post_id'] = $organizer_id;
+
+		$organizer    = tribe_get_organizer_object( null );
+
+		$this->assertInstanceOf( \WP_Post::class, $organizer );
+		$this->assertEquals('Indiana Jones', $organizer->post_title);
+		$this->assertEquals('11223344', $organizer->phone);
+		$this->assertEquals('http://the.org/anizer', $organizer->website);
+		$this->assertEquals('indy@the.org', $organizer->email);
+	}
+
+	/**
+	 * It should allow getting the organizer as associative_array
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_the_organizer_as_associative_array() {
+		$organizer_id       = $this->given_an_organizer();
+
+		$organizer    = tribe_get_organizer_object( $organizer_id, ARRAY_A );
+
+		$this->assertInternalType('array',$organizer);
+		$this->assertCount(0,array_filter(array_keys($organizer),'is_int'));
+		$this->assertEquals('Indiana Jones', $organizer['post_title']);
+		$this->assertEquals('11223344', $organizer['phone']);
+		$this->assertEquals('http://the.org/anizer', $organizer['website']);
+		$this->assertEquals('indy@the.org', $organizer['email']);
+	}
+
+	/**
+	 * It should allow getting the organizer as an array
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_the_organizer_as_an_array() {
+		$organizer_id = $this->given_an_organizer();
+
+		$organizer = tribe_get_organizer_object( $organizer_id, ARRAY_N );
+
+		$this->assertInternalType( 'array', $organizer );
+		$this->assertCount( count( $organizer ), array_filter( array_keys( $organizer ), 'is_int' ) );
+	}
+
+	protected function given_an_organizer() {
+		$organizer_id = ( new Organizer() )->create( [
+			'post_title' => 'Indiana Jones',
+			'meta_input' => [
+				'_OrganizerPhone'   => '11223344',
+				'_OrganizerWebsite' => 'http://the.org/anizer',
+				'_OrganizerEmail'   => 'indy@the.org',
+			]
+		] );
+
+		return $organizer_id;
 	}
 }

--- a/tests/wpunit/functions/template-tags/organizerTest.php
+++ b/tests/wpunit/functions/template-tags/organizerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TEC\Test\functions\template_tags;
 
 use Tribe\Events\Test\Factories\Organizer;
@@ -58,7 +59,7 @@ class organizerTest extends Events_TestCase {
 	 * @test
 	 */
 	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set() {
-		$found_posts = tribe_get_organizers( false, - 1, true, [ 'found_posts' => true] );
+		$found_posts = tribe_get_organizers( false, - 1, true, [ 'found_posts' => true ] );
 		$this->assertEquals( 0, $found_posts );
 	}
 
@@ -95,14 +96,27 @@ class organizerTest extends Events_TestCase {
 	public function should_allow_getting_an_organizer_decorated_post_object() {
 		$this->assertNull( tribe_get_organizer_object( PHP_INT_MAX ) );
 
-		$organizer_id       = $this->given_an_organizer();
+		$organizer_id = $this->given_an_organizer();
 		$organizer    = tribe_get_organizer_object( $organizer_id );
 
 		$this->assertInstanceOf( \WP_Post::class, $organizer );
-		$this->assertEquals('Indiana Jones', $organizer->post_title);
-		$this->assertEquals('11223344', $organizer->phone);
-		$this->assertEquals('http://the.org/anizer', $organizer->website);
-		$this->assertEquals('indy@the.org', $organizer->email);
+		$this->assertEquals( 'Indiana Jones', $organizer->post_title );
+		$this->assertEquals( '11223344', $organizer->phone );
+		$this->assertEquals( 'http://the.org/anizer', $organizer->website );
+		$this->assertEquals( 'indy@the.org', $organizer->email );
+	}
+
+	protected function given_an_organizer() {
+		$organizer_id = ( new Organizer() )->create( [
+			'post_title' => 'Indiana Jones',
+			'meta_input' => [
+				'_OrganizerPhone'   => '11223344',
+				'_OrganizerWebsite' => 'http://the.org/anizer',
+				'_OrganizerEmail'   => 'indy@the.org',
+			]
+		] );
+
+		return $organizer_id;
 	}
 
 	/**
@@ -112,16 +126,16 @@ class organizerTest extends Events_TestCase {
 	 */
 	public function should_return_the_data_of_the_global_organizer_when_set() {
 		$organizer_id       = $this->given_an_organizer();
-		$GLOBALS['post'] = get_post($organizer_id);
+		$GLOBALS['post']    = get_post( $organizer_id );
 		$GLOBALS['post_id'] = $organizer_id;
 
-		$organizer    = tribe_get_organizer_object( null );
+		$organizer = tribe_get_organizer_object( null );
 
 		$this->assertInstanceOf( \WP_Post::class, $organizer );
-		$this->assertEquals('Indiana Jones', $organizer->post_title);
-		$this->assertEquals('11223344', $organizer->phone);
-		$this->assertEquals('http://the.org/anizer', $organizer->website);
-		$this->assertEquals('indy@the.org', $organizer->email);
+		$this->assertEquals( 'Indiana Jones', $organizer->post_title );
+		$this->assertEquals( '11223344', $organizer->phone );
+		$this->assertEquals( 'http://the.org/anizer', $organizer->website );
+		$this->assertEquals( 'indy@the.org', $organizer->email );
 	}
 
 	/**
@@ -130,16 +144,16 @@ class organizerTest extends Events_TestCase {
 	 * @test
 	 */
 	public function should_allow_getting_the_organizer_as_associative_array() {
-		$organizer_id       = $this->given_an_organizer();
+		$organizer_id = $this->given_an_organizer();
 
-		$organizer    = tribe_get_organizer_object( $organizer_id, ARRAY_A );
+		$organizer = tribe_get_organizer_object( $organizer_id, ARRAY_A );
 
-		$this->assertInternalType('array',$organizer);
-		$this->assertCount(0,array_filter(array_keys($organizer),'is_int'));
-		$this->assertEquals('Indiana Jones', $organizer['post_title']);
-		$this->assertEquals('11223344', $organizer['phone']);
-		$this->assertEquals('http://the.org/anizer', $organizer['website']);
-		$this->assertEquals('indy@the.org', $organizer['email']);
+		$this->assertInternalType( 'array', $organizer );
+		$this->assertCount( 0, array_filter( array_keys( $organizer ), 'is_int' ) );
+		$this->assertEquals( 'Indiana Jones', $organizer['post_title'] );
+		$this->assertEquals( '11223344', $organizer['phone'] );
+		$this->assertEquals( 'http://the.org/anizer', $organizer['website'] );
+		$this->assertEquals( 'indy@the.org', $organizer['email'] );
 	}
 
 	/**
@@ -154,18 +168,5 @@ class organizerTest extends Events_TestCase {
 
 		$this->assertInternalType( 'array', $organizer );
 		$this->assertCount( count( $organizer ), array_filter( array_keys( $organizer ), 'is_int' ) );
-	}
-
-	protected function given_an_organizer() {
-		$organizer_id = ( new Organizer() )->create( [
-			'post_title' => 'Indiana Jones',
-			'meta_input' => [
-				'_OrganizerPhone'   => '11223344',
-				'_OrganizerWebsite' => 'http://the.org/anizer',
-				'_OrganizerEmail'   => 'indy@the.org',
-			]
-		] );
-
-		return $organizer_id;
 	}
 }


### PR DESCRIPTION
Issue: n/a

This PR adds the `tribe_get_organizer_object` function and, 
with it, all the attached structure to return a list of
Organizer post objects on `tribe_get_event()->organizers`.
The previous return value of the method, a collection of
Organizer names, is moved to the `tribe_get_event()->organizer_names`
method.

Artifacts: see tests.