### PR TITLE
Filter Customizer inline print styles action

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -118,6 +118,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_events_views_v2_view_data', [ View_Utils::class, 'clean_data' ] );
 
 		// Customizer.
+		add_filter( 'tribe_customizer_print_styles_action', [ $this, 'print_inline_styles_in_footer' ] );
 		add_filter( 'tribe_customizer_pre_sections', [ $this, 'filter_customizer_sections' ], 20, 2 );
 		add_filter( 'tribe_customizer_global_elements_css_template', [ $this, 'filter_global_elements_css_template' ], 10, 3 );
 		add_filter( 'tribe_customizer_single_event_css_template', [ $this, 'filter_single_event_css_template' ], 10, 3 );
@@ -848,6 +849,18 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		}
 
 		return array_merge( $sheets, $v2_sheets );
+	}
+
+	/**
+	 * Changes the action the Customizer should use to try and print inline styles to print the inline
+	 * styles in the footer.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The action the Customizer should use to print inline styles.
+	 */
+	public function print_inline_styles_in_footer() {
+		return 'wp_print_footer_scripts';
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_context__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_context__1.php
@@ -4,7 +4,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://tests.tri.be/?ical=something"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 ';

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
@@ -294,7 +294,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
@@ -390,7 +390,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
@@ -308,7 +308,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -402,7 +402,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
@@ -2197,7 +2197,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/2019-01-01/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -2473,7 +2473,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/2019-01-01/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
@@ -296,7 +296,7 @@
 		title="Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"
 		href="http://test.tri.be/events/?ical=1"
 	>
-		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--minus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--plus tribe-events-c-ical__link-icon-svg"  viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M11 5.881H1M5.88 1v10" stroke-width="2" stroke-linecap="square"/></svg>
 		Export Events	</a>
 </div>
 


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/TEC-3686 

Based on: https://github.com/moderntribe/tribe-common/pull/1509

This PR filters the action the Customizer will use to try and print inline styles to use the `wp_print_footer_scripts` one and print inline styles in the footer.

- feat(Views/V2) filter customizer inline styles print action
- build(common) track latest
