### PR TITLE
Remove deprecated code

### DIFF
--- a/src/Tribe/Importer/File_Reader.php
+++ b/src/Tribe/Importer/File_Reader.php
@@ -129,18 +129,10 @@ class Tribe__Events__Importer__File_Reader {
 	 * }
 	 */
 	private function set_csv_params( $params ) {
-		// The escape parameter was added in PHP v5.3.
-		if ( version_compare( phpversion(), '5.3', '>' ) ) {
-			$this->file->setCsvControl(
-				$params['delimter'],
-				$params['enclosure'],
-				$params['escape']
-			);
-		} else {
-			$this->file->setCsvControl(
-				$params['delimter'],
-				$params['enclosure']
-			);
-		}
+		$this->file->setCsvControl(
+			$params['delimter'],
+			$params['enclosure'],
+			$params['escape']
+		);
 	}
 }


### PR DESCRIPTION
As PHP 5.6 now is required this section of code can be removed.