### PR TITLE
Fix / TEC-3452 fast forward link copy

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,7 +224,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.3.2] TBD =
 
-
+* Fix - Use dynamic label for fast-forward link on the month view. [TEC-3452]
 
 = [5.3.1] 2020-12-15 =
 

--- a/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
+++ b/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
@@ -53,7 +53,7 @@ trait With_Fast_Forward_Link {
 		$url      = $this->build_url_for_date( $url_date, $canonical, $passthru_vars );
 
 		$link = sprintf(
-		/* translators: 1: opening href tag 2: event label singular 3: event label plural 4: closing href tag */
+		/* translators: 1: opening href tag 2: event label plural 3: closing href tag */
 			__( 'Jump to the %1$snext upcoming %2$s%3$s.', 'the-events-calendar' ),
 			'<a href="' . esc_url( $url ) . '" class="tribe-events-c-messages__message-list-item-link tribe-common-anchor-thin-alt" data-js="tribe-events-view-link">',
 			tribe_get_event_label_plural_lowercase(),

--- a/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
+++ b/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
@@ -23,7 +23,7 @@ trait With_Fast_Forward_Link {
 	/**
 	 * Creates a HTML link and "fast forward" message to append to the "no events found" message.
 	 *
-	 * @since 5.1.0
+	 * @since TBD
 	 *
 	 * @param bool  $canonical         Whether to return the canonical (pretty) version of the URL or not.
 	 * @param array $passthru_vars     An optional array of query variables that should pass thru the method untouched
@@ -51,11 +51,16 @@ trait With_Fast_Forward_Link {
 
 		$url_date = Dates::build_date_object( $next_event->start_date );
 		$url      = $this->build_url_for_date( $url_date, $canonical, $passthru_vars );
+		
+		$event_label_singular = tribe_get_event_label_singular_lowercase() ?: 'event';
+		$event_label_plural = tribe_get_event_label_plural_lowercase() ?: 'events';
 
 		$link = sprintf(
-		/* translators: 1: opening href tag 2: closing href tag */
-			__( 'Jump to the %1$snext upcoming event(s)%2$s.', 'the-events-calendar' ),
+		/* translators: 1: opening href tag 2: event label singular 3: event label plural 4: closing href tag */
+			__( 'Jump to the %1$snext upcoming %2$s/%3$s%4$s.', 'the-events-calendar' ),
 			'<a href="' . esc_url( $url ) . '" class="tribe-events-c-messages__message-list-item-link tribe-common-anchor-thin-alt" data-js="tribe-events-view-link">',
+			$event_label_singular,
+			$event_label_plural,
 			'</a>'
 		);
 

--- a/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
+++ b/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
@@ -51,16 +51,12 @@ trait With_Fast_Forward_Link {
 
 		$url_date = Dates::build_date_object( $next_event->start_date );
 		$url      = $this->build_url_for_date( $url_date, $canonical, $passthru_vars );
-		
-		$event_label_singular = tribe_get_event_label_singular_lowercase() ?: 'event';
-		$event_label_plural = tribe_get_event_label_plural_lowercase() ?: 'events';
 
 		$link = sprintf(
 		/* translators: 1: opening href tag 2: event label singular 3: event label plural 4: closing href tag */
-			__( 'Jump to the %1$snext upcoming %2$s/%3$s%4$s.', 'the-events-calendar' ),
+			__( 'Jump to the %1$snext upcoming %2$s%3$s.', 'the-events-calendar' ),
 			'<a href="' . esc_url( $url ) . '" class="tribe-events-c-messages__message-list-item-link tribe-common-anchor-thin-alt" data-js="tribe-events-view-link">',
-			$event_label_singular,
-			$event_label_plural,
+			tribe_get_event_label_plural_lowercase(),
 			'</a>'
 		);
 


### PR DESCRIPTION
**Description:** Updates the fast-forward link on the month view so that the plural version of the content type label is used, rather than always showing the hardcoded "events". That comes from the Relabeler extension, if defined ("classes" in the screenshot).

**Ticket:** https://moderntribe.atlassian.net/browse/TEC-3452

**Screenshots:**

![Screen Shot 2020-12-17 at 5 57 40 PM](https://user-images.githubusercontent.com/5049893/102519055-4d3a4780-4092-11eb-899e-aa664d18bcee.png)
