### PR TITLE
Feature / TEC-3654 improved ui single event tab

### DIFF
--- a/src/Tribe/Customizer/Single_Event.php
+++ b/src/Tribe/Customizer/Single_Event.php
@@ -1,5 +1,7 @@
 <?php
 // Don't load directly.
+use Tribe\Customizer\Controls\Heading;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
@@ -72,7 +74,7 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 			'details_bg_color' => '#e5e5e5',
 		);
 
-		$description = tribe_events_views_v2_is_enabled() ? esc_html__( 'Options selected here will override what was selected in the General and Text sections.', 'the-events-calendar' ) : esc_html__( 'Options selected here will override what was selected in the "General Theme" and "Global Elements" sections.', 'the-events-calendar' );
+		$description = tribe_events_views_v2_is_enabled() ? esc_html__( 'These settings control the appearance of the single event pages.', 'the-events-calendar' ) : esc_html__( 'Options selected here will override what was selected in the "General Theme" and "Global Elements" sections.', 'the-events-calendar' );
 
 		$this->arguments = array(
 			'priority'    => 60,
@@ -92,48 +94,67 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 	 */
 	public function register_settings( WP_Customize_Section $section, WP_Customize_Manager $manager ) {
 		$customizer = Tribe__Customizer::instance();
+		
+		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
+		$manager->add_control( new Heading(
+			$manager,
+			$customizer->get_setting_name( 'post_title_heading', $section ),
+			[
+				'label'   => esc_html__( 'Set Font Colors', 'the-events-calendar' ),
+				'section' => $section->id,
+			]
+		) );
 
 		$manager->add_setting(
 			$customizer->get_setting_name( 'post_title_color', $section ),
-			array(
+			[
 				'default'              => $this->get_default( 'post_title_color' ),
 				'type'                 => 'option',
-
 				'sanitize_callback'    => 'sanitize_hex_color',
 				'sanitize_js_callback' => 'maybe_hash_hex_color',
-			)
+			]
 		);
 
 		$manager->add_control(
 			new WP_Customize_Color_Control(
 				$manager,
 				$customizer->get_setting_name( 'post_title_color', $section ),
-				array(
+				[
 					'label'   => tribe_events_views_v2_is_enabled() ? esc_html__( 'Event Title Color', 'the-events-calendar' ) : esc_html__( 'Post Title Color', 'the-events-calendar' ),
 					'section' => $section->id,
-				)
+				]
 			)
 		);
+		
+		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
+		$manager->add_control( new Heading(
+			$manager,
+			$customizer->get_setting_name( 'details_bg_color_heading', $section ),
+			[
+				'label'   => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
+				'section' => $section->id,
+			]
+		) );
 
 		$manager->add_setting(
 			$customizer->get_setting_name( 'details_bg_color', $section ),
-			array(
+			[
 				'default'              => $this->get_default( 'details_bg_color' ),
 				'type'                 => 'option',
-
 				'sanitize_callback'    => 'sanitize_hex_color',
 				'sanitize_js_callback' => 'maybe_hash_hex_color',
-			)
+			]
 		);
 
 		$manager->add_control(
 			new WP_Customize_Color_Control(
 				$manager,
 				$customizer->get_setting_name( 'details_bg_color', $section ),
-				array(
-					'label'   => esc_html__( 'Details Background Color', 'the-events-calendar' ),
-					'section' => $section->id,
-				)
+				[
+					'label'       => esc_html__( 'Event Details Background Color', 'the-events-calendar' ),
+					'description' => esc_html__( 'For classic editor', 'the-events-calendar' ),
+					'section'     => $section->id,
+				]
 			)
 		);
 

--- a/src/Tribe/Customizer/Single_Event.php
+++ b/src/Tribe/Customizer/Single_Event.php
@@ -96,14 +96,16 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 		$customizer = Tribe__Customizer::instance();
 		
 		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
-		$manager->add_control( new Heading(
-			$manager,
-			$customizer->get_setting_name( 'post_title_heading', $section ),
-			[
-				'label'   => esc_html__( 'Set Font Colors', 'the-events-calendar' ),
-				'section' => $section->id,
-			]
-		) );
+		$manager->add_control(
+			new Heading(
+				$manager,
+				$customizer->get_setting_name( 'post_title_heading', $section ),
+				[
+					'label'   => esc_html__( 'Set Font Colors', 'the-events-calendar' ),
+					'section' => $section->id,
+				]
+			)
+		);
 
 		$manager->add_setting(
 			$customizer->get_setting_name( 'post_title_color', $section ),
@@ -127,14 +129,16 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 		);
 		
 		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
-		$manager->add_control( new Heading(
-			$manager,
-			$customizer->get_setting_name( 'details_bg_color_heading', $section ),
-			[
-				'label'   => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
-				'section' => $section->id,
-			]
-		) );
+		$manager->add_control(
+			new Heading(
+				$manager,
+				$customizer->get_setting_name( 'details_bg_color_heading', $section ),
+				[
+					'label'   => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
+					'section' => $section->id,
+				]
+			)
+		);
 
 		$manager->add_setting(
 			$customizer->get_setting_name( 'details_bg_color', $section ),


### PR DESCRIPTION
**Description:** Updates the Customizer UI's Single Event tab to include headings and other copy changes

**Ticket:** https://moderntribe.atlassian.net/browse/TEC-3654

**Screenshots:**

![Screen Shot 2020-11-25 at 1 59 01 PM](https://user-images.githubusercontent.com/5049893/100230755-684be880-2f26-11eb-82d1-04016748c6d4.png)
