### PR TITLE
update name of the list widget in the admin

### DIFF
--- a/src/Tribe/Views/V2/Widgets/Widget_List.php
+++ b/src/Tribe/Views/V2/Widgets/Widget_List.php
@@ -112,7 +112,7 @@ class Widget_List extends Widget_Abstract {
 
 		$default_arguments['description'] = esc_html_x( 'A widget that displays upcoming events.', 'The description of the List Widget.', 'the-events-calendar' );
 		// @todo update name once this widget is ready to replace the existing list widget.
-		$default_arguments['name']                          = esc_html_x( 'Events List V2', 'The name of the widget.', 'the-events-calendar' );
+		$default_arguments['name']                          = esc_html_x( 'Events List', 'The name of the List Widget.', 'the-events-calendar' );
 		$default_arguments['widget_options']['description'] = esc_html_x( 'A widget that displays upcoming events.', 'The description of the List Widget.', 'the-events-calendar' );
 		// Setup default title.
 		$default_arguments['title'] = _x( 'Upcoming Events', 'The default title of the List Widget.', 'the-events-calendar' );


### PR DESCRIPTION
**Ticket:** [TEC-3612]

This PR fixes the name for the events list widget in the admin.

**Artifact:**

![image](https://user-images.githubusercontent.com/16699941/100661076-e4fb1e80-338d-11eb-9381-974ed18c42dd.png)


[TEC-3612]: https://moderntribe.atlassian.net/browse/TEC-3612