### PR TITLE
Fix timezone issue in setup_repository_args

### DIFF
--- a/src/Tribe/Views/V2/Views/Day_View.php
+++ b/src/Tribe/Views/V2/Views/Day_View.php
@@ -111,7 +111,8 @@ class Day_View extends View {
 		$date = Arr::get( $context_arr, 'event_date', 'now' );
 		$event_display = Arr::get( $context_arr, 'event_display_mode', Arr::get( $context_arr, 'event_display' ), 'current' );
 
-		$args['date_overlaps'] = [ tribe_beginning_of_day( $date ), tribe_end_of_day( $date ) ];
+		$current_date = Dates::build_date_object( $date );
+		$args['date_overlaps'] = [ tribe_beginning_of_day( $current_date->format('Y-m-d') ), tribe_end_of_day( $current_date->format('Y-m-d') ) ];
 
 		/**
 		 * @todo  @bordoni We need to consider fetching events on a given day from a cache


### PR DESCRIPTION
tribe_beginning_of_day/tribe_end_of_day require a Dates::build_date_object to take the timezone into account.

This bug will only show up if PHP runs on a different timezone than the timezone set in the Wordpress settings. This is not unusual on shared hosting platforms where the server/PHP timezones are set to UTC.

This bug is not easy to reproduce as it requires to be in the time range where the WP timezone and the PHP timezone put the event on a different day, with the end of day cutoff taken into account.

All the other places where tribe_beginning_of_day/tribe_end_of_day are called, they are passed a Dates::build_date_object, so hopefully whoever wrote the code can see it's missing here. Or feel free to reject if you think the proposed change is wrong.