### PR TITLE
move mobile search down to display search button accent

### DIFF
--- a/src/resources/postcss/components/skeleton/_events-bar.pcss
+++ b/src/resources/postcss/components/skeleton/_events-bar.pcss
@@ -24,10 +24,10 @@
 		background-color: var(--color-background);
 		display: none;
 		left: 0;
-		padding: var(--spacer-2) var(--grid-gutter-small-half);
+		padding: var(--spacer-1) var(--grid-gutter-small-half) var(--spacer-2);
 		position: absolute;
 		right: 0;
-		top: calc(100% - var(--spacer-2));
+		top: calc(100% - var(--spacer-1));
 		z-index: var(--z-index-dropdown);
 
 		.tribe-common--breakpoint-medium& {
@@ -67,7 +67,7 @@
 	.tribe-events-c-events-bar__search-button-icon-svg {
 		height: 21px;
 		width: 21px;
-		
+
 		path {
 			fill: var(--color-icon-active);
 		}


### PR DESCRIPTION
**Ticket:** N/A

Spotfix a small issue with the accent not showing up when displaying mobile search

**Artifact:**

Before

![before](https://user-images.githubusercontent.com/16699941/99686673-cc058a00-2abe-11eb-9c93-c64b6a93d45d.PNG)

After

![after](https://user-images.githubusercontent.com/16699941/99686711-d162d480-2abe-11eb-8f37-d9d870b823c6.PNG)
