### PR TITLE
Fix and timezone handling issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -230,6 +230,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Switch the List View previous/next URL methods to use the slug rather than a hard-coded "list" so the class is more easily extendable. [TEC-3648]
 * Fix - Ensure ECP shortcode today button handles categories gracefully. [ECP-492]
 * Fix - Prevent creation of duplicate venues for default address while adding or editing events. [ECP-482]
+* Fix - Use more robust code in the `tribe_is_past_event` template tag to avoid Warnings.
 
 = [5.2.1] 2020-10-22 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+use Tribe__Timezones as Timezones;
+
 if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 	/**
@@ -390,7 +392,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 
 		// Try to create a a current and end date with the timezone to avoid using the WP timezone if is not the setup case.
 		try {
-			$timezone = new DateTimeZone( $timezone_name );
+			$timezone = Timezones::build_timezone_object( $timezone_name );
 			$current  = date_create( 'now', $timezone );
 			$end      = date_create( $end_date, $timezone );
 		} catch( Exception $exception ) {


### PR DESCRIPTION
Issue: n/a

This PR fixes an issue I ran into while working on other code that would cause
the `tribe_is_past_event` template tag to incorrectly report past events due
to an incorrect handling of the `UTC+0` timezone string.
Since that is the WordPress default on installations that are defining, via
filters too, an incorrect timezone string, this mis-handling could result in
consistent PHP Warnings on some sites, or, as is the case, on new installations.

The fix consists in building the timezone object using our more robust Timezone
handling class.