### PR TITLE
Fix/tec 3649 theme overrides 2

### DIFF
--- a/src/resources/postcss/widgets/full/_events-list.pcss
+++ b/src/resources/postcss/widgets/full/_events-list.pcss
@@ -85,7 +85,7 @@
 
 	.tribe-theme-twentyseventeen &,
 	.tribe-theme-twentyseventeen .site-footer .widget-area &,
-	.theme-twentyseventeen .site-footer .widget-area & {
+	.site-footer .widget-area & {
 
 		.tribe-events-widget-events-list__view-more-link {
 			color: var(--color-accent-primary);
@@ -115,12 +115,17 @@
 	 * ------------------------------------------------------------------------- */
 
 	.tribe-theme-enfold &,
-	.theme-enfold & {
+	.footer_color &,
+	.main_color & {
 
 		.tribe-events-widget-events-list__event-venue-address,
 		.tribe-events-widget-events-list__event-organizer-contact {
 			color: var(--color-text-primary);
 		}
+	}
+
+	.tribe-theme-enfold &,
+	.main_color .sidebar & {
 
 		.tribe-events-widget-events-list__view-more-link {
 			color: var(--color-accent-primary);

--- a/src/resources/postcss/widgets/full/_events-list.pcss
+++ b/src/resources/postcss/widgets/full/_events-list.pcss
@@ -102,7 +102,7 @@
 	 * ------------------------------------------------------------------------- */
 
 	.tribe-theme-astra.ast-separate-container &,
-	.theme-astra.ast-separate-container & {
+	.ast-separate-container & {
 
 		.tribe-events-widget-events-list__event {
 			background-color: transparent;

--- a/src/resources/postcss/widgets/skeleton/_events-list.pcss
+++ b/src/resources/postcss/widgets/skeleton/_events-list.pcss
@@ -81,7 +81,7 @@
 	 * ------------------------------------------------------------------------- */
 
 	.tribe-theme-astra.ast-separate-container &,
-	.theme-astra.ast-separate-container & {
+	.ast-separate-container & {
 
 		.tribe-events-widget-events-list__event {
 			padding: 0;

--- a/src/resources/postcss/widgets/skeleton/_events-list.pcss
+++ b/src/resources/postcss/widgets/skeleton/_events-list.pcss
@@ -1,4 +1,5 @@
 .tribe-events-widget {
+	margin-bottom: var(--spacer-7);
 
 	.tribe-events-widget-events-list__header {
 		margin-bottom: var(--spacer-5);


### PR DESCRIPTION
**Ticket:** [TEC-3649]

This PR fixes theme overrides that were incorrectly applied. The WooCommerce plugin would add the body class `theme-twentyseventeen`, for example, to the body. However, this was an incorrect selector to use, and has been removed.

**Artifacts:**

Astra:
![image](https://user-images.githubusercontent.com/16699941/99712964-c029c000-2ade-11eb-9bf4-f6cc82372605.png)

Enfold:
![image](https://user-images.githubusercontent.com/16699941/99713020-d2a3f980-2ade-11eb-9114-e58071d27780.png)

Twenty Seventeen:
![image](https://user-images.githubusercontent.com/16699941/99713131-e5b6c980-2ade-11eb-8e34-378ad2f1de57.png)


[TEC-3649]: https://moderntribe.atlassian.net/browse/TEC-3649