### PR TITLE
Fix/TEC-3569 - Fix Eventbrite 'do_not_override' status and additional statuses

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Change the return value of the `tribe_get_event( $event_id )->organizers` from a collection of Organizer names to a collection of Organizer post objects. [TEC-3645s]
 * Tweak - Add the `tribe_get_event( $event_id )->organizer_names` method to return a collection of the Event Organizer names. [TEC-3645]
 * Tweak - Switch the List View previous/next URL methods to use the slug rather than a hard-coded "list" so the class is more easily extendable. [TEC-3648]
+* Fix - Event Aggregator - Fix Eventbrite status filter to not return 'do_not_override' and handle Eventbrite's additional statuses. [TEC-3569]
 * Fix - Ensure ECP shortcode today button handles categories gracefully. [ECP-492]
 * Fix - Prevent creation of duplicate venues for default address while adding or editing events. [ECP-482]
 * Fix - Make sure Month View "View More" link to Day View will preserve the current search criteria. [TEC-3230]


### PR DESCRIPTION
 JIRA Ticket: [TEC-3569](https://moderntribe.atlassian.net/browse/TEC-3569)

- Map all statuses to at least 'Draft', 'Private' or 'Published', ensuring no "orphaned" events due to invalid status