### PR TITLE
Exclude release/B20.12 from Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,153 @@
+sudo: required
+
+language: php
+
+notifications:
+  email: false
+branches:
+  except:
+    # Temp fix, exclude `release/B20.12` branch from Travis CI automated builds.
+    - release/B20.12
+
+php:
+  - '7.0'
+
+services:
+  # Require docker and docker-compose as we'll need them to manage the containers.
+  - docker
+
+addons:
+  apt:
+    packages:
+      # needed for Nginx
+      - libjpeg-dev
+      - libpng12-dev
+
+# Disable the default submodule logic.
+git:
+  submodules: false
+
+cache:
+  directories:
+    # The composer user-level cache.
+    - $HOME/.composer/cache
+
+before_install:
+  # Sourcing the .env file will make sure we use, in the environment configuration, the same variables the tests are using.
+  - set -o allexport; source .env; set +o allexport;
+
+  # Spin up the `db` container from the test stack.
+  # Between initialization and creation of the test database it might take
+  # some time (seconds); if we spin it up now it should be ready to run by
+  # the time we need it.
+  - docker-compose -f ${TRAVIS_BUILD_DIR}/dev/docker/ci-compose.yml up -d db
+
+  # Tweak git to correctly work with submodules.
+  - sed -i 's/git@github.com:/git:\/\/github.com\//' .gitmodules
+  - git submodule update --init
+  - git submodule foreach --recursive "[ -f .gitmodules ] && sed -i 's/git@github.com:/git:\/\/github.com\//' .gitmodules; git submodule update --init;"
+
+install:
+  # Disable XDebug to speed up the tests.
+  - phpenv config-rm xdebug.ini
+
+  # Roll-back Composer to version 1, if required.
+  - composer self-update --1 || true
+
+  # The installation will include wp-cli as well as it's a requirement of wp-browser.
+  - composer install
+
+  # Let's ensure common autoload files are there.
+  - (cd common; composer install --no-dev)
+
+  # Install wp-cli phar.
+  # While wp-cli is one of wp-browser dependencies the binary that lives in the `vendor/bin` folder will load the
+  # Composer autoload file when used and that will conflict with the one loaded by the plugin.
+  - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  - chmod +x wp-cli.phar
+  - mkdir -p ${HOME}/.local/bin && mv wp-cli.phar ${HOME}/.local/bin/wp
+
+  # Tweak the path to look for binaries in `vendor/bin` first.
+  # Binaries installed in the `vendor/bin` folder, like `codecept`, will be available system-wide.
+  - export PATH=${PATH}:${TRAVIS_BUILD_DIR}/vendor/bin
+
+  # Create the WordPress root folder.
+  - mkdir -p ${WP_ROOT_FOLDER}
+
+  # Download, configure and install WordPress in the `wordpress` folder.
+  # To configure WordPress we use the configuration parameters that will be used by the Docker container.
+  # See `dev/docker/ci-compose.yml` for more information.
+  - cd ${WP_ROOT_FOLDER}
+  - wp core download --version=${WP_VERSION}
+  # Let's generate the wp-config.php file for the WordPress installation from a template.
+  - echo "WP_DB_NAME=${WP_DB_NAME} WP_DB_PORT=${WP_DB_PORT} WP_TABLE_PREFIX=${WP_TABLE_PREFIX}"
+  - envsubst '${WP_DB_NAME},${WP_DB_PORT},${WP_TABLE_PREFIX}' < ${TRAVIS_BUILD_DIR}/dev/docker/wp-config.template > ./wp-config.php
+  # Reset the WordPress installation database if set and then  re-install it.
+  - wp db reset --yes
+  - wp core install --url="${WP_URL}" --title="Tribe Tests" --admin_user="${WP_ADMIN_USERNAME}" --admin_password="${WP_ADMIN_PASSWORD}" --admin_email="admin@tribe.localhost" --skip-email
+  # Create a wp-cli configuration file to allow it to write an .htaccess file.
+  - echo -e "apache_modules:\n\t- mod_rewrite" > wp-cli.yml
+
+  # Now that it is we've got a wp-config.php in place start the WordPress Docker container to have WordPress.
+  - docker-compose -f ${TRAVIS_BUILD_DIR}/dev/docker/ci-compose.yml up -d wordpress
+  # Since we've bound the WordPress folder from the local filesystem let's clear any possible r/w access issue.
+  - docker-compose -f ${TRAVIS_BUILD_DIR}/dev/docker/ci-compose.yml exec wordpress bash -c "chmod -R 0777 /var/www/html/wp-content/uploads"
+  # Copy over a mu-plugin that will make it so that WordPress will be able to resolve `http://localhost:port`.
+  - mkdir -p ${WP_ROOT_FOLDER}/wp-content/mu-plugins && cp ${TRAVIS_BUILD_DIR}/dev/docker/redirect-localhost-requests.php ${WP_ROOT_FOLDER}/wp-content/mu-plugins
+
+  # Create the database we'll use in integration tests accessing the database container.
+  - mysql --user=root --host=127.0.0.1 --port=${WP_DB_PORT} -e "create database ${WP_TEST_DB_NAME}";
+  - mysql --user=root --host=127.0.0.1 --port=${WP_DB_PORT} -e "show databases";
+
+  # Get back to the build folder, the one where the plugin has been cloned by the CI.
+  - cd ${TRAVIS_BUILD_DIR}
+
+  # Copy the plugin into the WordPress plugin folder.
+  # We also set two variables:
+  # `PLUGIN_BASENAME` is the name of the plugin folder, e.g. `the-events-calendar` or `events-pro`.
+  # `PLUGIN_DIR` is the absolute path to the plugin folder in the WordPress installation, e.g. `/tmp/wordpress/wp-content/plugins/the-events-calendar`.
+  - export PLUGIN_BASENAME=$(basename "$(pwd)") && echo "PLUGIN_BASENAME=${PLUGIN_BASENAME}"
+  - cp -r ${TRAVIS_BUILD_DIR} ${WP_ROOT_FOLDER}/wp-content/plugins/${PLUGIN_BASENAME}
+  - export PLUGIN_DIR="${WP_ROOT_FOLDER}/wp-content/plugins/${PLUGIN_BASENAME}" && echo "PLUGIN_DIR=${PLUGIN_DIR}"
+
+  # Get back to the WordPress installation root folder.
+  - cd ${WP_ROOT_FOLDER}; echo "pwd=$(pwd)"
+
+  # Obtain the IP address of the `wordpress` container we started before from the stack.
+  - export WP_CONTAINER_IP=`docker inspect -f '{{ .NetworkSettings.Networks.docker_default.IPAddress }}' ci_wordpress`
+
+  # Finally start the Selenium and Chromedriver container.
+  - docker-compose -f ${TRAVIS_BUILD_DIR}/dev/docker/ci-compose.yml up -d chromedriver
+
+before_script:
+  # Activate the plugin in WordPress.
+  - wp plugin activate ${PLUGIN_BASENAME}
+
+  # Skip any welcome screen.
+  - wp option set tribe_skip_welcome 1
+
+  # Flush rewrite rules to make sure we're using permalinks.
+  - wp rewrite structure '/%postname%/' --hard
+
+  # Export a dump of the just installed database to the _data folder.
+  - wp db export ${PLUGIN_DIR}/tests/_data/dump.sql
+  # Do the same for the starting database fixture for the `aggregator` suite.
+  - wp db export ${PLUGIN_DIR}/tests/_data/aggregator-dump.sql
+
+  # Get back to the plugin dir.
+  - cd ${PLUGIN_DIR}
+
+script:
+  - codecept run -f views_integration
+  - codecept run -f views_settings
+  - codecept run -f views_rest
+  - codecept run -f views_ui
+  - codecept run -f views_widgets
+  - codecept run -f views_wpunit
+  - codecept run -f integration
+  - codecept run -f muintegration
+  - codecept run -f wpunit
+  - codecept run -f aggregatorv1
+  # Disabled on 2020/08/18 due to inconsistent failures.
+  # - codecept run -f restv1
+  # - codecept run acceptance


### PR DESCRIPTION
This PR restores the `.travis.yml` configuration file and excludes the `release/B20.12` branch from it.

This is just a temporary fix.
