### PR TITLE
Fix handling of URL query args diff

### DIFF
--- a/src/Tribe/Views/V2/Url.php
+++ b/src/Tribe/Views/V2/Url.php
@@ -359,6 +359,15 @@ class Url {
 			$a_args = array_diff_key( $a_args, array_combine( $ignore, $ignore ) );
 			$b_args = array_diff_key( $b_args, array_combine( $ignore, $ignore ) );
 
+			// "Fix" the `eventDisplay` query argument transforming `default` to the actual default view slug.
+			$default_view_slug = tribe_get_option( 'viewOption', 'default' );
+			if ( isset( $a_args['eventDisplay'] ) && $a_args['eventDisplay'] === 'default' ) {
+				$a_args['eventDisplay'] = $default_view_slug;
+			}
+			if ( isset( $b_args['eventDisplay'] ) && $b_args['eventDisplay'] === 'default' ) {
+				$b_args['eventDisplay'] = 'list';
+			}
+
 			// Query vars might just be ordered differently, so we sort them.
 			ksort( $a_args );
 			ksort( $b_args );

--- a/tests/views_integration/Tribe/Events/Views/V2/UrlTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/UrlTest.php
@@ -204,4 +204,20 @@ class UrlTest extends \Codeception\TestCase\WPTestCase {
 	public function should_correctly_spot_different_requests( $url_a, $url_b, $is_diff, $ignore = [] ) {
 		$this->assertEquals( $is_diff, URL::is_diff( $url_a, $url_b, $ignore ) );
 	}
+
+	/**
+	 * It should correctly handle diffing pagination from default view to next page
+	 *
+	 * @test
+	 */
+	public function should_correctly_handle_diffing_pagination_from_default_view_to_next_page() {
+		tribe_update_option('viewOption','list');
+		$this->assertFalse(
+			URL::is_diff(
+				home_url( '/events/' ),
+				home_url( '/events/list/page/2/' ),
+				[ 'page', 'paged' ]
+			)
+		);
+	}
 }


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/FBAR-208

[Screencast](https://drive.google.com/open?id=1J5gu4sSo36p_39MoMjAtelOY9XOweENy&authuser=luca%40tri.be&usp=drive_fs)

This PR fixes the issue in FBAR, and elsewhere, where going from `/events` (hence using default view) would not correctly load, in Views v2 AJAX requests, page 2 of the default view (e.g. `/events/list/page/2`) and would require a second click to work.