### PR TITLE
Use $this->slug when generating prev/next URLs for List View | TEC-3648

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Add the `tribe_get_organizer_object` function. [TEC-3645]
 * Tweak - Change the return value of the `tribe_get_event( $event_id )->organizers` from a collection of Organizer names to a collection of Organizer post objects. [TEC-3645s]
 * Tweak - Add the `tribe_get_event( $event_id )->organizer_names` method to return a collection of the Event Organizer names. [TEC-3645]
+* Tweak - Switch the List View previous/next URL methods to use the slug rather than a hard-coded "list" so the class is more easily extendable. [TEC-3648]
 * Fix - Ensure ECP shortcode today button handles categories gracefully. [ECP-492]
 * Fix - Prevent creation of duplicate venues for default address while adding or editing events. [ECP-482]
 

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -55,7 +55,7 @@ class List_View extends View {
 		}
 
 		$current_page = (int) $this->context->get( 'page', 1 );
-		$display      = $this->context->get( 'event_display_mode', 'list' );
+		$display      = $this->context->get( 'event_display_mode', $this->slug );
 
 		if ( 'past' === $display ) {
 			$url = parent::next_url( $canonical, [ Utils\View::get_past_event_display_key() => 'past' ] );
@@ -83,7 +83,7 @@ class List_View extends View {
 		}
 
 		$current_page = (int) $this->context->get( 'page', 1 );
-		$display      = $this->context->get( 'event_display_mode', 'list' );
+		$display      = $this->context->get( 'event_display_mode', $this->slug );
 
 		if ( $this->slug === $display || 'default' === $display ) {
 			$url = parent::next_url( $canonical );


### PR DESCRIPTION
With this small change (which is present on a couple of other views), we make the List View extendable when creating new views—which should make new views more DRY.

:movie_camera: http://p.tri.be/LsTnFg
:ticket: [TEC-3648]

[TEC-3648]: https://moderntribe.atlassian.net/browse/TEC-3648