### PR TITLE
Fix / TEC-3651 nav icons alignment

### DIFF
--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -55,4 +55,19 @@
 			background-color: transparent;
 		}
 	}
+	
+	/* -----------------------------------------------------------------------------
+	 * Theme Overrides - Genesis
+	 * ----------------------------------------------------------------------------- */
+	
+	.tribe-theme-genesis & {
+		
+		.tribe-events-c-top-bar__nav-link {
+			&:disabled,
+			&:hover,
+			&:focus {
+				background-color: transparent;
+			}
+		}
+	}
 }

--- a/src/resources/postcss/components/skeleton/_top-bar.pcss
+++ b/src/resources/postcss/components/skeleton/_top-bar.pcss
@@ -40,6 +40,7 @@
 
 	.tribe-events-c-top-bar__nav-link {
 		display: block;
+		line-height: 0;
 	}
 
 	.tribe-events-c-top-bar__nav-link-icon-svg {


### PR DESCRIPTION
**Description:** Fixes a misalignment introduced by the latest changes to svg icons. Also includes a fix for the background color of the disabled nav icon on Genesis as bonus. You're welcome (well, I guess it was my fault). See the issues in the screenshots attached.

**Ticket:** https://moderntribe.atlassian.net/browse/TEC-3651

**Screenshots:**

![Screen Shot 2020-12-04 at 11 03 33 AM](https://user-images.githubusercontent.com/5049893/101158914-dbdbad00-362c-11eb-8f0f-7aac1d3ca983.png)

![Screen Shot 2020-12-04 at 12 16 48 PM](https://user-images.githubusercontent.com/5049893/101158927-df6f3400-362c-11eb-8ae3-3c3025196a0f.png)
