### PR TITLE
Fix / TEC-3653 inverted controls

### DIFF
--- a/src/Tribe/Customizer/Global_Elements.php
+++ b/src/Tribe/Customizer/Global_Elements.php
@@ -482,37 +482,14 @@ final class Tribe__Events__Customizer__Global_Elements extends Tribe__Customizer
 		$manager->add_control(
 			new Heading(
 				$manager,
-				$customizer->get_setting_name( 'accent_color_heading', $section ),
+				$customizer->get_setting_name( 'link_color_heading', $section ),
 				[
 					'label'   => esc_html__( 'Set Font Colors', 'the-events-calendar' ),
 					'section' => $section->id,
 				]
 			)
 		);
-
-		$manager->add_setting(
-			$customizer->get_setting_name( 'accent_color', $section ),
-			[
-				'default'              => '#334AFF',
-				'type'                 => 'option',
-				'sanitize_callback'    => 'sanitize_hex_color',
-				'sanitize_js_callback' => 'maybe_hash_hex_color',
-			]
-		);
-
-		$manager->add_control(
-			new WP_Customize_Color_Control(
-				$manager,
-				$customizer->get_setting_name( 'accent_color', $section ),
-				[
-					'label'   => esc_html__( 'Accent Color', 'the-events-calendar' ),
-					'section' => $section->id,
-				]
-			)
-		);
-
-		$customizer->add_setting_name( $customizer->get_setting_name( 'accent_color', $section ) );
-
+		
 		$manager->add_setting(
 			$customizer->get_setting_name( 'link_color', $section ),
 			[
@@ -522,19 +499,7 @@ final class Tribe__Events__Customizer__Global_Elements extends Tribe__Customizer
 				'sanitize_js_callback' => 'maybe_hash_hex_color',
 			]
 		);
-
-		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
-		$manager->add_control(
-			new Heading(
-				$manager,
-				$customizer->get_setting_name( 'link_color_heading', $section ),
-				[
-					'label'   => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
-					'section' => $section->id,
-				]
-			)
-		);
-
+		
 		$manager->add_control(
 			new WP_Customize_Color_Control(
 				$manager,
@@ -548,6 +513,41 @@ final class Tribe__Events__Customizer__Global_Elements extends Tribe__Customizer
 		);
 
 		$customizer->add_setting_name( $customizer->get_setting_name( 'link_color', $section ) );
+		
+		// Add an heading that is a Control only in name: it does not, actulally, control or save any setting.
+		$manager->add_control(
+			new Heading(
+				$manager,
+				$customizer->get_setting_name( 'accent_color_heading', $section ),
+				[
+					'label'   => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
+					'section' => $section->id,
+				]
+			)
+		);
+		
+		$manager->add_setting(
+			$customizer->get_setting_name( 'accent_color', $section ),
+			[
+				'default'              => '#334AFF',
+				'type'                 => 'option',
+				'sanitize_callback'    => 'sanitize_hex_color',
+				'sanitize_js_callback' => 'maybe_hash_hex_color',
+			]
+		);
+		
+		$manager->add_control(
+			new WP_Customize_Color_Control(
+				$manager,
+				$customizer->get_setting_name( 'accent_color', $section ),
+				[
+					'label'   => esc_html__( 'Accent Color', 'the-events-calendar' ),
+					'section' => $section->id,
+				]
+			)
+		);
+
+		$customizer->add_setting_name( $customizer->get_setting_name( 'accent_color', $section ) );
 
 		if ( tribe_events_views_v2_is_enabled() ) {
 			return;


### PR DESCRIPTION
**Description:** Fixes the order of Links and Accent Color controls, according to the mockup and AC

**Ticket:** https://moderntribe.atlassian.net/browse/TEC-3653?focusedCommentId=91740

**Screenshots:**

![Screen Shot 2020-11-26 at 4 04 59 PM](https://user-images.githubusercontent.com/5049893/100366696-73277b80-3001-11eb-91dd-3cc00230a1f9.png)
